### PR TITLE
feat: add NeuralDQNPolicy with experience replay and target network (closes #20)

### DIFF
--- a/config/training_params.yaml
+++ b/config/training_params.yaml
@@ -12,7 +12,7 @@ n_lidar_rays: 8          # LIDAR wall-distance rays appended to observation (0 =
 
 
 # Policy algorithm for the greedy training phase.
-# Options: hill_climbing | neural_net | epsilon_greedy | mcts | genetic
+# Options: hill_climbing | neural_net | epsilon_greedy | mcts | genetic | neural_dqn
 policy_type: genetic
 
 # Type-specific hyperparams.  Only the block matching policy_type is used.
@@ -47,3 +47,15 @@ policy_params:
   population_size: 20      # individuals per generation
   elite_k: 3               # top survivors kept unchanged each generation
   # mutation_scale is inherited from the top-level value above
+
+  # neural_dqn — DQN with experience replay and frozen target network
+  #hidden_sizes: [64, 64]       # MLP hidden layer sizes
+  #replay_buffer_size: 10000    # max transitions stored in replay buffer
+  #batch_size: 64               # minibatch size for each gradient step
+  #min_replay_size: 500         # steps before first gradient update
+  #target_update_freq: 200      # gradient steps between target network syncs
+  #learning_rate: 0.001         # Adam learning rate
+  #epsilon_start: 1.0           # initial exploration rate
+  #epsilon_end: 0.05            # minimum exploration rate
+  #epsilon_decay_steps: 5000    # steps over which epsilon decays linearly
+  #gamma: 0.99                  # discount factor

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from policies import (
     EpsilonGreedyPolicy,
     MCTSPolicy,
     GeneticPolicy,
+    NeuralDQNPolicy,
 )
 from rl.env import TMNFEnv, make_env
 from rl.reward import RewardConfig
@@ -129,9 +130,32 @@ def _make_policy(
             logger.info("[GeneticPolicy] random population of %d", pop_size)
         return policy
 
+    elif policy_type == "neural_dqn":
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as f:
+                cfg = yaml.safe_load(f)
+            if cfg.get("policy_type") == "neural_dqn":
+                logger.info("[NeuralDQNPolicy] loaded from %s", weights_file)
+                return NeuralDQNPolicy.from_cfg(cfg, n_lidar_rays)
+        hidden = policy_params.get("hidden_sizes", [64, 64])
+        logger.info("[NeuralDQNPolicy] initialised new network (hidden=%s)", hidden)
+        return NeuralDQNPolicy(
+            hidden_sizes        = hidden,
+            replay_buffer_size  = policy_params.get("replay_buffer_size",  10000),
+            batch_size          = policy_params.get("batch_size",          64),
+            min_replay_size     = policy_params.get("min_replay_size",     500),
+            target_update_freq  = policy_params.get("target_update_freq",  200),
+            learning_rate       = policy_params.get("learning_rate",       0.001),
+            epsilon_start       = policy_params.get("epsilon_start",       1.0),
+            epsilon_end         = policy_params.get("epsilon_end",         0.05),
+            epsilon_decay_steps = policy_params.get("epsilon_decay_steps", 5000),
+            gamma               = policy_params.get("gamma",               0.99),
+            n_lidar_rays        = n_lidar_rays,
+        )
+
     else:
         raise ValueError(f"Unknown policy_type: {policy_type!r}. "
-                         f"Choose from: hill_climbing, neural_net, epsilon_greedy, mcts, genetic")
+                         f"Choose from: hill_climbing, neural_net, epsilon_greedy, mcts, genetic, neural_dqn")
 
 
 # ---------------------------------------------------------------------------

--- a/policies.py
+++ b/policies.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+from collections import deque
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -807,3 +808,302 @@ class GeneticPolicy(BasePolicy):
         """Save champion in WeightedLinearPolicy YAML format for analytics compatibility."""
         if self._champion is not None:
             self._champion.save(path)
+
+
+# ---------------------------------------------------------------------------
+# ReplayBuffer
+# ---------------------------------------------------------------------------
+
+class ReplayBuffer:
+    """Fixed-size circular buffer of (obs, action_idx, reward, next_obs, done) tuples."""
+
+    def __init__(self, maxlen: int) -> None:
+        self._buf: deque = deque(maxlen=maxlen)
+
+    def push(self, obs: np.ndarray, action_idx: int, reward: float,
+             next_obs: np.ndarray, done: bool) -> None:
+        self._buf.append((obs.copy(), int(action_idx), float(reward), next_obs.copy(), bool(done)))
+
+    def sample(self, batch_size: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        idxs  = np.random.choice(len(self._buf), size=batch_size, replace=False)
+        batch = [self._buf[i] for i in idxs]
+        obs_b  = np.stack([t[0] for t in batch]).astype(np.float32)
+        act_b  = np.array([t[1] for t in batch], dtype=np.int32)
+        rew_b  = np.array([t[2] for t in batch], dtype=np.float32)
+        next_b = np.stack([t[3] for t in batch]).astype(np.float32)
+        done_b = np.array([t[4] for t in batch], dtype=np.float32)
+        return obs_b, act_b, rew_b, next_b, done_b
+
+    def __len__(self) -> int:
+        return len(self._buf)
+
+
+# ---------------------------------------------------------------------------
+# NeuralDQNPolicy
+# ---------------------------------------------------------------------------
+
+class NeuralDQNPolicy(BasePolicy):
+    """
+    DQN over the 9-action discrete action set.
+
+    Online network:  Q(s, a; θ_online)
+    Target network:  Q(s, a; θ_target)  — synced every target_update_freq gradient steps
+    Replay buffer:   circular buffer of (s, a_idx, r, s', done)
+
+    Architecture: obs → Linear → ReLU → ... → Linear(9)
+    Pure numpy with Adam optimiser — no external ML framework required.
+    Epsilon decays linearly from epsilon_start → epsilon_end over epsilon_decay_steps steps.
+    """
+
+    def __init__(
+        self,
+        hidden_sizes: list[int] | None = None,
+        replay_buffer_size: int = 10000,
+        batch_size: int = 64,
+        min_replay_size: int = 500,
+        target_update_freq: int = 200,
+        learning_rate: float = 0.001,
+        epsilon_start: float = 1.0,
+        epsilon_end: float = 0.05,
+        epsilon_decay_steps: int = 5000,
+        gamma: float = 0.99,
+        n_lidar_rays: int = 0,
+    ) -> None:
+        from obs_spec import BASE_OBS_DIM
+        self._hidden       = list(hidden_sizes or [64, 64])
+        self._buf_maxlen   = int(replay_buffer_size)
+        self._batch_size   = int(batch_size)
+        self._min_replay   = int(min_replay_size)
+        self._target_freq  = int(target_update_freq)
+        self._lr           = float(learning_rate)
+        self._eps_start    = float(epsilon_start)
+        self._eps          = float(epsilon_start)
+        self._eps_end      = float(epsilon_end)
+        self._eps_steps    = int(epsilon_decay_steps)
+        self._eps_delta    = (float(epsilon_start) - float(epsilon_end)) / max(1, int(epsilon_decay_steps))
+        self._gamma        = float(gamma)
+        self._n_lidar_rays = n_lidar_rays
+        self._obs_dim      = BASE_OBS_DIM + n_lidar_rays
+        self._scales       = obs_scales_with_lidar(n_lidar_rays)
+
+        self._replay      = ReplayBuffer(replay_buffer_size)
+        self._total_steps = 0   # transitions pushed (drives epsilon schedule)
+        self._grad_steps  = 0   # gradient updates (drives target sync)
+
+        self._online = self._build_net()
+        self._target = self._build_net()
+        self._sync_target()
+
+        # Adam first/second moments — one entry per layer
+        self._m_w = [np.zeros_like(w) for w in self._online["weights"]]
+        self._m_b = [np.zeros_like(b) for b in self._online["biases"]]
+        self._v_w = [np.zeros_like(w) for w in self._online["weights"]]
+        self._v_b = [np.zeros_like(b) for b in self._online["biases"]]
+        self._adam_t = 0
+
+    @classmethod
+    def from_cfg(cls, cfg: dict, n_lidar_rays: int = 0) -> NeuralDQNPolicy:
+        obj = cls(
+            hidden_sizes        = cfg.get("hidden_sizes",        [64, 64]),
+            replay_buffer_size  = cfg.get("replay_buffer_size",  10000),
+            batch_size          = cfg.get("batch_size",          64),
+            min_replay_size     = cfg.get("min_replay_size",     500),
+            target_update_freq  = cfg.get("target_update_freq",  200),
+            learning_rate       = cfg.get("learning_rate",       0.001),
+            epsilon_start       = cfg.get("epsilon_start",       1.0),
+            epsilon_end         = cfg.get("epsilon_end",         0.05),
+            epsilon_decay_steps = cfg.get("epsilon_decay_steps", 5000),
+            gamma               = cfg.get("gamma",               0.99),
+            n_lidar_rays        = n_lidar_rays,
+        )
+        if "online_weights" in cfg:
+            obj._online["weights"] = [np.array(w, dtype=np.float32) for w in cfg["online_weights"]]
+            obj._online["biases"]  = [np.array(b, dtype=np.float32) for b in cfg["online_biases"]]
+            obj._target["weights"] = [np.array(w, dtype=np.float32) for w in cfg["target_weights"]]
+            obj._target["biases"]  = [np.array(b, dtype=np.float32) for b in cfg["target_biases"]]
+            obj._eps         = float(cfg.get("epsilon",      obj._eps_end))
+            obj._total_steps = int(cfg.get("total_steps",   0))
+            obj._grad_steps  = int(cfg.get("grad_steps",    0))
+            # Re-init Adam moments for the restored weights
+            obj._m_w = [np.zeros_like(w) for w in obj._online["weights"]]
+            obj._m_b = [np.zeros_like(b) for b in obj._online["biases"]]
+            obj._v_w = [np.zeros_like(w) for w in obj._online["weights"]]
+            obj._v_b = [np.zeros_like(b) for b in obj._online["biases"]]
+            logger.info("[NeuralDQNPolicy] loaded weights from cfg (eps=%.4f, steps=%d)",
+                        obj._eps, obj._total_steps)
+        return obj
+
+    # ------------------------------------------------------------------
+    # Network construction and sync
+    # ------------------------------------------------------------------
+
+    def _build_net(self) -> dict:
+        """He-initialised MLP: weights and biases as lists of float32 arrays."""
+        rng  = np.random.default_rng()
+        dims = [self._obs_dim] + self._hidden + [_N_DISCRETE_ACTIONS]
+        weights, biases = [], []
+        for i in range(len(dims) - 1):
+            fan_in = dims[i]
+            w = rng.standard_normal((dims[i + 1], fan_in)).astype(np.float32)
+            w *= np.sqrt(2.0 / fan_in)
+            b = np.zeros(dims[i + 1], dtype=np.float32)
+            weights.append(w)
+            biases.append(b)
+        return {"weights": weights, "biases": biases}
+
+    def _sync_target(self) -> None:
+        """Copy online network weights → target network (hard update)."""
+        self._target["weights"] = [w.copy() for w in self._online["weights"]]
+        self._target["biases"]  = [b.copy() for b in self._online["biases"]]
+
+    # ------------------------------------------------------------------
+    # Forward pass
+    # ------------------------------------------------------------------
+
+    def _forward(
+        self, net: dict, x: np.ndarray
+    ) -> tuple[np.ndarray, list[np.ndarray], list[np.ndarray]]:
+        """Forward pass through *net*.
+
+        x: (B, obs_dim) or (obs_dim,)
+        Returns:
+          q        — (B, n_actions) or (n_actions,) Q-values
+          inputs   — layer_inputs[i] is the (post-ReLU) input fed into layer i
+          pre_relu — pre_relu[i] is the linear output of hidden layer i (before ReLU)
+        """
+        single = x.ndim == 1
+        if single:
+            x = x[np.newaxis, :]
+
+        h: np.ndarray = x.astype(np.float32)
+        layer_inputs: list[np.ndarray] = []
+        pre_relu:     list[np.ndarray] = []
+
+        for i, (w, b) in enumerate(zip(net["weights"], net["biases"])):
+            layer_inputs.append(h)
+            z = h @ w.T + b
+            if i < len(net["weights"]) - 1:   # hidden layer
+                pre_relu.append(z)
+                h = np.maximum(0.0, z)
+            else:                              # output layer — linear
+                h = z
+
+        return (h[0] if single else h), layer_inputs, pre_relu
+
+    def _q_values(self, net: dict, obs_norm: np.ndarray) -> np.ndarray:
+        """Normalised obs → Q-value array (no bookkeeping)."""
+        q, _, _ = self._forward(net, obs_norm)
+        return q
+
+    # ------------------------------------------------------------------
+    # Gradient update
+    # ------------------------------------------------------------------
+
+    def _gradient_step(
+        self,
+        obs_b: np.ndarray, act_b: np.ndarray,
+        rew_b: np.ndarray, next_b: np.ndarray, done_b: np.ndarray,
+    ) -> None:
+        """One Adam step on the online network using a sampled minibatch."""
+        obs_norm  = obs_b  / self._scales
+        next_norm = next_b / self._scales
+        B = len(act_b)
+
+        # DQN targets: y = r + γ * max_a Q_target(s') * (1 - done)
+        q_next   = self._q_values(self._target, next_norm)        # (B, 9)
+        targets  = rew_b + self._gamma * np.max(q_next, axis=1) * (1.0 - done_b)  # (B,)
+
+        # Online forward (save intermediate values for backprop)
+        q_all, layer_inputs, pre_relu = self._forward(self._online, obs_norm)  # (B, 9)
+
+        # Loss gradient: 2*(Q(s,a) - y) / B, only for the taken action
+        grad_out = np.zeros_like(q_all)                           # (B, 9)
+        grad_out[np.arange(B), act_b] = (
+            2.0 * (q_all[np.arange(B), act_b] - targets) / B
+        )
+
+        # Backprop through layers (reverse order)
+        g = grad_out
+        grad_params: list[tuple[np.ndarray, np.ndarray]] = []
+        for i in range(len(self._online["weights"]) - 1, -1, -1):
+            a_in = layer_inputs[i]                 # (B, in_dim) — post-ReLU input
+            dW   = g.T @ a_in / B                  # (out_dim, in_dim)
+            db   = g.mean(axis=0)                  # (out_dim,)
+            grad_params.append((dW, db))
+            if i > 0:
+                # Propagate gradient through weights and apply ReLU mask
+                g = (g @ self._online["weights"][i]) * (pre_relu[i - 1] > 0)
+        grad_params.reverse()
+
+        # Adam update
+        self._adam_t += 1
+        t          = self._adam_t
+        b1, b2     = 0.9, 0.999
+        eps_adam   = 1e-8
+
+        for i, (dW, db) in enumerate(grad_params):
+            self._m_w[i] = b1 * self._m_w[i] + (1.0 - b1) * dW
+            self._v_w[i] = b2 * self._v_w[i] + (1.0 - b2) * dW ** 2
+            mw_hat = self._m_w[i] / (1.0 - b1 ** t)
+            vw_hat = self._v_w[i] / (1.0 - b2 ** t)
+            self._online["weights"][i] -= self._lr * mw_hat / (np.sqrt(vw_hat) + eps_adam)
+
+            self._m_b[i] = b1 * self._m_b[i] + (1.0 - b1) * db
+            self._v_b[i] = b2 * self._v_b[i] + (1.0 - b2) * db ** 2
+            mb_hat = self._m_b[i] / (1.0 - b1 ** t)
+            vb_hat = self._v_b[i] / (1.0 - b2 ** t)
+            self._online["biases"][i] -= self._lr * mb_hat / (np.sqrt(vb_hat) + eps_adam)
+
+        self._grad_steps += 1
+        if self._grad_steps % self._target_freq == 0:
+            self._sync_target()
+            logger.debug("[NeuralDQNPolicy] target network synced at grad_step %d", self._grad_steps)
+
+    # ------------------------------------------------------------------
+    # BasePolicy interface
+    # ------------------------------------------------------------------
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        if np.random.random() < self._eps:
+            return _DISCRETE_ACTIONS[np.random.randint(_N_DISCRETE_ACTIONS)].copy()
+        obs_norm = (obs / self._scales).astype(np.float32)
+        q        = self._q_values(self._online, obs_norm)
+        return _DISCRETE_ACTIONS[int(np.argmax(q))].copy()
+
+    def update(self, obs: np.ndarray, action: np.ndarray | int, reward: float,
+               next_obs: np.ndarray, done: bool) -> None:
+        action_idx = int(action) if np.isscalar(action) else _action_to_idx(action)
+        self._replay.push(obs, action_idx, reward, next_obs, done)
+        self._total_steps += 1
+        # Linear epsilon decay per step
+        self._eps = max(self._eps_end, self._eps - self._eps_delta)
+
+        if len(self._replay) >= self._min_replay:
+            obs_b, act_b, rew_b, next_b, done_b = self._replay.sample(self._batch_size)
+            self._gradient_step(obs_b, act_b, rew_b, next_b, done_b)
+
+    def on_episode_end(self) -> None:
+        pass   # Epsilon decays per step, not per episode
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type":        "neural_dqn",
+            "hidden_sizes":       self._hidden,
+            "replay_buffer_size": self._buf_maxlen,
+            "batch_size":         self._batch_size,
+            "min_replay_size":    self._min_replay,
+            "target_update_freq": self._target_freq,
+            "learning_rate":      float(self._lr),
+            "epsilon_start":      float(self._eps_start),
+            "epsilon_end":        float(self._eps_end),
+            "epsilon_decay_steps": self._eps_steps,
+            "gamma":              float(self._gamma),
+            "n_lidar_rays":       self._n_lidar_rays,
+            "epsilon":            float(self._eps),
+            "total_steps":        self._total_steps,
+            "grad_steps":         self._grad_steps,
+            "online_weights":     [w.tolist() for w in self._online["weights"]],
+            "online_biases":      [b.tolist() for b in self._online["biases"]],
+            "target_weights":     [w.tolist() for w in self._target["weights"]],
+            "target_biases":      [b.tolist() for b in self._target["biases"]],
+        }

--- a/policies.py
+++ b/policies.py
@@ -825,7 +825,8 @@ class ReplayBuffer:
         self._buf.append((obs.copy(), int(action_idx), float(reward), next_obs.copy(), bool(done)))
 
     def sample(self, batch_size: int) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        idxs  = np.random.choice(len(self._buf), size=batch_size, replace=False)
+        replace = batch_size > len(self._buf)
+        idxs  = np.random.choice(len(self._buf), size=batch_size, replace=replace)
         batch = [self._buf[i] for i in idxs]
         obs_b  = np.stack([t[0] for t in batch]).astype(np.float32)
         act_b  = np.array([t[1] for t in batch], dtype=np.int32)
@@ -917,7 +918,21 @@ class NeuralDQNPolicy(BasePolicy):
             n_lidar_rays        = n_lidar_rays,
         )
         if "online_weights" in cfg:
-            obj._online["weights"] = [np.array(w, dtype=np.float32) for w in cfg["online_weights"]]
+            required = ["online_weights", "online_biases", "target_weights", "target_biases"]
+            missing  = [k for k in required if k not in cfg]
+            if missing:
+                raise KeyError(f"NeuralDQNPolicy.from_cfg: missing keys {missing}")
+
+            loaded_w = [np.array(w, dtype=np.float32) for w in cfg["online_weights"]]
+            # Validate that the first layer's input dim matches obs_dim
+            if loaded_w[0].shape[1] != obj._obs_dim:
+                raise ValueError(
+                    f"NeuralDQNPolicy.from_cfg: weight shape mismatch — "
+                    f"first layer expects input dim {loaded_w[0].shape[1]} "
+                    f"but obs_dim is {obj._obs_dim} (n_lidar_rays={n_lidar_rays})"
+                )
+
+            obj._online["weights"] = loaded_w
             obj._online["biases"]  = [np.array(b, dtype=np.float32) for b in cfg["online_biases"]]
             obj._target["weights"] = [np.array(w, dtype=np.float32) for w in cfg["target_weights"]]
             obj._target["biases"]  = [np.array(b, dtype=np.float32) for b in cfg["target_biases"]]

--- a/policies.py
+++ b/policies.py
@@ -1027,8 +1027,8 @@ class NeuralDQNPolicy(BasePolicy):
         grad_params: list[tuple[np.ndarray, np.ndarray]] = []
         for i in range(len(self._online["weights"]) - 1, -1, -1):
             a_in = layer_inputs[i]                 # (B, in_dim) — post-ReLU input
-            dW   = g.T @ a_in / B                  # (out_dim, in_dim)
-            db   = g.mean(axis=0)                  # (out_dim,)
+            dW   = g.T @ a_in                      # (out_dim, in_dim)
+            db   = g.sum(axis=0)                   # (out_dim,)
             grad_params.append((dW, db))
             if i > 0:
                 # Propagate gradient through weights and apply ReLU mask

--- a/tests/test_neural_dqn_policy.py
+++ b/tests/test_neural_dqn_policy.py
@@ -1,0 +1,220 @@
+"""Tests for NeuralDQNPolicy and ReplayBuffer in policies.py."""
+import unittest
+
+import numpy as np
+
+from obs_spec import BASE_OBS_DIM
+from policies import (
+    NeuralDQNPolicy,
+    ReplayBuffer,
+    _DISCRETE_ACTIONS,
+    _action_to_idx,
+)
+
+_N = BASE_OBS_DIM
+
+
+def _zero_obs() -> np.ndarray:
+    return np.zeros(_N, dtype=np.float32)
+
+
+def _rand_obs() -> np.ndarray:
+    return np.random.randn(_N).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# ReplayBuffer tests
+# ---------------------------------------------------------------------------
+
+class TestReplayBuffer(unittest.TestCase):
+
+    def test_push_and_len(self):
+        buf = ReplayBuffer(maxlen=10)
+        self.assertEqual(len(buf), 0)
+        buf.push(_zero_obs(), 0, 1.0, _zero_obs(), False)
+        self.assertEqual(len(buf), 1)
+
+    def test_circular_eviction(self):
+        buf = ReplayBuffer(maxlen=3)
+        for i in range(5):
+            buf.push(_zero_obs(), i % 9, float(i), _zero_obs(), False)
+        self.assertEqual(len(buf), 3)
+
+    def test_sample_shapes(self):
+        buf = ReplayBuffer(maxlen=20)
+        for _ in range(10):
+            buf.push(_rand_obs(), 0, 0.0, _rand_obs(), False)
+        obs_b, act_b, rew_b, next_b, done_b = buf.sample(5)
+        self.assertEqual(obs_b.shape,  (5, _N))
+        self.assertEqual(act_b.shape,  (5,))
+        self.assertEqual(rew_b.shape,  (5,))
+        self.assertEqual(next_b.shape, (5, _N))
+        self.assertEqual(done_b.shape, (5,))
+        self.assertEqual(obs_b.dtype,  np.float32)
+
+    def test_sample_without_replacement(self):
+        """sample() should never return duplicate entries when buf is large enough."""
+        buf = ReplayBuffer(maxlen=100)
+        for i in range(20):
+            buf.push(_rand_obs(), i % 9, float(i), _rand_obs(), False)
+        _, act_b, rew_b, _, _ = buf.sample(10)
+        # rewards encode unique step indices — duplicates would repeat a reward
+        self.assertEqual(len(set(rew_b.tolist())), 10)
+
+
+# ---------------------------------------------------------------------------
+# NeuralDQNPolicy structural tests
+# ---------------------------------------------------------------------------
+
+class TestNeuralDQNPolicyStructure(unittest.TestCase):
+
+    def _make(self, **kw) -> NeuralDQNPolicy:
+        defaults = dict(
+            hidden_sizes=[8, 8],
+            replay_buffer_size=200,
+            batch_size=16,
+            min_replay_size=32,
+            target_update_freq=10,
+            learning_rate=0.01,
+            epsilon_start=1.0,
+            epsilon_end=0.05,
+            epsilon_decay_steps=100,
+            gamma=0.99,
+            n_lidar_rays=0,
+        )
+        defaults.update(kw)
+        return NeuralDQNPolicy(**defaults)
+
+    def test_action_shape_and_range(self):
+        p   = self._make(epsilon_start=0.0)
+        act = p(_zero_obs())
+        self.assertEqual(act.shape, (3,))
+        self.assertGreaterEqual(float(act[0]), -1.0)
+        self.assertLessEqual(float(act[0]), 1.0)
+        self.assertIn(float(act[1]), {0.0, 1.0})
+        self.assertIn(float(act[2]), {0.0, 1.0})
+
+    def test_greedy_action_is_discrete(self):
+        """Greedy action must be one of the 9 discrete actions."""
+        p   = self._make(epsilon_start=0.0)
+        act = p(_zero_obs())
+        idx = _action_to_idx(act)
+        self.assertIn(idx, range(9))
+
+    def test_random_action_when_epsilon_one(self):
+        """With epsilon=1, every call should still return a valid action."""
+        p = self._make(epsilon_start=1.0, epsilon_end=1.0)
+        for _ in range(20):
+            act = p(_zero_obs())
+            self.assertIn(_action_to_idx(act), range(9))
+
+    def test_replay_buffer_fills_on_update(self):
+        p = self._make()
+        for _ in range(10):
+            p.update(_zero_obs(), 0, 1.0, _zero_obs(), True)
+        self.assertEqual(len(p._replay), 10)
+
+    def test_epsilon_decays_on_update(self):
+        p = self._make(epsilon_start=1.0, epsilon_end=0.0, epsilon_decay_steps=10)
+        for _ in range(10):
+            p.update(_zero_obs(), 0, 0.0, _zero_obs(), True)
+        self.assertLess(p._eps, 1.0)
+
+    def test_epsilon_floored_at_epsilon_end(self):
+        p = self._make(epsilon_start=1.0, epsilon_end=0.1, epsilon_decay_steps=1)
+        for _ in range(50):
+            p.update(_zero_obs(), 0, 0.0, _zero_obs(), True)
+        self.assertGreaterEqual(p._eps, 0.1)
+
+    def test_target_sync_happens(self):
+        """Target network weights should match online after a sync."""
+        p = self._make(target_update_freq=5, min_replay_size=16)
+        # Fill buffer and trigger enough gradient steps to force a sync
+        for _ in range(50):
+            p.update(_rand_obs(), np.random.randint(9), 0.0, _rand_obs(), False)
+        # After sync, target matches online
+        for w_on, w_tgt in zip(p._online["weights"], p._target["weights"]):
+            np.testing.assert_array_equal(w_on, w_tgt)
+
+    def test_network_weight_shapes(self):
+        p = self._make(hidden_sizes=[32, 16])
+        # Layer dims: [obs_dim, 32, 16, 9]
+        self.assertEqual(p._online["weights"][0].shape, (32, _N))
+        self.assertEqual(p._online["weights"][1].shape, (16, 32))
+        self.assertEqual(p._online["weights"][2].shape, (9,  16))
+
+    def test_to_cfg_roundtrip(self):
+        p   = self._make(epsilon_start=0.0)
+        cfg = p.to_cfg()
+        p2  = NeuralDQNPolicy.from_cfg(cfg)
+        obs = _rand_obs()
+        # Greedy actions should match after round-trip
+        p._eps  = 0.0
+        p2._eps = 0.0
+        np.testing.assert_array_equal(p(obs), p2(obs))
+
+    def test_cfg_policy_type_key(self):
+        p = self._make()
+        self.assertEqual(p.to_cfg()["policy_type"], "neural_dqn")
+
+    def test_on_episode_end_no_crash(self):
+        p = self._make()
+        p.on_episode_end()   # should not raise
+
+
+# ---------------------------------------------------------------------------
+# NeuralDQNPolicy convergence test (2-state bandit MDP)
+# ---------------------------------------------------------------------------
+
+class TestNeuralDQNConvergence(unittest.TestCase):
+    """
+    Single-observation bandit: one action consistently gives +1 reward,
+    all others give -0.1.  With gamma=0 the optimal Q-values reduce to
+    expected reward per action.  After sufficient training the greedy
+    policy must select the rewarding action.
+    """
+
+    def test_bandit_convergence(self):
+        N = BASE_OBS_DIM
+        state   = np.zeros(N, dtype=np.float32)
+        BEST    = 7          # accel + straight
+        GOOD_R  =  1.0
+        BAD_R   = -0.1
+
+        policy = NeuralDQNPolicy(
+            hidden_sizes        = [32, 32],
+            replay_buffer_size  = 5000,
+            batch_size          = 32,
+            min_replay_size     = 128,
+            target_update_freq  = 25,
+            learning_rate       = 0.005,
+            epsilon_start       = 1.0,
+            epsilon_end         = 1.0,   # keep at 1; we push transitions directly
+            epsilon_decay_steps = 1,
+            gamma               = 0.0,   # pure bandit — no bootstrapping
+            n_lidar_rays        = 0,
+        )
+
+        next_obs = np.zeros(N, dtype=np.float32)
+        # Cycle through all 9 actions so each is equally represented
+        for step in range(4500):
+            action_idx = step % 9
+            r = GOOD_R if action_idx == BEST else BAD_R
+            policy.update(state, action_idx, r, next_obs, done=True)
+
+        # Evaluate greedy
+        policy._eps = 0.0
+        obs_norm    = (state / policy._scales).astype(np.float32)
+        q_vals      = policy._q_values(policy._online, obs_norm)
+        greedy_idx  = int(np.argmax(q_vals))
+
+        self.assertEqual(
+            greedy_idx, BEST,
+            f"Expected greedy action {BEST}, got {greedy_idx}. Q-values: {q_vals.tolist()}"
+        )
+        # The best action should also have a clearly higher Q-value
+        self.assertGreater(float(q_vals[BEST]), float(np.max(np.delete(q_vals, BEST))))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_neural_dqn_policy.py
+++ b/tests/test_neural_dqn_policy.py
@@ -61,6 +61,15 @@ class TestReplayBuffer(unittest.TestCase):
         # rewards encode unique step indices — duplicates would repeat a reward
         self.assertEqual(len(set(rew_b.tolist())), 10)
 
+    def test_sample_with_replacement_when_small(self):
+        """sample() falls back to replace=True when batch_size > buffer length."""
+        buf = ReplayBuffer(maxlen=100)
+        for i in range(3):
+            buf.push(_rand_obs(), i % 9, float(i), _rand_obs(), False)
+        # Requesting more samples than buffer size should not raise
+        obs_b, act_b, rew_b, next_b, done_b = buf.sample(10)
+        self.assertEqual(obs_b.shape[0], 10)
+
 
 # ---------------------------------------------------------------------------
 # NeuralDQNPolicy structural tests
@@ -161,6 +170,20 @@ class TestNeuralDQNPolicyStructure(unittest.TestCase):
         p = self._make()
         p.on_episode_end()   # should not raise
 
+    def test_from_cfg_missing_keys_raises(self):
+        """from_cfg() should raise KeyError if weight keys are incomplete."""
+        cfg = {"online_weights": [[[1.0]]]}  # missing other required keys
+        with self.assertRaises(KeyError):
+            NeuralDQNPolicy.from_cfg(cfg)
+
+    def test_from_cfg_shape_mismatch_raises(self):
+        """from_cfg() should raise ValueError when obs_dim doesn't match weights."""
+        p   = self._make()
+        cfg = p.to_cfg()
+        # Pass a different n_lidar_rays to cause shape mismatch
+        with self.assertRaises(ValueError):
+            NeuralDQNPolicy.from_cfg(cfg, n_lidar_rays=5)
+
 
 # ---------------------------------------------------------------------------
 # NeuralDQNPolicy convergence test (2-state bandit MDP)
@@ -175,6 +198,7 @@ class TestNeuralDQNConvergence(unittest.TestCase):
     """
 
     def test_bandit_convergence(self):
+        np.random.seed(42)
         N = BASE_OBS_DIM
         state   = np.zeros(N, dtype=np.float32)
         BEST    = 7          # accel + straight


### PR DESCRIPTION
Implements DQN over the 9-action discrete action set in pure numpy:
- ReplayBuffer: circular buffer (collections.deque) of (s, a, r, s', done)
- NeuralDQNPolicy: MLP Q-function with online + frozen target network,
  Adam optimiser, linear epsilon schedule, and YAML serialisation
- main.py: registers "neural_dqn" in _make_policy() with full cfg passthrough
- config/training_params.yaml: documents all neural_dqn hyperparameters
- tests/test_neural_dqn_policy.py: 16 unit tests including bandit convergence

https://claude.ai/code/session_01Newa1Qvg4P732JmhtqzQqj