### PR TITLE
Add CMAESPolicy: (mu/mu_w, lambda)-CMA-ES over WeightedLinearPolicy weights

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # CLAUDE.md
 
-Trackmania Nations Forever RL agent. Drives autonomously using hill-climbing / evolutionary / Q-learning algorithms trained against a live TMInterface session.
+Trackmania Nations Forever RL agent. Drives autonomously using hill-climbing / evolutionary / CMA-ES / Q-learning algorithms trained against a live TMInterface session.
 
 ---
 
@@ -11,7 +11,7 @@ tmnf-ai/
 ├── main.py                 # Entry point — python main.py <experiment_name>
 ├── grid_search.py          # Grid search over param combinations
 ├── analytics.py            # Experiment result plots and summary tables
-├── policies.py             # All policy implementations (6 trainable + 1 baseline)
+├── policies.py             # All policy implementations (7 trainable + 1 baseline)
 ├── obs_spec.py             # Observation space definition (single source of truth)
 ├── utils.py                # StateData, Vec3, Quat, WheelState data classes
 ├── constants.py            # N_ACTIONS, STEER_SCALE, UP_VECTOR
@@ -78,6 +78,7 @@ All policies live in `policies.py` and inherit `BasePolicy`. The active policy i
 | `epsilon_greedy` | `EpsilonGreedyPolicy` | Tabular Q-learning, ε-greedy exploration, ε decays per episode. |
 | `mcts` | `MCTSPolicy` | UCT-style online Q-learner (UCB1). No env cloning — builds value table over real episodes. |
 | `genetic` | `GeneticPolicy` | Population of `WeightedLinearPolicy` instances. Evolutionary selection + crossover + mutation. |
+| `cmaes` | `CMAESPolicy` | `(μ/μ_w, λ)-CMA-ES` (Hansen 2016) over flat `WeightedLinearPolicy` weights. Automatic step-size + covariance adaptation. |
 
 `SimplePolicy` is a non-trainable hand-coded PD baseline (see `steering.py`).
 
@@ -88,6 +89,28 @@ Three independent linear heads (steer, accel, brake), each `dot(weights, normali
 ### GeneticPolicy
 
 Maintains a population of `WeightedLinearPolicy` instances. Each generation: evaluate all individuals (1 episode each), keep top `elite_k` unchanged, breed the rest via uniform crossover between two random elites + mutation. The best individual ever seen is the champion and is saved to YAML for inference.
+
+### CMAESPolicy
+
+Implements `(μ/μ_w, λ)-CMA-ES` (Hansen 2016) over the concatenated `[steer | accel | brake]` weight vector of a `WeightedLinearPolicy` (~63 dimensions for the base observation space).
+
+**Training loop** (called from `_greedy_loop_cmaes`):
+1. `sample_population()` — draws λ offspring from `N(mean, σ²·C)` using cached eigen-factorization `C = B D² Bᵀ`
+2. Evaluate each offspring for one episode → reward vector
+3. `update_distribution(rewards)` — weighted mean recombination (top μ = λ//2 elites), cumulative step-size adaptation (CSA) for σ, rank-1 + rank-μ covariance update
+
+**Key properties**: `population_size` (λ), `sigma` (current σ), `champion_reward`.
+
+**Hyperparams** (in `policy_params`):
+
+| Param | Default | Description |
+|---|---|---|
+| `population_size` | `20` | λ — offspring sampled per generation |
+| `initial_sigma` | `0.3` | Starting step size (adapts via CSA each generation) |
+
+`n_sims` controls the number of generations; total episodes = `n_sims × population_size`. No `mutation_scale` tuning required — σ adapts automatically.
+
+`save()` writes the champion in `WeightedLinearPolicy` YAML format so analytics, weight heatmaps, and inference work without changes.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TMNF — Trackmania Nations Forever RL
 
-Hill-climbing / evolutionary / Q-learning agent for A03. See the root `CLAUDE.md` for full architecture documentation.
+Hill-climbing / evolutionary / CMA-ES / Q-learning agent for A03. See the root `CLAUDE.md` for full architecture documentation.
 
 ---
 
@@ -55,6 +55,7 @@ Set `policy_type` in `training_params.yaml`. Each type uses the same `n_sims` bu
 | `epsilon_greedy` | Tabular Q-learning, ε-greedy exploration | ε decays per episode. Q-table is in-memory only. |
 | `mcts` | UCT-style online Q-learner (UCB1) | Approximation — no env cloning, builds value table over real episodes. |
 | `genetic` | Population of `WeightedLinearPolicy`, evolutionary | `n_sims` = number of generations; total episodes = `n_sims × population_size`. |
+| `cmaes` | CMA-ES over flat `WeightedLinearPolicy` weights (Hansen 2016) | Adapts full covariance matrix; automatic step-size control via CSA. |
 
 ### Policy-specific params
 
@@ -84,7 +85,25 @@ policy_params:
   population_size: 20
   elite_k: 3
   # mutation_scale inherited from top-level
+
+# cmaes
+policy_params:
+  population_size: 20   # λ — offspring per generation
+  initial_sigma: 0.3    # starting step size (adapts automatically via CSA)
 ```
+
+#### CMA-ES details
+
+`CMAESPolicy` implements `(μ/μ_w, λ)-CMA-ES` (Hansen 2016) over the concatenated `[steer | accel | brake]` weight vector of a `WeightedLinearPolicy` (~63 dimensions for the base observation space).
+
+Each generation:
+1. **Sample** — draw λ offspring from `N(mean, σ²·C)` using the cached eigen-factorization `C = B D² Bᵀ`
+2. **Evaluate** — run one episode per offspring
+3. **Update** — weighted mean recombination, cumulative step-size adaptation (CSA) for σ, and rank-1 + rank-μ covariance update
+
+The champion (best individual seen across all generations) is saved in standard `WeightedLinearPolicy` YAML format so analytics, heatmaps, and inference work without modification. Step-size σ is reported per generation in logs and adapts automatically — no `mutation_scale` tuning needed.
+
+`n_sims` controls the number of generations; total episodes = `n_sims × population_size`.
 
 ### Training phases (hill_climbing only)
 

--- a/config/training_params.yaml
+++ b/config/training_params.yaml
@@ -12,7 +12,7 @@ n_lidar_rays: 8          # LIDAR wall-distance rays appended to observation (0 =
 
 
 # Policy algorithm for the greedy training phase.
-# Options: hill_climbing | neural_net | epsilon_greedy | mcts | genetic
+# Options: hill_climbing | neural_net | epsilon_greedy | mcts | genetic | cmaes
 policy_type: genetic
 
 # Type-specific hyperparams.  Only the block matching policy_type is used.
@@ -47,3 +47,8 @@ policy_params:
   population_size: 20      # individuals per generation
   elite_k: 3               # top survivors kept unchanged each generation
   # mutation_scale is inherited from the top-level value above
+
+  # cmaes — CMA-ES over flat WeightedLinearPolicy weight vector (Hansen 2016)
+  #population_size: 20     # λ — offspring sampled each generation
+  #initial_sigma: 0.3      # initial step size (adapted automatically)
+  #elite_fraction: 0.5     # μ/λ ratio (μ = population_size // 2)

--- a/config/training_params.yaml
+++ b/config/training_params.yaml
@@ -51,4 +51,3 @@ policy_params:
   # cmaes — CMA-ES over flat WeightedLinearPolicy weight vector (Hansen 2016)
   #population_size: 20     # λ — offspring sampled each generation
   #initial_sigma: 0.3      # initial step size (adapted automatically)
-  #elite_fraction: 0.5     # μ/λ ratio (μ = population_size // 2)

--- a/main.py
+++ b/main.py
@@ -746,7 +746,8 @@ def _greedy_loop_cmaes(
 
     logger.info(
         "[CMAES] population_size=%d, total episodes = %d × %d = %d",
-        policy._lam, n_generations, policy._lam, n_generations * policy._lam,
+        policy.population_size, n_generations, policy.population_size,
+        n_generations * policy.population_size,
     )
 
     try:
@@ -756,7 +757,7 @@ def _greedy_loop_cmaes(
             pop_size   = len(population)
             logger.info(
                 "--- Generation %d/%d --- evaluating %d individuals (σ=%.4f, episode_time=%.1fs)",
-                gen, n_generations, pop_size, policy._sigma, env._max_episode_time_s,
+                gen, n_generations, pop_size, policy.sigma, env._max_episode_time_s,
             )
 
             rewards     = []
@@ -780,12 +781,12 @@ def _greedy_loop_cmaes(
                 policy.save(weights_file)
                 verdict = (
                     f"NEW BEST champion  reward={policy.champion_reward:+.1f}"
-                    f"  σ={policy._sigma:.4f}"
+                    f"  σ={policy.sigma:.4f}"
                 )
             else:
                 verdict = (
                     f"no improvement  gen_best={gen_best:+.1f}"
-                    f"  champion={policy.champion_reward:+.1f}  σ={policy._sigma:.4f}"
+                    f"  champion={policy.champion_reward:+.1f}  σ={policy.sigma:.4f}"
                 )
 
             logger.info("  >> %s", verdict)

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from policies import (
     EpsilonGreedyPolicy,
     MCTSPolicy,
     GeneticPolicy,
+    CMAESPolicy,
 )
 from rl.env import TMNFEnv, make_env
 from rl.reward import RewardConfig
@@ -129,9 +130,26 @@ def _make_policy(
             logger.info("[GeneticPolicy] random population of %d", pop_size)
         return policy
 
+    elif policy_type == "cmaes":
+        pop_size = policy_params.get("population_size", 20)
+        sigma    = policy_params.get("initial_sigma", 0.3)
+        policy   = CMAESPolicy(
+            population_size = pop_size,
+            initial_sigma   = sigma,
+            n_lidar_rays    = n_lidar_rays,
+        )
+        if os.path.exists(weights_file) and not re_initialize:
+            champion = WeightedLinearPolicy(weights_file, n_lidar_rays)
+            policy.initialize_from_champion(champion)
+            logger.info("[CMAESPolicy] seeded mean from champion at %s", weights_file)
+        else:
+            policy.initialize_random()
+            logger.info("[CMAESPolicy] initialised with zero mean, σ=%.3f", sigma)
+        return policy
+
     else:
         raise ValueError(f"Unknown policy_type: {policy_type!r}. "
-                         f"Choose from: hill_climbing, neural_net, epsilon_greedy, mcts, genetic")
+                         f"Choose from: hill_climbing, neural_net, epsilon_greedy, mcts, genetic, cmaes")
 
 
 # ---------------------------------------------------------------------------
@@ -703,6 +721,89 @@ def _greedy_loop_genetic(
 
 
 # ---------------------------------------------------------------------------
+# CMA-ES greedy loop (structurally similar to genetic: N_pop episodes per generation)
+# ---------------------------------------------------------------------------
+
+def _greedy_loop_cmaes(
+    env: TMNFEnv,
+    policy: CMAESPolicy,
+    n_generations: int,
+    weights_file: str,
+) -> tuple[CMAESPolicy, float, list[GreedySimResult]]:
+    """
+    CMA-ES training loop.
+
+    Each "sim" is one generation:
+      1. sample_population() → draw λ offspring from N(mean, σ²·C)
+      2. Evaluate each offspring for one episode
+      3. update_distribution(rewards) → update mean, σ, C, paths
+
+    Total episodes = n_generations × population_size.
+    """
+    best_reward = policy.champion_reward
+    greedy_sims: list[GreedySimResult] = []
+    full_episode_time_s = env._max_episode_time_s
+
+    logger.info(
+        "[CMAES] population_size=%d, total episodes = %d × %d = %d",
+        policy._lam, n_generations, policy._lam, n_generations * policy._lam,
+    )
+
+    try:
+        for gen in range(1, n_generations + 1):
+            env._max_episode_time_s = _scaled_episode_time(gen, n_generations, full_episode_time_s)
+            population = policy.sample_population()
+            pop_size   = len(population)
+            logger.info(
+                "--- Generation %d/%d --- evaluating %d individuals (σ=%.4f, episode_time=%.1fs)",
+                gen, n_generations, pop_size, policy._sigma, env._max_episode_time_s,
+            )
+
+            rewards     = []
+            total_steps = 0
+            trace       = None
+            info: dict[str, Any] = {}
+
+            for idx, individual in enumerate(population):
+                logger.debug("Individual %d/%d (respawning)", idx + 1, pop_size)
+                obs, _ = env.reset()
+                reward, info, _, steps, trace = _run_episode(env, individual, obs)
+                rewards.append(reward)
+                total_steps += steps
+
+            improved = policy.update_distribution(rewards)
+            gen_best = max(rewards)
+            if gen_best > best_reward:
+                best_reward = gen_best
+
+            if improved:
+                policy.save(weights_file)
+                verdict = (
+                    f"NEW BEST champion  reward={policy.champion_reward:+.1f}"
+                    f"  σ={policy._sigma:.4f}"
+                )
+            else:
+                verdict = (
+                    f"no improvement  gen_best={gen_best:+.1f}"
+                    f"  champion={policy.champion_reward:+.1f}  σ={policy._sigma:.4f}"
+                )
+
+            logger.info("  >> %s", verdict)
+            greedy_sims.append(GreedySimResult(
+                sim=gen, reward=gen_best, improved=improved,
+                throttle_counts=[0, 0, 0], total_steps=total_steps,
+                trace=trace,
+                weights=policy.to_cfg(),
+                final_track_progress=info.get("track_progress", 0.0),
+                laps_completed=info.get("laps_completed", 0),
+            ))
+    except KeyboardInterrupt:
+        logger.warning("Training interrupted.")
+
+    return policy, best_reward, greedy_sims
+
+
+# ---------------------------------------------------------------------------
 # Training orchestrator
 # ---------------------------------------------------------------------------
 
@@ -820,6 +921,13 @@ def train_rl(
             policy=best_policy, # type: ignore[arg-type]
             n_generations=n_sims,
             weights_file=weights_file
+        )
+    elif policy_type == "cmaes":
+        best_policy, best_reward, greedy_sims = _greedy_loop_cmaes(
+            env=env,
+            policy=best_policy,  # type: ignore[arg-type]
+            n_generations=n_sims,
+            weights_file=weights_file,
         )
     else:
         best_policy, best_reward, greedy_sims = _greedy_loop(

--- a/policies.py
+++ b/policies.py
@@ -834,6 +834,7 @@ class CMAESPolicy(BasePolicy):
         population_size: int = 20,
         initial_sigma: float = 0.3,
         n_lidar_rays: int = 0,
+        seed: int | None = None,
     ) -> None:
         from obs_spec import BASE_OBS_DIM
         self._lam          = population_size
@@ -863,9 +864,11 @@ class CMAESPolicy(BasePolicy):
             2.0 * (self._mu_eff - 2 + 1.0 / self._mu_eff) / ((n + 2) ** 2 + self._mu_eff),
         )
 
+        # Shared RNG — seeding makes sampling reproducible (useful for tests)
+        self._rng = np.random.default_rng(seed)
+
         # Distribution state (float64 for numerical stability)
-        rng             = np.random.default_rng()
-        self._mean      = rng.standard_normal(n).astype(np.float64)
+        self._mean      = self._rng.standard_normal(n).astype(np.float64)
         self._sigma     = float(initial_sigma)
         self._ps        = np.zeros(n, dtype=np.float64)   # step-size evolution path
         self._pc        = np.zeros(n, dtype=np.float64)   # covariance evolution path
@@ -891,6 +894,16 @@ class CMAESPolicy(BasePolicy):
     @property
     def champion_reward(self) -> float:
         return self._champion_reward
+
+    @property
+    def population_size(self) -> int:
+        """Number of offspring sampled each generation (λ)."""
+        return self._lam
+
+    @property
+    def sigma(self) -> float:
+        """Current step size σ (adapts each generation)."""
+        return self._sigma
 
     # ------------------------------------------------------------------
     # Initialisation
@@ -961,8 +974,7 @@ class CMAESPolicy(BasePolicy):
         Returns a list of WeightedLinearPolicy instances ready for evaluation.
         Must be followed by update_distribution(rewards) with the same ordering.
         """
-        n   = self._n
-        rng = np.random.default_rng()
+        n = self._n
 
         # Refresh eigendecomposition every generation (λ/(10n) < 1 for typical dims)
         if self._gen - self._eigengen >= max(1, self._lam // max(1, 10 * n)):
@@ -971,7 +983,7 @@ class CMAESPolicy(BasePolicy):
         self._pop_xs = []
         self._pop_ys = []
         for _ in range(self._lam):
-            z = rng.standard_normal(n)
+            z = self._rng.standard_normal(n)
             y = self._B @ (self._D * z)        # sample from N(0, C)
             x = self._mean + self._sigma * y
             self._pop_xs.append(x)
@@ -989,6 +1001,13 @@ class CMAESPolicy(BasePolicy):
         """
         if len(rewards) != self._lam:
             raise ValueError(f"Expected {self._lam} rewards, got {len(rewards)}")
+        if len(self._pop_xs) != self._lam or len(self._pop_ys) != self._lam:
+            raise RuntimeError(
+                "update_distribution() called before a matching sample_population(). "
+                f"Expected {self._lam} samples in _pop_xs/_pop_ys, "
+                f"got {len(self._pop_xs)}/{len(self._pop_ys)}. "
+                "Call sample_population() first."
+            )
         n = self._n
 
         # Rank offspring descending by reward

--- a/policies.py
+++ b/policies.py
@@ -903,11 +903,30 @@ class CMAESPolicy(BasePolicy):
 
     def initialize_from_champion(self, champion: WeightedLinearPolicy) -> None:
         """Seed the search mean from an existing champion's flat weight vector."""
-        self._champion        = champion
-        self._champion_reward = float("-inf")   # re-evaluated in first generation
-        self._mean            = champion.to_flat().astype(np.float64)
-        logger.info("[CMAESPolicy] seeded mean from champion")
+        self._champion = champion
 
+        seeded_reward = None
+        for attr_name in ("champion_reward", "reward"):
+            reward_value = getattr(champion, attr_name, None)
+            if reward_value is not None:
+                try:
+                    seeded_reward = float(reward_value)
+                except (TypeError, ValueError):
+                    seeded_reward = None
+                else:
+                    if math.isfinite(seeded_reward):
+                        break
+                    seeded_reward = None
+
+        if seeded_reward is None and math.isfinite(self._champion_reward):
+            seeded_reward = float(self._champion_reward)
+
+        self._champion_reward = seeded_reward if seeded_reward is not None else float("-inf")
+        self._mean = champion.to_flat().astype(np.float64)
+        logger.info(
+            "[CMAESPolicy] seeded mean from champion%s",
+            "" if seeded_reward is None else f" (baseline reward={self._champion_reward:.6f})",
+        )
     # ------------------------------------------------------------------
     # Internal helpers
     # ------------------------------------------------------------------

--- a/policies.py
+++ b/policies.py
@@ -1057,7 +1057,7 @@ class CMAESPolicy(BasePolicy):
         return {
             "policy_type":     "cmaes",
             "population_size": self._lam,
-            "initial_sigma":   self._sigma,
+            "sigma":          self._sigma,
             "n_lidar_rays":    self._n_lidar_rays,
             "champion_reward": float(self._champion_reward),
         }

--- a/policies.py
+++ b/policies.py
@@ -13,6 +13,7 @@ QTablePolicy         — shared base for tabular Q-learning policies
 EpsilonGreedyPolicy  — Q-table with epsilon-greedy exploration
 MCTSPolicy           — Q-table with UCB1 (UCT-style) action selection
 GeneticPolicy        — population of WeightedLinearPolicy, evolutionary training
+CMAESPolicy          — CMA-ES over flat WeightedLinearPolicy weights (Hansen 2016)
 """
 
 from __future__ import annotations
@@ -801,6 +802,245 @@ class GeneticPolicy(BasePolicy):
             "mutation_share":   float(self._mutation_share),
             "champion_reward":  float(self._champion_reward),
             "champion_weights": self._champion.to_cfg() if self._champion else {},
+        }
+
+    def save(self, path: str) -> None:
+        """Save champion in WeightedLinearPolicy YAML format for analytics compatibility."""
+        if self._champion is not None:
+            self._champion.save(path)
+
+
+# ---------------------------------------------------------------------------
+# CMAESPolicy
+# ---------------------------------------------------------------------------
+
+class CMAESPolicy(BasePolicy):
+    """
+    CMA-ES over the flat weight vector of a WeightedLinearPolicy.
+    Uses the (μ/μ_w, λ)-CMA-ES algorithm (Hansen 2016).
+
+    Each generation:
+      1. sample_population() — draw λ offspring from N(mean, σ²·C)
+      2. Evaluate each offspring for one episode
+      3. update_distribution(rewards) — update mean, σ, C, and evolution paths
+
+    Inference always uses the champion (best individual seen so far).
+    save() writes the champion in WeightedLinearPolicy YAML format so
+    existing analytics (weight heatmaps, etc.) work without changes.
+    """
+
+    def __init__(
+        self,
+        population_size: int = 20,
+        initial_sigma: float = 0.3,
+        n_lidar_rays: int = 0,
+    ) -> None:
+        from obs_spec import BASE_OBS_DIM
+        self._lam          = population_size
+        self._n_lidar_rays = n_lidar_rays
+        n                  = (BASE_OBS_DIM + n_lidar_rays) * 3   # steer + accel + brake heads
+        self._n            = n
+
+        # Recombination weights (elite half, log-based, normalised)
+        mu            = self._lam // 2
+        self._mu      = mu
+        raw_w         = np.array([np.log(mu + 0.5) - np.log(i + 1) for i in range(mu)],
+                                 dtype=np.float64)
+        self._weights = raw_w / raw_w.sum()
+        self._mu_eff  = 1.0 / float(np.sum(self._weights ** 2))
+
+        # Step-size adaptation constants (Hansen 2016, §3)
+        self._cs   = (self._mu_eff + 2) / (n + self._mu_eff + 5)
+        self._ds   = (1 + 2 * max(0.0, float(np.sqrt((self._mu_eff - 1) / (n + 1))) - 1)
+                      + self._cs)
+        self._chin = float(np.sqrt(n) * (1 - 1.0 / (4 * n) + 1.0 / (21 * n ** 2)))
+
+        # Covariance adaptation constants (Hansen 2016, §3)
+        self._cc  = (4 + self._mu_eff / n) / (n + 4 + 2 * self._mu_eff / n)
+        self._c1  = 2.0 / ((n + 1.3) ** 2 + self._mu_eff)
+        self._cmu = min(
+            1.0 - self._c1,
+            2.0 * (self._mu_eff - 2 + 1.0 / self._mu_eff) / ((n + 2) ** 2 + self._mu_eff),
+        )
+
+        # Distribution state (float64 for numerical stability)
+        rng             = np.random.default_rng()
+        self._mean      = rng.standard_normal(n).astype(np.float64)
+        self._sigma     = float(initial_sigma)
+        self._ps        = np.zeros(n, dtype=np.float64)   # step-size evolution path
+        self._pc        = np.zeros(n, dtype=np.float64)   # covariance evolution path
+        self._C         = np.eye(n, dtype=np.float64)     # covariance matrix
+        self._B         = np.eye(n, dtype=np.float64)     # eigenvectors of C
+        self._D         = np.ones(n, dtype=np.float64)    # sqrt(eigenvalues) of C
+        self._invsqrtC  = np.eye(n, dtype=np.float64)     # C^{-1/2}
+        self._eigengen  = 0    # generation of last eigendecomposition
+        self._gen       = 0    # current generation counter
+
+        # Sampling buffer (filled by sample_population, consumed by update_distribution)
+        self._pop_xs: list[np.ndarray] = []
+        self._pop_ys: list[np.ndarray] = []
+
+        # Champion
+        self._champion: WeightedLinearPolicy | None = None
+        self._champion_reward: float = float("-inf")
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def champion_reward(self) -> float:
+        return self._champion_reward
+
+    # ------------------------------------------------------------------
+    # Initialisation
+    # ------------------------------------------------------------------
+
+    def initialize_random(self) -> None:
+        """Initialise the search mean at zero; CMA-ES adapts scale via σ."""
+        self._mean = np.zeros(self._n, dtype=np.float64)
+        logger.info("[CMAESPolicy] initialised with zero mean, σ=%.3f", self._sigma)
+
+    def initialize_from_champion(self, champion: WeightedLinearPolicy) -> None:
+        """Seed the search mean from an existing champion's flat weight vector."""
+        self._champion        = champion
+        self._champion_reward = float("-inf")   # re-evaluated in first generation
+        self._mean            = champion.to_flat().astype(np.float64)
+        logger.info("[CMAESPolicy] seeded mean from champion")
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _flat_to_policy(self, flat: np.ndarray) -> WeightedLinearPolicy:
+        """Build a WeightedLinearPolicy from a flat [steer|accel|brake] weight vector."""
+        names  = obs_names_with_lidar(self._n_lidar_rays)
+        obs_n  = len(names)
+        cfg = {
+            "steer_weights": {names[i]: float(flat[i])             for i in range(obs_n)},
+            "accel_weights": {names[i]: float(flat[obs_n + i])     for i in range(obs_n)},
+            "brake_weights": {names[i]: float(flat[2 * obs_n + i]) for i in range(obs_n)},
+        }
+        return WeightedLinearPolicy.from_cfg(cfg, n_lidar_rays=self._n_lidar_rays)
+
+    def _update_eigen(self) -> None:
+        """Eigendecompose C and refresh B, D, invsqrtC."""
+        self._C = np.triu(self._C) + np.triu(self._C, 1).T     # enforce symmetry
+        eigvals, self._B = np.linalg.eigh(self._C)
+        eigvals          = np.maximum(eigvals, 1e-20)           # clamp negatives
+        self._D          = np.sqrt(eigvals)
+        self._invsqrtC   = self._B @ np.diag(1.0 / self._D) @ self._B.T
+        self._eigengen   = self._gen
+
+    # ------------------------------------------------------------------
+    # Training interface
+    # ------------------------------------------------------------------
+
+    def sample_population(self) -> list[WeightedLinearPolicy]:
+        """Sample λ offspring from N(mean, σ²·C).
+
+        Returns a list of WeightedLinearPolicy instances ready for evaluation.
+        Must be followed by update_distribution(rewards) with the same ordering.
+        """
+        n   = self._n
+        rng = np.random.default_rng()
+
+        # Refresh eigendecomposition every generation (λ/(10n) < 1 for typical dims)
+        if self._gen - self._eigengen >= max(1, self._lam // max(1, 10 * n)):
+            self._update_eigen()
+
+        self._pop_xs = []
+        self._pop_ys = []
+        for _ in range(self._lam):
+            z = rng.standard_normal(n)
+            y = self._B @ (self._D * z)        # sample from N(0, C)
+            x = self._mean + self._sigma * y
+            self._pop_xs.append(x)
+            self._pop_ys.append(y)
+
+        return [self._flat_to_policy(x) for x in self._pop_xs]
+
+    def update_distribution(self, rewards: list[float]) -> bool:
+        """Apply (μ/μ_w, λ)-CMA-ES update given per-offspring episode rewards.
+
+        Updates mean, σ, p_σ, p_c, and C in place.
+
+        Returns:
+            True if the all-time champion was improved this generation.
+        """
+        if len(rewards) != self._lam:
+            raise ValueError(f"Expected {self._lam} rewards, got {len(rewards)}")
+        n = self._n
+
+        # Rank offspring descending by reward
+        order = np.argsort(rewards)[::-1]
+
+        # Update champion
+        improved = False
+        best_r   = rewards[order[0]]
+        if best_r > self._champion_reward:
+            self._champion_reward = best_r
+            self._champion        = self._flat_to_policy(self._pop_xs[order[0]])
+            improved              = True
+
+        # Weighted average of elite steps y_i = (x_i − mean) / σ
+        elite_ys = np.stack([self._pop_ys[order[i]] for i in range(self._mu)])  # (mu, n)
+        step     = np.einsum("i,ij->j", self._weights, elite_ys)                # (n,)
+
+        # Mean update
+        self._mean = self._mean + self._sigma * step
+
+        # Step-size evolution path p_σ  (Hansen 2016, eq. 43)
+        ps_scale  = float(np.sqrt(self._cs * (2 - self._cs) * self._mu_eff))
+        self._ps  = (1 - self._cs) * self._ps + ps_scale * (self._invsqrtC @ step)
+
+        # Step-size update σ  (Hansen 2016, eq. 44)
+        ps_norm     = float(np.linalg.norm(self._ps))
+        self._sigma = float(np.clip(
+            self._sigma * np.exp((self._cs / self._ds) * (ps_norm / self._chin - 1)),
+            1e-10, 1e6,
+        ))
+
+        # h_σ stall indicator
+        ps_norm_normed = ps_norm / float(np.sqrt(1 - (1 - self._cs) ** (2 * (self._gen + 1))))
+        h_sigma = 1.0 if ps_norm_normed < (1.4 + 2.0 / (n + 1)) * self._chin else 0.0
+
+        # Covariance evolution path p_c  (Hansen 2016, eq. 45)
+        pc_scale  = float(np.sqrt(self._cc * (2 - self._cc) * self._mu_eff))
+        self._pc  = (1 - self._cc) * self._pc + h_sigma * pc_scale * step
+
+        # Covariance update  (Hansen 2016, eq. 47)
+        delta_h = (1 - h_sigma) * self._cc * (2 - self._cc)
+        rank1   = np.outer(self._pc, self._pc)
+        rank_mu = np.einsum("i,ij,ik->jk", self._weights, elite_ys, elite_ys)
+        self._C = (
+            (1 - self._c1 - self._cmu) * self._C
+            + self._c1 * (rank1 + delta_h * self._C)
+            + self._cmu * rank_mu
+        )
+
+        self._gen += 1
+        return improved
+
+    # ------------------------------------------------------------------
+    # BasePolicy interface
+    # ------------------------------------------------------------------
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        if self._champion is None:
+            raise RuntimeError(
+                "CMAESPolicy: no champion yet — call sample_population() "
+                "and update_distribution() for at least one generation first."
+            )
+        return self._champion(obs)
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type":     "cmaes",
+            "population_size": self._lam,
+            "initial_sigma":   self._sigma,
+            "n_lidar_rays":    self._n_lidar_rays,
+            "champion_reward": float(self._champion_reward),
         }
 
     def save(self, path: str) -> None:

--- a/tests/test_cmaes_policy.py
+++ b/tests/test_cmaes_policy.py
@@ -123,6 +123,13 @@ class TestCMAESPolicyUpdate(unittest.TestCase):
         with self.assertRaises(ValueError):
             policy.update_distribution([0.0] * (policy._lam - 1))
 
+    def test_update_without_sample_raises(self):
+        policy = CMAESPolicy(population_size=6)
+        policy.initialize_random()
+        # Never called sample_population() — _pop_xs/_pop_ys are empty
+        with self.assertRaises(RuntimeError):
+            policy.update_distribution([0.0] * 6)
+
     def test_mean_moves_after_update(self):
         policy = CMAESPolicy(population_size=10, initial_sigma=0.5)
         policy.initialize_random()
@@ -200,7 +207,7 @@ class TestCMAESConvergence(unittest.TestCase):
         """CMA-ES mean should move toward the maximizer of a quadratic in <=50 generations."""
         from obs_spec import BASE_OBS_DIM
 
-        policy  = CMAESPolicy(population_size=20, initial_sigma=1.0, n_lidar_rays=0)
+        policy  = CMAESPolicy(population_size=20, initial_sigma=1.0, n_lidar_rays=0, seed=42)
         policy.initialize_random()
 
         n_weights = BASE_OBS_DIM * 3

--- a/tests/test_cmaes_policy.py
+++ b/tests/test_cmaes_policy.py
@@ -171,7 +171,7 @@ class TestCMAESPolicySerialisation(unittest.TestCase):
     def test_to_cfg_contains_required_keys(self):
         policy = CMAESPolicy(population_size=10, initial_sigma=0.3)
         cfg    = policy.to_cfg()
-        for key in ("policy_type", "population_size", "initial_sigma",
+        for key in ("policy_type", "population_size", "sigma",
                     "n_lidar_rays", "champion_reward"):
             self.assertIn(key, cfg)
 

--- a/tests/test_cmaes_policy.py
+++ b/tests/test_cmaes_policy.py
@@ -1,0 +1,228 @@
+"""Tests for CMAESPolicy in policies.py."""
+import unittest
+
+import numpy as np
+
+from policies import CMAESPolicy, WeightedLinearPolicy
+
+
+class TestCMAESPolicyInit(unittest.TestCase):
+
+    def test_default_population_size(self):
+        policy = CMAESPolicy(population_size=10, initial_sigma=0.3)
+        self.assertEqual(policy._lam, 10)
+
+    def test_mu_is_half_lambda(self):
+        policy = CMAESPolicy(population_size=20)
+        self.assertEqual(policy._mu, 10)
+
+    def test_weights_sum_to_one(self):
+        policy = CMAESPolicy(population_size=16)
+        self.assertAlmostEqual(float(policy._weights.sum()), 1.0, places=10)
+
+    def test_covariance_is_identity_at_init(self):
+        policy = CMAESPolicy(population_size=10)
+        np.testing.assert_array_almost_equal(policy._C, np.eye(policy._n))
+
+    def test_initialize_random_sets_zero_mean(self):
+        policy = CMAESPolicy(population_size=10)
+        policy.initialize_random()
+        np.testing.assert_array_equal(policy._mean, np.zeros(policy._n))
+
+    def test_initialize_from_champion_seeds_mean(self):
+        policy    = CMAESPolicy(population_size=10, n_lidar_rays=0)
+        names     = WeightedLinearPolicy.get_obs_names(0)
+        cfg       = {
+            "steer_weights": {n: 1.0 for n in names},
+            "accel_weights": {n: 0.0 for n in names},
+            "brake_weights": {n: 0.0 for n in names},
+        }
+        champion  = WeightedLinearPolicy.from_cfg(cfg)
+        policy.initialize_from_champion(champion)
+        expected  = champion.to_flat().astype(np.float64)
+        np.testing.assert_array_almost_equal(policy._mean, expected)
+
+    def test_initialize_from_champion_sets_champion(self):
+        policy   = CMAESPolicy(population_size=10)
+        names    = WeightedLinearPolicy.get_obs_names(0)
+        cfg      = {
+            "steer_weights": {n: 0.5 for n in names},
+            "accel_weights": {n: 0.5 for n in names},
+            "brake_weights": {n: 0.0 for n in names},
+        }
+        champion = WeightedLinearPolicy.from_cfg(cfg)
+        policy.initialize_from_champion(champion)
+        self.assertIs(policy._champion, champion)
+
+
+class TestCMAESPolicySampling(unittest.TestCase):
+
+    def test_sample_population_returns_correct_count(self):
+        policy = CMAESPolicy(population_size=12)
+        policy.initialize_random()
+        population = policy.sample_population()
+        self.assertEqual(len(population), 12)
+
+    def test_sample_population_returns_weighted_linear_policies(self):
+        policy = CMAESPolicy(population_size=8)
+        policy.initialize_random()
+        population = policy.sample_population()
+        for ind in population:
+            self.assertIsInstance(ind, WeightedLinearPolicy)
+
+    def test_pop_xs_and_ys_filled_after_sample(self):
+        policy = CMAESPolicy(population_size=6)
+        policy.initialize_random()
+        policy.sample_population()
+        self.assertEqual(len(policy._pop_xs), 6)
+        self.assertEqual(len(policy._pop_ys), 6)
+
+
+class TestCMAESPolicyUpdate(unittest.TestCase):
+
+    def _make_and_sample(self, pop=10):
+        policy = CMAESPolicy(population_size=pop, initial_sigma=0.5)
+        policy.initialize_random()
+        policy.sample_population()
+        return policy
+
+    def test_update_sets_champion_on_first_call(self):
+        policy = self._make_and_sample()
+        rewards = list(range(policy._lam))
+        policy.update_distribution(rewards)
+        self.assertIsNotNone(policy._champion)
+
+    def test_update_returns_true_when_champion_improved(self):
+        policy = self._make_and_sample()
+        rewards = [float(i) for i in range(policy._lam)]
+        improved = policy.update_distribution(rewards)
+        self.assertTrue(improved)
+
+    def test_update_returns_false_when_no_improvement(self):
+        policy = self._make_and_sample()
+        rewards = [100.0] * policy._lam
+        policy.update_distribution(rewards)     # sets champion_reward = 100.0
+
+        policy.sample_population()
+        improved = policy.update_distribution([50.0] * policy._lam)
+        self.assertFalse(improved)
+
+    def test_champion_reward_is_best_seen(self):
+        policy = self._make_and_sample()
+        rewards = [10.0, 99.0] + [1.0] * (policy._lam - 2)
+        policy.update_distribution(rewards)
+        self.assertAlmostEqual(policy.champion_reward, 99.0)
+
+    def test_generation_counter_increments(self):
+        policy = self._make_and_sample()
+        policy.update_distribution([0.0] * policy._lam)
+        self.assertEqual(policy._gen, 1)
+
+    def test_wrong_reward_count_raises(self):
+        policy = self._make_and_sample()
+        with self.assertRaises(ValueError):
+            policy.update_distribution([0.0] * (policy._lam - 1))
+
+    def test_mean_moves_after_update(self):
+        policy = CMAESPolicy(population_size=10, initial_sigma=0.5)
+        policy.initialize_random()
+        old_mean = policy._mean.copy()
+        policy.sample_population()
+        # Give high reward to all — any non-zero step should shift the mean
+        rewards = [float(i) for i in range(policy._lam)]
+        policy.update_distribution(rewards)
+        self.assertFalse(np.allclose(policy._mean, old_mean))
+
+
+class TestCMAESPolicyCallable(unittest.TestCase):
+
+    def test_call_raises_before_any_update(self):
+        policy = CMAESPolicy(population_size=6)
+        policy.initialize_random()
+        obs = np.zeros(21, dtype=np.float32)
+        with self.assertRaises(RuntimeError):
+            policy(obs)
+
+    def test_call_returns_valid_action_after_update(self):
+        policy = CMAESPolicy(population_size=6, initial_sigma=0.3)
+        policy.initialize_random()
+        policy.sample_population()
+        policy.update_distribution([float(i) for i in range(6)])
+
+        from obs_spec import BASE_OBS_DIM
+        obs    = np.zeros(BASE_OBS_DIM, dtype=np.float32)
+        action = policy(obs)
+        self.assertEqual(action.shape, (3,))
+        self.assertGreaterEqual(float(action[0]), -1.0)
+        self.assertLessEqual(float(action[0]),  1.0)
+        self.assertIn(float(action[1]), (0.0, 1.0))
+        self.assertIn(float(action[2]), (0.0, 1.0))
+
+
+class TestCMAESPolicySerialisation(unittest.TestCase):
+
+    def test_to_cfg_contains_required_keys(self):
+        policy = CMAESPolicy(population_size=10, initial_sigma=0.3)
+        cfg    = policy.to_cfg()
+        for key in ("policy_type", "population_size", "initial_sigma",
+                    "n_lidar_rays", "champion_reward"):
+            self.assertIn(key, cfg)
+
+    def test_to_cfg_policy_type(self):
+        policy = CMAESPolicy(population_size=10)
+        self.assertEqual(policy.to_cfg()["policy_type"], "cmaes")
+
+    def test_save_writes_weighted_linear_yaml(self, tmp_path=None):
+        import tempfile, os
+        policy = CMAESPolicy(population_size=6, initial_sigma=0.3)
+        policy.initialize_random()
+        policy.sample_population()
+        policy.update_distribution([float(i) for i in range(6)])
+
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            path = f.name
+        try:
+            policy.save(path)
+            self.assertTrue(os.path.exists(path))
+            import yaml
+            with open(path) as f:
+                cfg = yaml.safe_load(f)
+            self.assertIn("steer_weights", cfg)
+            self.assertIn("accel_weights", cfg)
+            self.assertIn("brake_weights", cfg)
+        finally:
+            os.unlink(path)
+
+
+class TestCMAESConvergence(unittest.TestCase):
+
+    def test_converges_toward_quadratic_maximum(self):
+        """CMA-ES mean should move toward the maximizer of a quadratic in <=50 generations."""
+        from obs_spec import BASE_OBS_DIM
+
+        policy  = CMAESPolicy(population_size=20, initial_sigma=1.0, n_lidar_rays=0)
+        policy.initialize_random()
+
+        n_weights = BASE_OBS_DIM * 3
+        target    = np.ones(n_weights, dtype=np.float64)
+
+        initial_dist = float(np.linalg.norm(policy._mean - target))
+
+        for _ in range(50):
+            individuals = policy.sample_population()
+            rewards = [
+                -float(np.sum((ind.to_flat().astype(np.float64) - target) ** 2))
+                for ind in individuals
+            ]
+            policy.update_distribution(rewards)
+
+        final_dist = float(np.linalg.norm(policy._mean - target))
+        self.assertLess(
+            final_dist, initial_dist,
+            f"CMA-ES failed to converge: initial_dist={initial_dist:.3f}, "
+            f"final_dist={final_dist:.3f}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Closes #19.

CMA-ES adapts a full covariance matrix over the flat [steer|accel|brake] weight vector (~63-D), providing automatic step-size adaptation and correlation learning without manual mutation tuning.

## Changes

- **`policies.py`**: `CMAESPolicy` class implementing `(μ/μ_w, λ)-CMA-ES` (Hansen 2016):
  - `sample_population()` / `update_distribution()` interface matching `GeneticPolicy`'s training loop contract
  - Cumulative step-size adaptation (CSA) for σ, rank-1 + rank-μ covariance update
  - Seeded `self._rng` for reproducible sampling (accepts optional `seed` parameter)
  - Public properties `population_size` and `sigma`
  - Guard in `update_distribution()` raises `RuntimeError` if called before a matching `sample_population()`
  - `save()` writes champion in `WeightedLinearPolicy` YAML format for analytics compatibility

- **`main.py`**: `_greedy_loop_cmaes()`, `_make_policy()` `'cmaes'` branch, dispatch in `train_rl()`

- **`config/training_params.yaml`**: documents `cmaes` `policy_params` block

- **`tests/test_cmaes_policy.py`**: 24 unit tests covering init, sampling, distribution updates, serialisation, guard behaviour, and deterministic quadratic convergence (fixed seed)

- **`README.md`** / **`CLAUDE.md`**: CMAESPolicy added to policy tables with algorithm description, hyperparameter reference, and usage notes

https://claude.ai/code/session_01Mj7MA8eay11RaGgMYd5XEJ