### PR TITLE
Implement plan 05: multi-track support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,6 @@ __marimo__/
 .claude/
 
 replays/
-tracks/
+tracks/*.npy
 
 docs/codestyle/

--- a/build_centerline.py
+++ b/build_centerline.py
@@ -4,13 +4,15 @@ an evenly-spaced centerline as a .npy file.
 
 Usage:
     python build_centerline.py path/to/replay.Replay.Gbx
-    python build_centerline.py path/to/replay.Replay.Gbx --output runs/centerline.npy --spacing 2.0
+    python build_centerline.py path/to/replay.Replay.Gbx --output tracks/b05_centerline.npy --track-name b05 --spacing 2.0
 """
 
 import argparse
 import logging
+from pathlib import Path
 
 import numpy as np
+import yaml
 
 logger = logging.getLogger(__name__)
 from pygbx import Gbx, GbxType
@@ -58,10 +60,24 @@ def resample_centerline(positions: np.ndarray, spacing: float) -> np.ndarray:
     return centerline
 
 
+def update_registry(registry_path: Path, track_name: str, output_path: Path, replay_path: str) -> None:
+    """Upsert an entry for *track_name* in *registry_path*."""
+    registry = yaml.safe_load(registry_path.read_text()) if registry_path.exists() else {}
+    registry[track_name] = {
+        "centerline_path": str(output_path),
+        "default_par_time_s": None,   # user fills in manually
+        "source_replay": str(replay_path),
+    }
+    registry_path.write_text(yaml.dump(registry, sort_keys=True))
+    logger.info("Updated registry %s  (track=%r)", registry_path, track_name)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Build a track centerline from a TMNF ghost replay.")
     parser.add_argument("replay", help="Path to .Replay.Gbx file")
     parser.add_argument("--output", default="runs/centerline.npy", help="Output .npy path (default: runs/centerline.npy)")
+    parser.add_argument("--track-name", default=None,
+                        help="Track identifier for tracks/registry.yaml (defaults to stem of --output)")
     parser.add_argument("--spacing", type=float, default=2.0, help="Point spacing in metres (default: 2.0)")
     parser.add_argument("--log-level", default="INFO", choices=["DEBUG", "INFO", "WARNING", "ERROR"],
                         help="Logging verbosity (default: INFO)")
@@ -72,6 +88,9 @@ def main() -> None:
         format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
         datefmt="%H:%M:%S",
     )
+
+    output_path = Path(args.output)
+    track_name = args.track_name or output_path.stem
 
     logger.info("Reading %r ...", args.replay)
     try:
@@ -88,6 +107,8 @@ def main() -> None:
 
     np.save(args.output, centerline)
     logger.info("Saved centerline to %r  shape=%s", args.output, centerline.shape)
+
+    update_registry(Path("tracks/registry.yaml"), track_name, output_path, args.replay)
 
 
 if __name__ == "__main__":

--- a/config/reward_config.yaml
+++ b/config/reward_config.yaml
@@ -35,3 +35,7 @@ lidar_wall_weight: -5.0
 
 # --- Episode termination ---
 crash_threshold_m: 25.0
+
+# --- Track ---
+track_name: a03
+centerline_path: tracks/a03_centerline.npy

--- a/grid_search.py
+++ b/grid_search.py
@@ -231,7 +231,7 @@ def main() -> None:
 
     base_name, track, training_spec, reward_spec = _load_grid_config(args.config)
     combos, varied_keys = _expand_grid(training_spec, reward_spec)
-    centerline_file = f"tracks/{track}.npy"
+    centerline_path = f"tracks/{track}.npy"
 
     n = len(combos)
     logger.info(f"  Grid search: {n} combination(s)")
@@ -272,6 +272,8 @@ def main() -> None:
         with open("config/reward_config.yaml") as f:
             reward_cfg = yaml.safe_load(f) or {}
         reward_cfg.update(r)
+        reward_cfg["track_name"] = track
+        reward_cfg["centerline_path"] = centerline_path
         with open(reward_cfg_file, "w") as f:
             yaml.dump(reward_cfg, f, default_flow_style=False, sort_keys=False)
         with open(training_params_file, "w") as f:
@@ -295,7 +297,6 @@ def main() -> None:
             re_initialize=args.re_initialize,
             policy_type=t.get("policy_type", "hill_climbing"),
             policy_params=_build_policy_params(t),
-            centerline_file=centerline_file,
             track=track,
         )
 

--- a/main.py
+++ b/main.py
@@ -724,7 +724,6 @@ def train_rl(
     re_initialize: bool = False,
     policy_type: str = "hill_climbing",
     policy_params: dict[str, Any] | None = None,
-    centerline_file: str = "tracks/a03_centerline.npy",
     track: str = "",
     adaptive_mutation: bool = True,
 ) -> ExperimentData:
@@ -755,7 +754,6 @@ def train_rl(
         speed=speed,
         in_game_episode_s=in_game_episode_s,
         n_lidar_rays=n_lidar_rays,
-        centerline_file=centerline_file
     )
 
     probe_results: list[ProbeResult] = []
@@ -896,7 +894,6 @@ def main() -> None:
     with open("config/training_params.yaml") as f:
         master_p = yaml.safe_load(f)
     track = master_p.get("track", "a03_centerline")
-    centerline_file = f"tracks/{track}.npy"
 
     experiment_dir  = f"experiments/{track}/{args.experiment}"
     weights_file    = f"{experiment_dir}/policy_weights.yaml"
@@ -917,7 +914,6 @@ def main() -> None:
 
     # Allow per-experiment overrides of track (if the copied config was edited).
     track = p.get("track", track)
-    centerline_file = f"tracks/{track}.npy"
 
     data = train_rl(
         experiment_name=args.experiment,
@@ -937,7 +933,6 @@ def main() -> None:
         re_initialize=args.re_initialize,
         policy_type=p.get("policy_type", "hill_climbing"),
         policy_params=p.get("policy_params") or {},
-        centerline_file=centerline_file,
         track=track,
         adaptive_mutation=p.get("adaptive_mutation", True),
     )

--- a/rl/env.py
+++ b/rl/env.py
@@ -330,7 +330,6 @@ def make_env(
     experiment_dir: str | Path,
     speed: float = 10.0,
     in_game_episode_s: float = 20.0,
-    centerline_file: str = _DEFAULT_CENTERLINE,
     n_lidar_rays: int = 0,
 ) -> TMNFEnv:
     """
@@ -338,12 +337,14 @@ def make_env(
 
     Loads reward_config.yaml from *experiment_dir* and converts
     *in_game_episode_s* to a wall-clock episode limit at the given speed.
+    The centerline path is read from reward_config.centerline_path so that
+    different experiments can target different tracks without touching source code.
     Both main.py and rl/train.py call this instead of constructing TMNFEnv directly.
     """
     experiment_dir = Path(experiment_dir)
     reward_config = RewardConfig.from_yaml(str(experiment_dir / "reward_config.yaml"))
     return TMNFEnv(
-        centerline_file=centerline_file,
+        centerline_file=reward_config.centerline_path,
         speed=speed,
         reward_config=reward_config,
         max_episode_time_s=in_game_episode_s / speed,

--- a/rl/reward.py
+++ b/rl/reward.py
@@ -70,6 +70,8 @@ class RewardConfig:
     airborne_penalty:   float = -1.0
     lidar_wall_weight:  float = 0.0
     crash_threshold_m:  float = 25.0
+    track_name:         str   = "a03"
+    centerline_path:    str   = "tracks/a03_centerline.npy"
 
     @classmethod
     def from_yaml(cls, path: str) -> RewardConfig:

--- a/tracks/registry.yaml
+++ b/tracks/registry.yaml
@@ -1,0 +1,4 @@
+a03:
+  centerline_path: tracks/a03_centerline.npy
+  default_par_time_s: 60.0
+  source_replay: replays/a03_centerline.Replay.Gbx


### PR DESCRIPTION
- Add `track_name` and `centerline_path` fields to `RewardConfig` with
  defaults that preserve existing behaviour; old experiment configs that
  lack these fields fall back to the a03 values automatically.
- Add `track_name: a03` and `centerline_path: tracks/a03_centerline.npy`
  to the master `config/reward_config.yaml` template so new experiments
  get the fields on first run.
- `make_env()` now reads the centerline path from
  `reward_config.centerline_path` instead of a hardcoded constant;
  the `centerline_file` parameter is removed from `make_env()` and from
  `train_rl()` in `main.py`.
- `build_centerline.py` gains a `--track-name` CLI argument and upserts
  an entry in `tracks/registry.yaml` after saving the .npy file.
- Add `tracks/registry.yaml` with the a03 entry as the initial registry.
- Tighten .gitignore: ignore `tracks/*.npy` instead of all of `tracks/`
  so that `tracks/registry.yaml` is tracked normally.

https://claude.ai/code/session_01MtWcCyP9MmpzvPYpxWcgPZ