### PR TITLE
feat: add lookahead track observations (plan 01)

### DIFF
--- a/obs_spec.py
+++ b/obs_spec.py
@@ -23,6 +23,11 @@ class ObsDim:
     description: str
 
 
+# Lookahead configuration — how many waypoints ahead to observe, and at which
+# centerline indices relative to the current nearest point.
+N_LOOKAHEAD: int = 3
+LOOKAHEAD_STEPS: list[int] = [10, 25, 50]
+
 OBS_SPEC: list[ObsDim] = [
     ObsDim("speed_ms",          50.0,    "Vehicle speed in m/s"),
     ObsDim("lateral_offset_m",   5.0,    "Metres from centreline (neg=left, pos=right)"),
@@ -39,6 +44,13 @@ OBS_SPEC: list[ObsDim] = [
     ObsDim("angular_vel_x",      5.0,    "Roll rate (rad/s)"),
     ObsDim("angular_vel_y",      5.0,    "Yaw rate (rad/s)"),
     ObsDim("angular_vel_z",      5.0,    "Pitch rate (rad/s)"),
+    # Lookahead: (lateral offset m, heading change rad) at each upcoming waypoint.
+    ObsDim("lookahead_10_lat",   5.0,    "Lateral offset 10 pts ahead (m)"),
+    ObsDim("lookahead_10_yaw",   3.14,   "Heading change 10 pts ahead (rad)"),
+    ObsDim("lookahead_25_lat",   5.0,    "Lateral offset 25 pts ahead (m)"),
+    ObsDim("lookahead_25_yaw",   3.14,   "Heading change 25 pts ahead (rad)"),
+    ObsDim("lookahead_50_lat",   5.0,    "Lateral offset 50 pts ahead (m)"),
+    ObsDim("lookahead_50_yaw",   3.14,   "Heading change 50 pts ahead (rad)"),
 ]
 
 # Derived constants — import these instead of hardcoding 15 / list-literals elsewhere.

--- a/policies.py
+++ b/policies.py
@@ -232,7 +232,8 @@ class WeightedLinearPolicy(BasePolicy):
 
     def with_flat(self, flat: np.ndarray) -> "WeightedLinearPolicy":
         """Return a new policy with weights replaced by a flat vector."""
-        n = 15 + self._n_lidar_rays
+        from obs_spec import BASE_OBS_DIM
+        n = BASE_OBS_DIM + self._n_lidar_rays
         names = self.get_obs_names(self._n_lidar_rays)
         cfg = {
             "steer_weights": {names[i]: float(flat[i]) for i in range(n)},
@@ -283,6 +284,13 @@ class WeightedLinearPolicy(BasePolicy):
             with open(self._weights_file) as f:
                 cfg = yaml.safe_load(f)
 
+            loaded_dim = len(cfg.get("steer_weights", {}))
+            if loaded_dim != len(names):
+                logger.warning(
+                    "[WeightedLinearPolicy] loaded weights dim=%d doesn't match obs_dim=%d; "
+                    "new features initialised to 0.0 → %s",
+                    loaded_dim, len(names), self._weights_file,
+                )
             normalized = _normalize_weight_cfg(cfg, names)
             if normalized != cfg:
                 with open(self._weights_file, "w") as f:
@@ -323,7 +331,7 @@ class NeuralNetPolicy(BasePolicy):
         from obs_spec import BASE_OBS_DIM
         self._hidden = list(hidden_sizes or [16, 16])
         self._n_lidar_rays = n_lidar_rays
-        obs_dim = 15 + n_lidar_rays
+        obs_dim = BASE_OBS_DIM + n_lidar_rays
         layer_dims = [obs_dim] + self._hidden + [self._OUTPUT_DIM]
         rng = np.random.default_rng()
         self._weights: list[np.ndarray] = []

--- a/rl/env.py
+++ b/rl/env.py
@@ -15,7 +15,8 @@ Observation space  (BASE_OBS_DIM + n_lidar_rays floats, dtype float32)
     [7]  turning_rate      — current steering angle reported by the game
     [8–11] wheel_N_contact — 1.0 if wheel has ground contact, else 0.0
     [12–14] angular_vel_N  — angular velocity components (rad/s)
-    [15+] lidar_i          — LIDAR wall distances ~[0,1] (only if n_lidar_rays > 0)
+    [15–20] lookahead_N    — (lateral_offset_m, heading_change_rad) × 3 waypoints
+    [21+] lidar_i          — LIDAR wall distances ~[0,1] (only if n_lidar_rays > 0)
 
 Action space
 ------------
@@ -58,6 +59,7 @@ from gymnasium import spaces
 from tminterface.interface import TMInterface
 
 from clients.rl_client import RLClient, StepState
+from obs_spec import BASE_OBS_DIM
 from rl.reward import RewardConfig, RewardCalculator
 from lidar import LidarSensor
 
@@ -289,6 +291,8 @@ class TMNFEnv(gym.Env):
 
     def _make_obs(self, step: StepState) -> np.ndarray:
         d = step.state_data
+        # [15-20] interleaved lookahead: lat10, yaw10, lat25, yaw25, lat50, yaw50
+        lookahead_vals = [v for lat, yaw in d.lookahead for v in (lat, yaw)]
         state = np.array(
             [
                 d.velocity.magnitude(),                    # [0] speed m/s
@@ -306,6 +310,7 @@ class TMNFEnv(gym.Env):
                 d.angular_velocity.x,                      # [12-14] angular vel
                 d.angular_velocity.y,
                 d.angular_velocity.z,
+                *lookahead_vals,                           # [15-20] lookahead
             ],
             dtype=np.float32,
         )

--- a/tests/test_discretize_obs.py
+++ b/tests/test_discretize_obs.py
@@ -3,7 +3,10 @@ import unittest
 
 import numpy as np
 
+from obs_spec import BASE_OBS_DIM
 from policies import WeightedLinearPolicy, _discretize_obs
+
+_N = BASE_OBS_DIM
 
 
 class TestDiscretizeObs(unittest.TestCase):
@@ -13,15 +16,15 @@ class TestDiscretizeObs(unittest.TestCase):
 
     def test_zero_obs_maps_to_middle_bin(self):
         # Zero normalised → middle of [-3, 3] range → bin 1 with n_bins=3
-        bins = _discretize_obs(np.zeros(15, dtype=np.float32), self._scales(), n_bins=3)
+        bins = _discretize_obs(np.zeros(_N, dtype=np.float32), self._scales(), n_bins=3)
         self.assertTrue(all(b == 1 for b in bins))
 
     def test_clipped_high_obs_maps_to_max_bin(self):
-        bins = _discretize_obs(np.full(15, 1e9, dtype=np.float32), self._scales(), n_bins=3)
+        bins = _discretize_obs(np.full(_N, 1e9, dtype=np.float32), self._scales(), n_bins=3)
         self.assertTrue(all(b == 2 for b in bins))
 
     def test_clipped_low_obs_maps_to_min_bin(self):
-        bins = _discretize_obs(np.full(15, -1e9, dtype=np.float32), self._scales(), n_bins=3)
+        bins = _discretize_obs(np.full(_N, -1e9, dtype=np.float32), self._scales(), n_bins=3)
         self.assertTrue(all(b == 0 for b in bins))
 
     def test_symmetry(self):
@@ -34,14 +37,14 @@ class TestDiscretizeObs(unittest.TestCase):
             self.assertEqual(p + n, 2 * mid)
 
     def test_returns_tuple_of_ints(self):
-        bins = _discretize_obs(np.zeros(15, dtype=np.float32), self._scales(), n_bins=3)
+        bins = _discretize_obs(np.zeros(_N, dtype=np.float32), self._scales(), n_bins=3)
         self.assertIsInstance(bins, tuple)
         self.assertTrue(all(isinstance(b, int) for b in bins))
 
     def test_length_matches_obs_dim(self):
-        obs = np.zeros(15, dtype=np.float32)
+        obs = np.zeros(_N, dtype=np.float32)
         bins = _discretize_obs(obs, self._scales(), n_bins=3)
-        self.assertEqual(len(bins), 15)
+        self.assertEqual(len(bins), _N)
 
 
 if __name__ == "__main__":

--- a/tests/test_epsilon_greedy_policy.py
+++ b/tests/test_epsilon_greedy_policy.py
@@ -3,11 +3,12 @@ import unittest
 
 import numpy as np
 
+from obs_spec import BASE_OBS_DIM
 from policies import EpsilonGreedyPolicy, WeightedLinearPolicy, _action_to_idx, _discretize_obs
 
 
 def _zero_obs() -> np.ndarray:
-    return np.zeros(15, dtype=np.float32)
+    return np.zeros(BASE_OBS_DIM, dtype=np.float32)
 
 
 def _state_key(obs: np.ndarray) -> tuple:
@@ -45,7 +46,7 @@ class TestEpsilonGreedyPolicy(unittest.TestCase):
         alpha, gamma = 0.5, 0.9
         p = EpsilonGreedyPolicy(epsilon=0.0, alpha=alpha, gamma=gamma)
         obs      = _zero_obs()
-        next_obs = np.ones(15, dtype=np.float32)
+        next_obs = np.ones(BASE_OBS_DIM, dtype=np.float32)
         s  = _state_key(obs)
         s_ = _state_key(next_obs)
         # Seed Q(s', 2) = 5 → max_Q(s') = 5

--- a/tests/test_mcts_policy.py
+++ b/tests/test_mcts_policy.py
@@ -3,11 +3,12 @@ import unittest
 
 import numpy as np
 
+from obs_spec import BASE_OBS_DIM
 from policies import MCTSPolicy, WeightedLinearPolicy, _action_to_idx, _discretize_obs
 
 
 def _zero_obs() -> np.ndarray:
-    return np.zeros(15, dtype=np.float32)
+    return np.zeros(BASE_OBS_DIM, dtype=np.float32)
 
 
 def _state_key(obs: np.ndarray) -> tuple:
@@ -24,7 +25,7 @@ class TestMCTSPolicy(unittest.TestCase):
         # With an empty table every call is random — expect multiple distinct actions over many calls.
         # Probability of all 30 calls picking the same action: 9^{-29} ≈ 0.
         p = MCTSPolicy()
-        actions = {_action_to_idx(p(np.random.randn(15).astype(np.float32))) for _ in range(30)}
+        actions = {_action_to_idx(p(np.random.randn(BASE_OBS_DIM).astype(np.float32))) for _ in range(30)}
         self.assertGreater(len(actions), 1)
 
     def test_update_increments_visit_count(self):

--- a/tests/test_neural_net_policy.py
+++ b/tests/test_neural_net_policy.py
@@ -3,7 +3,10 @@ import unittest
 
 import numpy as np
 
+from obs_spec import BASE_OBS_DIM
 from policies import NeuralNetPolicy
+
+_N = BASE_OBS_DIM
 
 
 class TestNeuralNetPolicy(unittest.TestCase):
@@ -18,17 +21,17 @@ class TestNeuralNetPolicy(unittest.TestCase):
 
     def test_action_in_range(self):
         p = NeuralNetPolicy(hidden_sizes=[8])
-        obs = np.random.randn(15).astype(np.float32)
+        obs = np.random.randn(_N).astype(np.float32)
         self.assert_action_vector(p(obs))
 
     def test_deterministic(self):
         p = NeuralNetPolicy(hidden_sizes=[8])
-        obs = np.random.randn(15).astype(np.float32)
+        obs = np.random.randn(_N).astype(np.float32)
         np.testing.assert_array_equal(p(obs), p(obs))
 
     def test_from_cfg_roundtrip(self):
         p = NeuralNetPolicy(hidden_sizes=[8, 8])
-        obs = np.random.randn(15).astype(np.float32)
+        obs = np.random.randn(_N).astype(np.float32)
         p2 = NeuralNetPolicy.from_cfg(p.to_cfg())
         np.testing.assert_allclose(p(obs), p2(obs))
 
@@ -39,7 +42,7 @@ class TestNeuralNetPolicy(unittest.TestCase):
     def test_output_always_9_actions(self):
         p = NeuralNetPolicy(hidden_sizes=[4])
         for _ in range(20):
-            obs = np.random.randn(15).astype(np.float32) * 100
+            obs = np.random.randn(_N).astype(np.float32) * 100
             self.assert_action_vector(p(obs))
 
     def test_mutated_has_different_weights(self):
@@ -53,8 +56,8 @@ class TestNeuralNetPolicy(unittest.TestCase):
         p = NeuralNetPolicy(hidden_sizes=[16, 8])
         cfg = p.to_cfg()
         weights = cfg["weights"]
-        # Layer dims: [15, 16, 8, 3]
-        self.assertEqual(np.array(weights[0]).shape, (16, 15))
+        # Layer dims: [BASE_OBS_DIM, 16, 8, 3]
+        self.assertEqual(np.array(weights[0]).shape, (16, _N))
         self.assertEqual(np.array(weights[1]).shape, (8, 16))
         self.assertEqual(np.array(weights[2]).shape, (3, 8))
 

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -50,5 +50,56 @@ class TestCenterline(unittest.TestCase):
         self.assertAlmostEqual(float(np.linalg.norm(fwd)), 1.0, places=5)
 
 
+class TestProjectAhead(unittest.TestCase):
+    """Straight-line track along Z: 0 → 100 m (11 points, 10 m apart)."""
+
+    @classmethod
+    def setUpClass(cls):
+        points = np.array([[0.0, 0.0, i * 10.0] for i in range(11)], dtype=np.float32)
+        fd, cls._tmp_path = tempfile.mkstemp(suffix=".npy")
+        os.close(fd)
+        np.save(cls._tmp_path, points)
+        cls.cl = Centerline(cls._tmp_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        os.unlink(cls._tmp_path)
+
+    def test_returns_two_floats(self):
+        result = self.cl.project_ahead(Vec3(0, 0, 0), nearest_idx=0, steps=5)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+        lat, heading = result
+        self.assertIsInstance(float(lat), float)
+        self.assertIsInstance(float(heading), float)
+
+    def test_straight_track_zero_heading_change(self):
+        # Straight track: heading change between any two segments should be 0
+        lat, heading = self.cl.project_ahead(Vec3(0, 0, 0), nearest_idx=0, steps=5)
+        self.assertAlmostEqual(heading, 0.0, places=5)
+
+    def test_straight_track_lateral_is_finite(self):
+        lat, _ = self.cl.project_ahead(Vec3(0, 0, 0), nearest_idx=0, steps=5)
+        self.assertTrue(np.isfinite(lat))
+
+    def test_steps_clamped_at_track_end(self):
+        # steps=9999 should not raise — clamped to last valid idx
+        lat, heading = self.cl.project_ahead(Vec3(0, 0, 0), nearest_idx=0, steps=9999)
+        self.assertTrue(np.isfinite(lat))
+        self.assertTrue(np.isfinite(heading))
+
+    def test_lateral_opposite_sign_when_car_moves_across_centreline(self):
+        # Moving the car to opposite sides of the centreline should flip the sign
+        # of the lateral offset, regardless of the axis convention.
+        lat_pos, _ = self.cl.project_ahead(Vec3(3.0, 0, 0), nearest_idx=0, steps=5)
+        lat_neg, _ = self.cl.project_ahead(Vec3(-3.0, 0, 0), nearest_idx=0, steps=5)
+        # Signs must be strictly opposite
+        self.assertGreater(lat_pos * lat_neg, -float('inf'))  # both finite
+        self.assertNotEqual(lat_pos, 0.0)
+        self.assertNotEqual(lat_neg, 0.0)
+        # Opposite sides → opposite signs
+        self.assertLess(lat_pos * lat_neg, 0.0)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -77,6 +77,26 @@ class TestStateData(unittest.TestCase):
         finally:
             os.unlink(f.name)
 
+    def test_lookahead_has_three_entries_when_centerline_present(self):
+        points = np.array([[0, 0, i * 10.0] for i in range(11)], dtype=np.float32)
+        with tempfile.NamedTemporaryFile(suffix=".npy", delete=False) as f:
+            np.save(f.name, points)
+            cl = Centerline(f.name)
+        try:
+            gs = make_game_state(position=(0.0, 0.0, 10.0))
+            sd = StateData(gs, centerline=cl)
+            self.assertEqual(len(sd.lookahead), 3)
+            for lat, heading in sd.lookahead:
+                self.assertTrue(math.isfinite(lat))
+                self.assertTrue(math.isfinite(heading))
+        finally:
+            os.unlink(f.name)
+
+    def test_lookahead_defaults_to_zeros_without_centerline(self):
+        gs = make_game_state(position=(0.0, 0.0, 0.0))
+        sd = StateData(gs)
+        self.assertEqual(sd.lookahead, [(0.0, 0.0)] * 3)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_weighted_linear_policy.py
+++ b/tests/test_weighted_linear_policy.py
@@ -4,7 +4,10 @@ import unittest
 import numpy as np
 
 from helpers import make_wlp
+from obs_spec import BASE_OBS_DIM
 from policies import WeightedLinearPolicy
+
+_N = BASE_OBS_DIM
 
 
 class TestWeightedLinearPolicy(unittest.TestCase):
@@ -20,28 +23,28 @@ class TestWeightedLinearPolicy(unittest.TestCase):
     def test_action_in_range(self):
         p = make_wlp()
         for _ in range(10):
-            obs = np.random.randn(15).astype(np.float32)
+            obs = np.random.randn(_N).astype(np.float32)
             self.assert_action_vector(p(obs))
 
     def test_deterministic(self):
         p = make_wlp()
-        obs = np.ones(15, dtype=np.float32)
+        obs = np.ones(_N, dtype=np.float32)
         np.testing.assert_array_equal(p(obs), p(obs))
 
     def test_accel_weights_dominate(self):
         # Large positive weight on speed_ms (index 0, scale 50) → throttle score ≫ threshold
-        tw = np.zeros(15, dtype=np.float32)
+        tw = np.zeros(_N, dtype=np.float32)
         tw[0] = 1000.0
-        obs = np.array([50.0] + [0.0] * 14, dtype=np.float32)
+        obs = np.array([50.0] + [0.0] * (_N - 1), dtype=np.float32)
         p = make_wlp(throttle_weights=tw)
         action = p(obs)
         self.assertEqual(float(action[1]), 1.0)
         self.assertEqual(float(action[2]), 0.0)
 
     def test_brake_weights_dominate(self):
-        tw = np.zeros(15, dtype=np.float32)
+        tw = np.zeros(_N, dtype=np.float32)
         tw[0] = -1000.0
-        obs = np.array([50.0] + [0.0] * 14, dtype=np.float32)
+        obs = np.array([50.0] + [0.0] * (_N - 1), dtype=np.float32)
         p = make_wlp(throttle_weights=tw)
         action = p(obs)
         self.assertEqual(float(action[1]), 0.0)
@@ -49,7 +52,7 @@ class TestWeightedLinearPolicy(unittest.TestCase):
 
     def test_coast_within_threshold(self):
         # All-zero weights → throttle score = 0 → within threshold → coast actions
-        obs = np.ones(15, dtype=np.float32)
+        obs = np.ones(_N, dtype=np.float32)
         p = make_wlp()
         action = p(obs)
         self.assertEqual(float(action[1]), 0.0)
@@ -58,11 +61,11 @@ class TestWeightedLinearPolicy(unittest.TestCase):
     def test_steer_left_action(self):
         # Large negative steer weight on lateral_offset (index 1) → steer score ≪ -threshold → left
         # Large positive throttle weight → accel; combined: action 6 (accel+left)
-        sw = np.zeros(15, dtype=np.float32)
+        sw = np.zeros(_N, dtype=np.float32)
         sw[1] = -1000.0
-        tw = np.zeros(15, dtype=np.float32)
+        tw = np.zeros(_N, dtype=np.float32)
         tw[0] = 1000.0
-        obs = np.array([50.0, 1.0] + [0.0] * 13, dtype=np.float32)
+        obs = np.array([50.0, 1.0] + [0.0] * (_N - 2), dtype=np.float32)
         p = make_wlp(steer_weights=sw, throttle_weights=tw)
         action = p(obs)
         self.assertEqual(float(action[0]), -1.0)
@@ -70,11 +73,11 @@ class TestWeightedLinearPolicy(unittest.TestCase):
         self.assertEqual(float(action[2]), 0.0)
 
     def test_steer_right_action(self):
-        sw = np.zeros(15, dtype=np.float32)
+        sw = np.zeros(_N, dtype=np.float32)
         sw[1] = 1000.0
-        tw = np.zeros(15, dtype=np.float32)
+        tw = np.zeros(_N, dtype=np.float32)
         tw[0] = 1000.0
-        obs = np.array([50.0, 1.0] + [0.0] * 13, dtype=np.float32)
+        obs = np.array([50.0, 1.0] + [0.0] * (_N - 2), dtype=np.float32)
         p = make_wlp(steer_weights=sw, throttle_weights=tw)
         action = p(obs)
         self.assertEqual(float(action[0]), 1.0)
@@ -85,11 +88,11 @@ class TestWeightedLinearPolicy(unittest.TestCase):
         p = make_wlp()
         cfg = p.to_cfg()
         p2 = WeightedLinearPolicy.from_cfg(cfg)
-        obs = np.random.randn(15).astype(np.float32)
+        obs = np.random.randn(_N).astype(np.float32)
         np.testing.assert_array_equal(p(obs), p2(obs))
 
     def test_mutated_weights_differ(self):
-        sw = np.ones(15, dtype=np.float32)
+        sw = np.ones(_N, dtype=np.float32)
         p = make_wlp(steer_weights=sw)
         mutated = p.mutated(scale=1.0)
         orig = list(p.to_cfg()["steer_weights"].values())
@@ -102,7 +105,7 @@ class TestWeightedLinearPolicy(unittest.TestCase):
 
     def test_action_is_int(self):
         p = make_wlp()
-        action = p(np.zeros(15, dtype=np.float32))
+        action = p(np.zeros(_N, dtype=np.float32))
         self.assertIsInstance(action, np.ndarray)
         self.assertEqual(action.shape, (3,))
 

--- a/track.py
+++ b/track.py
@@ -1,3 +1,5 @@
+import math
+
 import numpy as np
 from scipy.spatial import KDTree
 
@@ -73,6 +75,49 @@ class Centerline:
         vertical_offset = float(offset[1])
 
         return float(progress), lateral_offset, vertical_offset, forward, idx
+
+    def project_ahead(self, pos: Vec3, nearest_idx: int, steps: int) -> tuple[float, float]:
+        """Return (lateral_offset, heading_change) for the waypoint *steps* ahead.
+
+        lateral_offset: metres from the car's current position to the target
+          waypoint, projected onto the right axis at *nearest_idx*.  Positive
+          means the waypoint is to the right of the car.
+        heading_change: signed angle (rad) between the track forward direction at
+          *nearest_idx* and at *target_idx*, i.e. how much the track turns between
+          here and the lookahead point.  Positive = right turn, negative = left turn.
+        """
+        n = len(self._points)
+        target_idx = min(nearest_idx + steps, n - 2)
+
+        # Forward and right vectors at the current nearest point
+        a0 = self._points[nearest_idx].astype(np.float64)
+        b0 = self._points[nearest_idx + 1].astype(np.float64)
+        fwd0 = b0 - a0
+        fwd0_len = float(np.linalg.norm(fwd0))
+        fwd0 = fwd0 / fwd0_len if fwd0_len > 1e-9 else np.array([1.0, 0.0, 0.0])
+
+        right0 = np.cross(fwd0, UP_VECTOR)
+        right0_len = float(np.linalg.norm(right0))
+        right0 = right0 / right0_len if right0_len > 1e-9 else np.array([1.0, 0.0, 0.0])
+
+        # Forward direction at the target point
+        a1 = self._points[target_idx].astype(np.float64)
+        b1 = self._points[target_idx + 1].astype(np.float64)
+        fwd1 = b1 - a1
+        fwd1_len = float(np.linalg.norm(fwd1))
+        fwd1 = fwd1 / fwd1_len if fwd1_len > 1e-9 else np.array([1.0, 0.0, 0.0])
+
+        # Lateral offset: how far the lookahead waypoint is to the right/left
+        p = np.array([pos.x, pos.y, pos.z], dtype=np.float64)
+        lateral_offset = float(np.dot(a1 - p, right0))
+
+        # Heading change: signed angle between fwd0 and fwd1 (Y-up cross product)
+        cos_a = float(np.clip(np.dot(fwd0, fwd1), -1.0, 1.0))
+        cross = np.cross(fwd0, fwd1)
+        sign = 1.0 if float(cross[1]) >= 0.0 else -1.0
+        heading_change = sign * math.acos(cos_a)
+
+        return lateral_offset, heading_change
 
     def project(self, pos: Vec3) -> tuple[float, float, float]:
         """Returns (progress, lateral_offset, vertical_offset). See project_with_forward()."""

--- a/utils.py
+++ b/utils.py
@@ -93,11 +93,17 @@ class StateData:
         self.vertical_offset = None
         self.track_forward = None   # unit np.ndarray of track direction at car position
         self._centerline_idx = None  # nearest centerline point index (for windowed search)
+        self.lookahead: list[tuple[float, float]] = [(0.0, 0.0)] * 3
         if centerline is not None:
             (self.track_progress, self.lateral_offset, self.vertical_offset,
              self.track_forward, self._centerline_idx) = centerline.project_with_forward(
                 self.position, hint_idx=hint_idx
             )
+            from obs_spec import LOOKAHEAD_STEPS
+            self.lookahead = [
+                centerline.project_ahead(self.position, self._centerline_idx, s)
+                for s in LOOKAHEAD_STEPS
+            ]
 
     def __str__(self) -> str:
         contact_str = " ".join(str(int(w.contact)) for w in self.wheels)


### PR DESCRIPTION
Extends the observation vector from 15 to 21 dimensions by adding 6
lookahead features: (lateral_offset, heading_change) for the centerline
waypoints at +10, +25, +50 indices ahead of the current nearest point.

Changes:
- obs_spec.py: add N_LOOKAHEAD/LOOKAHEAD_STEPS constants and 6 new ObsDim
  entries; BASE_OBS_DIM auto-updates to 21
- track.py: add Centerline.project_ahead() computing geometric lateral
  offset and signed heading change to a lookahead waypoint
- utils.py: populate StateData.lookahead after centerline projection
- rl/env.py: import BASE_OBS_DIM (was missing), append lookahead values
  in _make_obs() matching OBS_SPEC interleaved ordering
- policies.py: replace hardcoded obs_dim=15 with BASE_OBS_DIM in
  with_flat() and NeuralNetPolicy.__init__(); log warning when saved
  weights dim mismatches current obs_dim (new features default to 0.0)
- tests: update all hardcoded obs-dim=15 references to BASE_OBS_DIM;
  add TestProjectAhead and StateData.lookahead tests (82 tests pass)

https://claude.ai/code/session_01So8iv2o648tNPbmH9xQCTS