### PR TITLE
fix(reward): scale centerline, speed, and airborne terms by n_ticks

### DIFF
--- a/config/reward_config.yaml
+++ b/config/reward_config.yaml
@@ -7,11 +7,14 @@ progress_weight: 10000.0
 
 # --- Centerline adherence ---
 # penalty = centerline_weight * |lateral_offset_m| ^ centerline_exp
-centerline_weight: -0.1
+# Divided by ~1.2 (expected avg ticks/step at 10x speed) because compute() now
+# scales this term by n_ticks, keeping reward magnitudes comparable to before.
+centerline_weight: -0.083
 centerline_exp: 2.0
 
 # --- Speed ---
-speed_weight: 0.05
+# Divided by ~1.2 for the same n_ticks scaling reason as centerline_weight above.
+speed_weight: 0.042
 
 # --- Time cost ---
 step_penalty: -0.05
@@ -26,7 +29,8 @@ par_time_s: 60.0
 accel_bonus: 0.5
 
 # --- Airborne penalty (below/beside centerline only) ---
-airborne_penalty: -1.0
+# Divided by ~1.2 for the same n_ticks scaling reason as centerline_weight above.
+airborne_penalty: -0.83
 
 # --- Lidar wall proximity ---
 # penalty = lidar_wall_weight * (1 - min_ray)^2  (negative weight → closer = worse)

--- a/rl/reward.py
+++ b/rl/reward.py
@@ -105,13 +105,16 @@ class RewardCalculator:
             reward += delta * cfg.progress_weight
 
         # Centerline: quadratic penalty for lateral deviation.
+        # Scaled by n_ticks: the car was off-centreline for this many game ticks.
         if curr.lateral_offset is not None:
             reward += (
                 cfg.centerline_weight * abs(curr.lateral_offset) ** cfg.centerline_exp
+                * n_ticks
             )
 
         # Speed: small reward for going fast.
-        reward += cfg.speed_weight * curr.velocity.magnitude()
+        # Scaled by n_ticks: the car was travelling at this speed for this many ticks.
+        reward += cfg.speed_weight * curr.velocity.magnitude() * n_ticks
 
         # Acceleration bonus: nudge the policy away from coasting.
         # Scaled by n_ticks because the action was held for that many game ticks.
@@ -128,12 +131,13 @@ class RewardCalculator:
             reward += cfg.finish_time_weight * over_par  # negative if slow
 
         # Airborne penalty: only when below or beside the centerline.
+        # Scaled by n_ticks: the car was airborne for this many game ticks.
         if curr.vertical_offset is not None:
             wheels_in_contact = sum(w.contact for w in curr.wheels)
             airborne = wheels_in_contact <= 1
             # vertical_offset > 0 → car is above centerline → legitimate jump → no penalty
             if airborne and curr.vertical_offset <= 0.0:
-                reward += cfg.airborne_penalty
+                reward += cfg.airborne_penalty * n_ticks
 
         # Lidar wall proximity: quadratic penalty for the nearest detected wall.
         if (

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -192,9 +192,10 @@ class TestNTicksScaling(unittest.TestCase):
         curr = make_state_data(track_progress=0.1, speed=(0.0, 0.0, 0.0))
         r1 = self._r(prev, curr, n_ticks=1)
         r3 = self._r(prev, curr, n_ticks=3)
-        # progress contribution is identical in both; difference is only per-tick terms
+        # progress contribution is identical in both; only per-tick terms scale
         per_tick_diff = r3 - r1
-        self.assertLess(abs(per_tick_diff), self.cfg.progress_weight * 0.1)
+        expected_diff = 2.0 * self.cfg.step_penalty
+        self.assertAlmostEqual(per_tick_diff, expected_diff, places=5)
 
 
 if __name__ == "__main__":

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -180,10 +180,11 @@ class TestNTicksScaling(unittest.TestCase):
         curr = make_state_data(track_progress=1.0, speed=(0.0, 0.0, 0.0))
         r1 = self._r(prev, curr, n_ticks=1, finished=True, elapsed_s=self.cfg.par_time_s)
         r3 = self._r(prev, curr, n_ticks=3, finished=True, elapsed_s=self.cfg.par_time_s)
-        # finish_bonus is one-time, so the difference should NOT include finish_bonus*2
-        # The difference is only from per-tick components scaled by n_ticks
+        # finish_bonus and progress are one-time in this setup; with zero speed,
+        # no lateral offset, and no acceleration, only the per-tick step penalty scales.
         per_tick_diff = r3 - r1
-        self.assertLess(abs(per_tick_diff), self.cfg.finish_bonus)
+        expected_diff = 2.0 * self.cfg.step_penalty
+        self.assertAlmostEqual(per_tick_diff, expected_diff, places=5)
 
     def test_progress_reward_does_not_scale_with_n_ticks(self):
         # progress delta is inherently multi-tick; doubling n_ticks should not double it

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -25,8 +25,10 @@ class TestRewardCalculator(unittest.TestCase):
         self.cfg  = RewardConfig()
         self.calc = RewardCalculator(self.cfg)
 
-    def _r(self, prev, curr, finished=False, elapsed_s=0.0, accelerating=False):
-        return self.calc.compute(prev, curr, finished, elapsed_s, accelerating)
+    def _r(self, prev, curr, finished=False, elapsed_s=0.0, accelerating=False,
+           n_ticks=1):
+        return self.calc.compute(prev, curr, finished, elapsed_s, accelerating,
+                                 n_ticks=n_ticks)
 
     # --- Progress ---
 
@@ -118,6 +120,80 @@ class TestRewardCalculator(unittest.TestCase):
         reward = self._r(state, state)
         # Should NOT have airborne penalty — only step penalty (≈ -0.01)
         self.assertGreater(reward, self.cfg.airborne_penalty)
+
+
+class TestNTicksScaling(unittest.TestCase):
+    """Per-tick reward components must scale linearly with n_ticks."""
+
+    def setUp(self):
+        self.cfg  = RewardConfig()
+        self.calc = RewardCalculator(self.cfg)
+
+    def _r(self, prev, curr, n_ticks=1, finished=False, elapsed_s=0.0,
+           accelerating=False):
+        return self.calc.compute(prev, curr, finished, elapsed_s, accelerating,
+                                 n_ticks=n_ticks)
+
+    def test_centerline_scales_with_n_ticks(self):
+        # lateral_offset=2, progress=0, speed=0 → only centerline + step_penalty vary
+        prev = make_state_data(track_progress=0.5, lateral_offset=0.0, speed=(0.0, 0.0, 0.0))
+        curr = make_state_data(track_progress=0.5, lateral_offset=2.0, speed=(0.0, 0.0, 0.0))
+        r1 = self._r(prev, curr, n_ticks=1)
+        r3 = self._r(prev, curr, n_ticks=3)
+        # centerline contribution: cfg.centerline_weight * 2^2 = -2.0 per tick
+        # step_penalty also scales, so r3 - r1 == 2 * (centerline + step_penalty)
+        expected_diff = 2.0 * (self.cfg.centerline_weight * 2.0 ** self.cfg.centerline_exp
+                               + self.cfg.step_penalty)
+        self.assertAlmostEqual(r3 - r1, expected_diff, places=5)
+
+    def test_speed_scales_with_n_ticks(self):
+        # speed=(5,0,0) → velocity.magnitude()=5; no lateral offset, no progress change
+        state = make_state_data(track_progress=0.5, lateral_offset=0.0, speed=(5.0, 0.0, 0.0))
+        r1 = self._r(state, state, n_ticks=1)
+        r3 = self._r(state, state, n_ticks=3)
+        # (speed + step_penalty) scales; diff = 2 * (speed_weight*5 + step_penalty)
+        expected_diff = 2.0 * (self.cfg.speed_weight * 5.0 + self.cfg.step_penalty)
+        self.assertAlmostEqual(r3 - r1, expected_diff, places=5)
+
+    def test_airborne_penalty_scales_with_n_ticks(self):
+        prev = make_state_data(track_progress=0.5, vertical_offset=-1.0,
+                               speed=(0.0, 0.0, 0.0),
+                               wheel_contacts=(True, False, False, False))
+        curr = make_state_data(track_progress=0.5, vertical_offset=-1.0,
+                               speed=(0.0, 0.0, 0.0),
+                               wheel_contacts=(True, False, False, False))
+        r1 = self._r(prev, curr, n_ticks=1)
+        r3 = self._r(prev, curr, n_ticks=3)
+        # airborne + step_penalty scale; diff = 2 * (airborne_penalty + step_penalty)
+        expected_diff = 2.0 * (self.cfg.airborne_penalty + self.cfg.step_penalty)
+        self.assertAlmostEqual(r3 - r1, expected_diff, places=5)
+
+    def test_accel_bonus_scales_with_n_ticks(self):
+        state = make_state_data(track_progress=0.5, lateral_offset=0.0, speed=(0.0, 0.0, 0.0))
+        r1 = self._r(state, state, n_ticks=1, accelerating=True)
+        r3 = self._r(state, state, n_ticks=3, accelerating=True)
+        expected_diff = 2.0 * (self.cfg.accel_bonus + self.cfg.step_penalty)
+        self.assertAlmostEqual(r3 - r1, expected_diff, places=5)
+
+    def test_finish_bonus_does_not_scale_with_n_ticks(self):
+        prev = make_state_data(track_progress=0.9, speed=(0.0, 0.0, 0.0))
+        curr = make_state_data(track_progress=1.0, speed=(0.0, 0.0, 0.0))
+        r1 = self._r(prev, curr, n_ticks=1, finished=True, elapsed_s=self.cfg.par_time_s)
+        r3 = self._r(prev, curr, n_ticks=3, finished=True, elapsed_s=self.cfg.par_time_s)
+        # finish_bonus is one-time, so the difference should NOT include finish_bonus*2
+        # The difference is only from per-tick components scaled by n_ticks
+        per_tick_diff = r3 - r1
+        self.assertLess(abs(per_tick_diff), self.cfg.finish_bonus)
+
+    def test_progress_reward_does_not_scale_with_n_ticks(self):
+        # progress delta is inherently multi-tick; doubling n_ticks should not double it
+        prev = make_state_data(track_progress=0.0, speed=(0.0, 0.0, 0.0))
+        curr = make_state_data(track_progress=0.1, speed=(0.0, 0.0, 0.0))
+        r1 = self._r(prev, curr, n_ticks=1)
+        r3 = self._r(prev, curr, n_ticks=3)
+        # progress contribution is identical in both; difference is only per-tick terms
+        per_tick_diff = r3 - r1
+        self.assertLess(abs(per_tick_diff), self.cfg.progress_weight * 0.1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When the RL thread is slower than the game, multiple ticks fire between
env.step() calls. Previously accel_bonus and step_penalty scaled with
n_ticks but centerline, speed, and airborne did not, causing accel/penalty
signals to dominate at high game speeds and making weight tuning unreliable.

Scale all per-tick components consistently. Rescale the three affected
weights in config/reward_config.yaml by /1.2 (expected avg ticks/step at
10x speed) to keep reward magnitudes comparable to existing experiments.

Add TestNTicksScaling tests verifying linear scaling for all per-tick
components and confirming finish_bonus and progress_weight are unaffected.

https://claude.ai/code/session_0191BAhVwxopL9fb2CX64TDQ