### PR TITLE
fix(plan): correct target files for Q-table persistence (issue #12)

### DIFF
--- a/framework/policies.py
+++ b/framework/policies.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+import pickle
 from abc import ABC, abstractmethod
 
 import numpy as np
@@ -25,6 +26,14 @@ import yaml
 from framework.obs_spec import ObsSpec
 
 logger = logging.getLogger(__name__)
+
+
+_MAX_QTABLE_ENTRIES = 500_000
+
+
+def _qtable_pkl_path(yaml_path: str) -> str:
+    base, _ = os.path.splitext(yaml_path)
+    return base + "_qtable.pkl"
 
 
 # ---------------------------------------------------------------------------
@@ -404,6 +413,29 @@ class QTablePolicy(BasePolicy):
     @property
     def n_states_visited(self) -> int:
         return len(self._q_table)
+
+    def save(self, path: str) -> None:
+        super().save(path)
+        if len(self._q_table) > _MAX_QTABLE_ENTRIES:
+            logger.warning(
+                "Q-table has %d entries (>%d), skipping pickle.",
+                len(self._q_table), _MAX_QTABLE_ENTRIES,
+            )
+            return
+        pkl_path = _qtable_pkl_path(path)
+        with open(pkl_path, "wb") as f:
+            pickle.dump((self._q_table, self._n_sa, self._n_s), f)
+        logger.info("Q-table saved: %d states → %s", len(self._q_table), pkl_path)
+
+    def _load_table(self, path: str) -> None:
+        pkl_path = _qtable_pkl_path(path)
+        if os.path.exists(pkl_path):
+            with open(pkl_path, "rb") as f:
+                q_table, n_sa, n_s = pickle.load(f)
+            self._q_table = q_table
+            self._n_sa    = n_sa
+            self._n_s     = n_s
+            logger.info("Q-table loaded: %d states from %s", len(q_table), pkl_path)
 
 
 # ---------------------------------------------------------------------------

--- a/framework/training.py
+++ b/framework/training.py
@@ -102,19 +102,27 @@ def _make_policy(
                                hidden_sizes=hidden)
 
     elif policy_type == "epsilon_greedy":
-        return EpsilonGreedyPolicy(
+        epsilon = policy_params.get("epsilon", 1.0)
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as f:
+                saved_cfg = yaml.safe_load(f) or {}
+            epsilon = float(saved_cfg.get("epsilon", epsilon))
+        policy = EpsilonGreedyPolicy(
             obs_spec=obs_spec,
             discrete_actions=discrete_actions,
             n_bins=policy_params.get("n_bins", 3),
-            epsilon=policy_params.get("epsilon", 1.0),
+            epsilon=epsilon,
             epsilon_decay=policy_params.get("epsilon_decay", 0.995),
             epsilon_min=policy_params.get("epsilon_min", 0.05),
             alpha=policy_params.get("alpha", 0.1),
             gamma=policy_params.get("gamma", 0.99),
         )
+        if os.path.exists(weights_file) and not re_initialize:
+            policy._load_table(weights_file)
+        return policy
 
     elif policy_type == "mcts":
-        return MCTSPolicy(
+        policy = MCTSPolicy(
             obs_spec=obs_spec,
             discrete_actions=discrete_actions,
             c=policy_params.get("c", 1.41),
@@ -122,6 +130,9 @@ def _make_policy(
             gamma=policy_params.get("gamma", 0.99),
             n_bins=policy_params.get("n_bins", 3),
         )
+        if os.path.exists(weights_file) and not re_initialize:
+            policy._load_table(weights_file)
+        return policy
 
     elif policy_type == "genetic":
         pop_size = policy_params.get("population_size", 10)

--- a/plans/12-q-table-persistence.md
+++ b/plans/12-q-table-persistence.md
@@ -20,52 +20,95 @@ Pickle the three table dicts alongside the YAML config:
 
 On load, if the pickle exists, restore the tables automatically.
 
-## Changes to `policies.py`
+## Changes
 
-### `QTablePolicy` — add `save()` override and `_load_table()` classmethod
+> **Important:** `policies.py` is a TMNF backward-compatibility shim. The training
+> framework imports `EpsilonGreedyPolicy` / `MCTSPolicy` directly from
+> `framework/policies.py`, so all logic changes go there and in
+> `framework/training.py`. The `from_cfg()` methods in the shim are currently
+> unused by the training loop.
+
+### `framework/policies.py` — `QTablePolicy`: add `save()` + `_load_table()`
 
 ```python
+import pickle  # add at top of file
+
 MAX_QTABLE_ENTRIES = 500_000  # guard against saving enormous tables
 
-def save(self, path: Path) -> None:
+# Inside QTablePolicy:
+
+def save(self, path: str) -> None:
     """Save hyperparams to YAML and Q-table to sibling .pkl file."""
     super().save(path)  # writes YAML via to_cfg()
     if len(self._q_table) > MAX_QTABLE_ENTRIES:
-        print(f"WARNING: Q-table has {len(self._q_table)} entries (>{MAX_QTABLE_ENTRIES}), skipping pickle.")
+        logger.warning(
+            "Q-table has %d entries (>%d), skipping pickle.",
+            len(self._q_table), MAX_QTABLE_ENTRIES,
+        )
         return
-    pkl_path = path.with_name(path.stem + "_qtable.pkl")
+    pkl_path = _qtable_pkl_path(path)
     with open(pkl_path, "wb") as f:
         pickle.dump((self._q_table, self._n_sa, self._n_s), f)
-    print(f"Q-table saved: {len(self._q_table)} states → {pkl_path}")
+    logger.info("Q-table saved: %d states → %s", len(self._q_table), pkl_path)
 
-@classmethod
-def _load_table(cls, self_instance, path: Path) -> None:
+def _load_table(self, path: str) -> None:
     """Restore Q-table from sibling .pkl if it exists."""
-    pkl_path = path.with_name(path.stem + "_qtable.pkl")
-    if pkl_path.exists():
+    pkl_path = _qtable_pkl_path(path)
+    if os.path.exists(pkl_path):
         with open(pkl_path, "rb") as f:
             q_table, n_sa, n_s = pickle.load(f)
-        self_instance._q_table = q_table
-        self_instance._n_sa = n_sa
-        self_instance._n_s = n_s
-        print(f"Q-table loaded: {len(q_table)} states from {pkl_path}")
+        self._q_table = q_table
+        self._n_sa    = n_sa
+        self._n_s     = n_s
+        logger.info("Q-table loaded: %d states from %s", len(q_table), pkl_path)
 ```
 
-Add `import pickle` at the top of `policies.py`.
-
-### `EpsilonGreedyPolicy.from_cfg()` (lines 507–517)
-After the existing construction, call `_load_table()`:
+Add a small helper near the top of the file:
 ```python
-@classmethod
-def from_cfg(cls, cfg: dict, weights_file: Path | None = None) -> "EpsilonGreedyPolicy":
-    policy = cls(...)  # existing construction
-    if weights_file is not None:
-        cls._load_table(policy, weights_file)
+def _qtable_pkl_path(yaml_path: str) -> str:
+    base, _ = os.path.splitext(yaml_path)
+    return base + "_qtable.pkl"
+```
+
+### `framework/training.py` — `_make_policy()`: restore table on restart
+
+After constructing the `epsilon_greedy` and `mcts` policies, add a load call:
+
+```python
+elif policy_type == "epsilon_greedy":
+    policy = EpsilonGreedyPolicy(
+        obs_spec=obs_spec,
+        discrete_actions=discrete_actions,
+        n_bins=policy_params.get("n_bins", 3),
+        epsilon=policy_params.get("epsilon", 1.0),
+        epsilon_decay=policy_params.get("epsilon_decay", 0.995),
+        epsilon_min=policy_params.get("epsilon_min", 0.05),
+        alpha=policy_params.get("alpha", 0.1),
+        gamma=policy_params.get("gamma", 0.99),
+    )
+    if os.path.exists(weights_file) and not re_initialize:
+        with open(weights_file) as f:
+            saved_cfg = yaml.safe_load(f) or {}
+        policy._epsilon = float(saved_cfg.get("epsilon", policy._epsilon))
+        policy._load_table(weights_file)
+    return policy
+
+elif policy_type == "mcts":
+    policy = MCTSPolicy(
+        obs_spec=obs_spec,
+        discrete_actions=discrete_actions,
+        c=policy_params.get("c", 1.41),
+        alpha=policy_params.get("alpha", 0.1),
+        gamma=policy_params.get("gamma", 0.99),
+        n_bins=policy_params.get("n_bins", 3),
+    )
+    if os.path.exists(weights_file) and not re_initialize:
+        policy._load_table(weights_file)
     return policy
 ```
 
-### `MCTSPolicy.from_cfg()` (lines 596–604)
-Same pattern as `EpsilonGreedyPolicy.from_cfg()`.
+Note: restoring `epsilon` from the saved YAML is important so decay continues
+from where it left off rather than restarting from 1.0.
 
 ## File Naming
 
@@ -89,7 +132,8 @@ from producing huge pickle files.
 
 | File | Change |
 |------|--------|
-| `policies.py` | Add `save()` + `_load_table()` to `QTablePolicy`; update `from_cfg()` in `EpsilonGreedy` and `MCTS` |
+| `framework/policies.py` | Add `save()` + `_load_table()` to `QTablePolicy`; add `_qtable_pkl_path()` helper; add `import pickle` |
+| `framework/training.py` | Update `_make_policy()` for `epsilon_greedy` and `mcts`: restore epsilon + call `_load_table()` when weights file exists |
 
 ## Testing
 


### PR DESCRIPTION
The original plan pointed at the TMNF shim (policies.py), but the
training framework imports EpsilonGreedyPolicy/MCTSPolicy directly
from framework/policies.py.  Update the plan to target the correct
files and add the _make_policy() restore step in training.py.

https://claude.ai/code/session_01HB3iF95zVh71Bj5aBHTkUf