### PR TITLE
Replace discrete throttle plots with continuous two-line graphs

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -467,22 +467,20 @@ def plot_weight_evolution(data: ExperimentData, results_dir: str) -> None:
 # ---------------------------------------------------------------------------
 
 def _plot_throttle_trace(ax: Axes, throttle_state: list, title: str) -> None:
-    """Draw accel and brake as continuous line traces on *ax*.
+    """Draw accel (green) and brake (red) as continuous line traces on *ax*.
 
     throttle_state entries are (accel_val, brake_val) float tuples in [0, 1].
-    accel is plotted above zero; brake is mirrored below zero so both lines
-    share an axis with a clear visual separation.
+    Both lines share a [0, 1] y-axis.
     """
     steps = range(len(throttle_state))
     accel = [t[0] for t in throttle_state]
     brake = [t[1] for t in throttle_state]
-    ax.plot(steps, accel, color=_THROTTLE_COLORS[2], linewidth=0.8, alpha=0.85, label="accel")
-    ax.plot(steps, [-b for b in brake], color=_THROTTLE_COLORS[0], linewidth=0.8, alpha=0.85, label="brake")
-    ax.axhline(0, color="#aaa", linewidth=0.5, linestyle="--")
-    ax.set_ylim(-1.15, 1.15)
-    ax.set_yticks([-1, 0, 1])
-    ax.set_yticklabels(["brake 1.0", "0", "accel 1.0"], fontsize=8)
+    ax.plot(steps, accel, color="#27ae60", linewidth=0.8, alpha=0.85, label="accel")
+    ax.plot(steps, brake, color="#c0392b", linewidth=0.8, alpha=0.85, label="brake")
+    ax.set_ylim(-0.05, 1.1)
+    ax.set_yticks([0, 0.5, 1])
     ax.set_xlabel("Step")
+    ax.set_ylabel("Value")
     ax.set_title(title, fontsize=9)
     ax.legend(fontsize=8, loc="upper right")
 

--- a/analytics.py
+++ b/analytics.py
@@ -35,7 +35,7 @@ class RunTrace:
     """Sampled position + per-step throttle state for one episode."""
     pos_x: list          # world X, sampled every TRACE_SAMPLE_EVERY steps
     pos_z: list          # world Z (horizontal plane in TMNF; Y is up)
-    throttle_state: list # per step: 0=brake, 1=coast, 2=accel
+    throttle_state: list # per step: (accel_val, brake_val) floats in [0, 1]
     total_reward: float
 
 
@@ -208,31 +208,31 @@ def plot_cold_start_rewards(data: ExperimentData, results_dir: str) -> None:
 
 
 def plot_cold_start_action_dist(data: ExperimentData, results_dir: str) -> None:
-    """Stacked bar: mean throttle distribution (brake/coast/accel) per restart."""
+    """Line graph: accel% and brake% per restart (thresholded at 0.5)."""
 
     restarts = data.cold_start_restarts
     xs = [r.restart for r in restarts]
 
-    pcts = []  # shape (n_restarts, 3)  — percent for brake/coast/accel
+    accel_pcts = []
+    brake_pcts = []
     for r in restarts:
         total_b = total_c = total_a = 0
         for s in r.sims:
             b, c, a = s.throttle_counts
             total_b += b; total_c += c; total_a += a
         total = total_b + total_c + total_a or 1
-        pcts.append([100 * total_b / total, 100 * total_c / total, 100 * total_a / total])
-    pcts = np.array(pcts)
+        accel_pcts.append(100 * total_a / total)
+        brake_pcts.append(100 * total_b / total)
 
     fig, ax = plt.subplots(figsize=(max(6, len(xs) * 0.8), 5))
-    bottoms = np.zeros(len(xs))
-    for i, (label, color) in enumerate(zip(_THROTTLE_LABELS, _THROTTLE_COLORS)):
-        ax.bar(xs, pcts[:, i], bottom=bottoms, color=color, label=label,
-               edgecolor="white", linewidth=0.4)
-        bottoms += pcts[:, i]
+    ax.plot(xs, accel_pcts, color=_THROTTLE_COLORS[2], linewidth=1.8,
+            marker="o", markersize=4, label="accel %")
+    ax.plot(xs, brake_pcts, color=_THROTTLE_COLORS[0], linewidth=1.8,
+            marker="o", markersize=4, label="brake %")
 
-    ax.set_title(f"{data.experiment_name} — Cold-Start: Throttle Distribution per Restart")
+    ax.set_title(f"{data.experiment_name} — Cold-Start: Accel / Brake % per Restart")
     ax.set_xlabel("Restart")
-    ax.set_ylabel("% Steps")
+    ax.set_ylabel("% Steps (threshold ≥ 0.5)")
     ax.set_xticks(xs)
     ax.set_ylim(0, 100)
     ax.legend(fontsize=9)
@@ -294,27 +294,27 @@ def plot_greedy_rewards(data: ExperimentData, results_dir: str) -> None:
 # ---------------------------------------------------------------------------
 
 def plot_greedy_action_dist(data: ExperimentData, results_dir: str) -> None:
-    """100% stacked bar: throttle mix per greedy sim — shows if policy shifts toward accel."""
+    """Line graph: accel% and brake% per greedy sim — shows if policy shifts toward accel."""
 
     sims = data.greedy_sims
     xs   = [s.sim for s in sims]
-    pcts = []
+    accel_pcts = []
+    brake_pcts = []
     for s in sims:
         b, c, a = s.throttle_counts
         total = (b + c + a) or 1
-        pcts.append([100 * b / total, 100 * c / total, 100 * a / total])
-    pcts = np.array(pcts)
+        accel_pcts.append(100 * a / total)
+        brake_pcts.append(100 * b / total)
 
     fig, ax = plt.subplots(figsize=(max(8, len(xs) * 0.15), 5))
-    bottoms = np.zeros(len(xs))
-    for i, (label, color) in enumerate(zip(_THROTTLE_LABELS, _THROTTLE_COLORS)):
-        ax.bar(xs, pcts[:, i], bottom=bottoms, color=color, label=label,
-               width=1.0, edgecolor="none")
-        bottoms += pcts[:, i]
+    ax.plot(xs, accel_pcts, color=_THROTTLE_COLORS[2], linewidth=1.2,
+            alpha=0.85, label="accel %")
+    ax.plot(xs, brake_pcts, color=_THROTTLE_COLORS[0], linewidth=1.2,
+            alpha=0.85, label="brake %")
 
-    ax.set_title(f"{data.experiment_name} — Greedy Phase: Throttle Mix per Sim")
+    ax.set_title(f"{data.experiment_name} — Greedy Phase: Accel / Brake % per Sim")
     ax.set_xlabel("Simulation")
-    ax.set_ylabel("% Steps")
+    ax.set_ylabel("% Steps (threshold ≥ 0.5)")
     ax.set_ylim(0, 100)
     ax.legend(fontsize=9)
     fig.tight_layout()
@@ -466,17 +466,22 @@ def plot_weight_evolution(data: ExperimentData, results_dir: str) -> None:
 # Entry point
 # ---------------------------------------------------------------------------
 
-def _plot_throttle_trace(ax: Axes, throttle_state: list[int], title: str) -> None:
-    """Draw a throttle/brake trace as two binary step lines on *ax*."""
+def _plot_throttle_trace(ax: Axes, throttle_state: list, title: str) -> None:
+    """Draw accel and brake as continuous line traces on *ax*.
+
+    throttle_state entries are (accel_val, brake_val) float tuples in [0, 1].
+    accel is plotted above zero; brake is mirrored below zero so both lines
+    share an axis with a clear visual separation.
+    """
     steps = range(len(throttle_state))
-    accel = [1 if t == 2 else 0 for t in throttle_state]
-    brake = [1 if t == 0 else 0 for t in throttle_state]
-    ax.step(steps, accel, where="post", color=_THROTTLE_COLORS[2], linewidth=1.0, label="accel")
-    ax.step(steps, [-b for b in brake], where="post", color=_THROTTLE_COLORS[0], linewidth=1.0, label="brake")
+    accel = [t[0] for t in throttle_state]
+    brake = [t[1] for t in throttle_state]
+    ax.plot(steps, accel, color=_THROTTLE_COLORS[2], linewidth=0.8, alpha=0.85, label="accel")
+    ax.plot(steps, [-b for b in brake], color=_THROTTLE_COLORS[0], linewidth=0.8, alpha=0.85, label="brake")
     ax.axhline(0, color="#aaa", linewidth=0.5, linestyle="--")
-    ax.set_ylim(-1.3, 1.3)
+    ax.set_ylim(-1.15, 1.15)
     ax.set_yticks([-1, 0, 1])
-    ax.set_yticklabels(["brake", "", "accel"], fontsize=8)
+    ax.set_yticklabels(["brake 1.0", "0", "accel 1.0"], fontsize=8)
     ax.set_xlabel("Step")
     ax.set_title(title, fontsize=9)
     ax.legend(fontsize=8, loc="upper right")

--- a/main.py
+++ b/main.py
@@ -202,7 +202,7 @@ def _run_episode(
     turning_steps = 0
     pos_x: list[float] = []
     pos_z: list[float] = []
-    throttle_state: list[int] = []
+    throttle_state: list[tuple[float, float]] = []
     prev_obs = obs
 
     while True:
@@ -227,7 +227,7 @@ def _run_episode(
         else:
             t = 1   # coast
         throttle_counts[t] += 1
-        throttle_state.append(t)
+        throttle_state.append((float(action[1]), float(action[2])))
         if abs(float(action[0])) > 0.05:
             turning_steps += 1
 


### PR DESCRIPTION
- Store (accel_val, brake_val) float tuples in RunTrace.throttle_state
  instead of discrete 0/1/2 integers, reflecting that actions are now
  continuous rather than categorical.
- _plot_throttle_trace: switch from binary step lines to continuous line
  plots of the raw accel/brake values; brake mirrored below zero.
- plot_cold_start_action_dist / plot_greedy_action_dist: replace 100%
  stacked bar charts (brake/coast/accel) with two-line graphs showing
  accel% and brake% across restarts/sims. Coast is implicitly the gap.

https://claude.ai/code/session_017sSiQAAKUaTsNwhRv1v4RS