### PR TITLE
Implement behavior cloning warm-start from SimplePolicy (issue #11)

### DIFF
--- a/framework/training.py
+++ b/framework/training.py
@@ -771,6 +771,7 @@ def train_rl(
     training_params: dict | None = None,
     no_interrupt: bool = False,
     re_initialize: bool = False,
+    do_pretrain: bool = False,
     policy_type: str = "hill_climbing",
     policy_params: dict | None = None,
     track: str = "",
@@ -810,18 +811,33 @@ def train_rl(
         and len(probe_actions) > 0
     )
 
-    if cold_start and not no_interrupt:
+    _will_pretrain = (
+        do_pretrain
+        and policy_type == "hill_climbing"
+        and not os.path.exists(weights_file)
+        and not re_initialize
+    )
+
+    if _will_pretrain and not no_interrupt:
+        input("\n  [PRE-TRAIN]  Press Enter to connect and start behavior cloning from SimplePolicy...")
+    elif cold_start and not no_interrupt:
         input("\n  [PROBE PHASE]  Press Enter to connect and start probe runs...")
 
     logger.info("Connecting to game...")
     env = make_env_fn()
+
+    pretrained = False
+    if _will_pretrain:
+        from rl.pretrain import run as _pretrain_run
+        _pretrain_run(env, experiment_dir=os.path.dirname(os.path.abspath(weights_file)), obs_spec=obs_spec)
+        pretrained = True
 
     probe_results: list[ProbeResult]             = []
     cold_start_data: list[ColdStartRestartResult] = []
     probe_best    = None
     t_after_probe = t_after_cold = None
 
-    if cold_start:
+    if cold_start and not pretrained:
         probe_best, probe_results = _run_probes(
             env, probe_actions, probe_in_game_s, speed,
             warmup_action=warmup_action, warmup_steps=warmup_steps,

--- a/grid_search.py
+++ b/grid_search.py
@@ -55,6 +55,7 @@ _ABBREV = {
     "cold_restarts":   "cr",
     "cold_sims":       "cs",
     "policy_type":     "pt",
+    "do_pretrain":     "dpt",
     # neural_net policy params
     "hidden_sizes":    "hs",
     # genetic policy params
@@ -315,6 +316,7 @@ def main() -> None:
             policy_type         = t.get("policy_type", "hill_climbing"),
             policy_params       = _build_policy_params(t),
             track               = track,
+            do_pretrain         = t.get("do_pretrain", False),
         )
 
         save_experiment_results(data, results_dir=f"{experiment_dir}/results")

--- a/main.py
+++ b/main.py
@@ -151,6 +151,7 @@ def main() -> None:
         training_params     = p,
         no_interrupt        = args.no_interrupt,
         re_initialize       = re_initialize,
+        do_pretrain         = p.get("do_pretrain", False),
         policy_type         = policy_type,
         policy_params       = policy_params,
         track               = track,

--- a/rl/pretrain.py
+++ b/rl/pretrain.py
@@ -1,0 +1,60 @@
+"""Behavior cloning: fit WeightedLinearPolicy to SimplePolicy demonstrations."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import numpy as np
+
+from games.tmnf.simple_policy import SimplePolicy
+from policies import WeightedLinearPolicy
+
+logger = logging.getLogger(__name__)
+
+N_DEMO_LAPS = 3
+
+
+def collect_demos(env, n_laps: int) -> tuple[np.ndarray, np.ndarray]:
+    """Drive n_laps with SimplePolicy, return (obs_matrix, action_matrix)."""
+    expert = SimplePolicy()
+    obs, _ = env.reset()
+    obs_list, act_list = [], []
+    laps_done = 0
+    while laps_done < n_laps:
+        action = expert(obs)
+        obs_list.append(obs.copy())
+        act_list.append(action.copy())
+        obs, _, terminated, truncated, info = env.step(action)
+        if (terminated or truncated) and info.get("finished", False):
+            laps_done += 1
+        if terminated or truncated:
+            obs, _ = env.reset()
+    return np.array(obs_list), np.array(act_list)
+
+
+def fit_weighted_linear(obs_matrix, act_matrix, obs_spec) -> WeightedLinearPolicy:
+    """Fit steer/accel/brake heads via lstsq. Returns a WeightedLinearPolicy."""
+    scales = obs_spec.scales.astype(float)
+    norm_obs = obs_matrix / scales[np.newaxis, :]
+    w_steer, *_ = np.linalg.lstsq(norm_obs, act_matrix[:, 0], rcond=None)
+    w_accel, *_ = np.linalg.lstsq(norm_obs, act_matrix[:, 1], rcond=None)
+    w_brake, *_ = np.linalg.lstsq(norm_obs, act_matrix[:, 2], rcond=None)
+    n_lidar = sum(1 for d in obs_spec.dims if d.name.startswith("lidar_"))
+    return WeightedLinearPolicy.from_cfg(
+        {
+            "steer_weights": w_steer.tolist(),
+            "accel_weights": w_accel.tolist(),
+            "brake_weights": w_brake.tolist(),
+        },
+        n_lidar_rays=n_lidar,
+    )
+
+
+def run(env, experiment_dir: Path, obs_spec) -> None:
+    """Collect demos and save pre-trained weights to experiment_dir."""
+    logger.info("Collecting demos from SimplePolicy (%d laps)...", N_DEMO_LAPS)
+    obs_m, act_m = collect_demos(env, N_DEMO_LAPS)
+    policy = fit_weighted_linear(obs_m, act_m, obs_spec)
+    weights_file = Path(experiment_dir) / "policy_weights.yaml"
+    policy.save(str(weights_file))
+    logger.info("Pre-trained weights saved to %s (%d steps)", weights_file, len(obs_m))


### PR DESCRIPTION
- Add rl/pretrain.py: collect_demos() drives SimplePolicy for N laps,
  fit_weighted_linear() fits steer/accel/brake heads via lstsq against
  normalised observations, run() saves pre-trained weights to experiment dir
- Add do_pretrain param to framework/training.py train_rl(); when set,
  runs pretrain before probe/cold-start and skips those phases if weights
  were written successfully
- Forward do_pretrain from config in main.py and grid_search.py
- Add "do_pretrain": "dpt" to grid_search._ABBREV (avoids "pt" conflict
  with policy_type)

https://claude.ai/code/session_01GebvQ4tSq7ZcFT6nCTcjL1