### PR TITLE
feat(#14): add tests for multi-track support

### DIFF
--- a/games/tmnf/tools/build_centerline.py
+++ b/games/tmnf/tools/build_centerline.py
@@ -13,13 +13,13 @@ from pathlib import Path
 
 import numpy as np
 import yaml
+from scipy.interpolate import splev, splprep
 
 logger = logging.getLogger(__name__)
-from pygbx import Gbx, GbxType
-from scipy.interpolate import splev, splprep
 
 
 def extract_positions(gbx_path: str) -> np.ndarray:
+    from pygbx import Gbx, GbxType
     g = Gbx(gbx_path)
     ghost = g.get_class_by_id(GbxType.CTN_GHOST)
     if ghost is None:

--- a/tests/test_build_centerline.py
+++ b/tests/test_build_centerline.py
@@ -1,0 +1,58 @@
+"""Tests for build_centerline.update_registry() (issue #14 multi-track support)."""
+import os
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from games.tmnf.tools.build_centerline import update_registry
+
+
+class TestUpdateRegistry(unittest.TestCase):
+
+    def setUp(self):
+        self._tmp = tempfile.mkdtemp()
+        self.registry_path = Path(self._tmp) / "registry.yaml"
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmp, ignore_errors=True)
+
+    def test_creates_registry_when_absent(self):
+        self.assertFalse(self.registry_path.exists())
+        update_registry(self.registry_path, "a03", Path("tracks/a03_centerline.npy"), "replays/a03.Replay.Gbx")
+        self.assertTrue(self.registry_path.exists())
+
+    def test_entry_fields(self):
+        update_registry(self.registry_path, "a03", Path("tracks/a03_centerline.npy"), "replays/a03.Replay.Gbx")
+        data = yaml.safe_load(self.registry_path.read_text())
+        entry = data["a03"]
+        self.assertEqual(entry["centerline_path"], "tracks/a03_centerline.npy")
+        self.assertEqual(entry["source_replay"], "replays/a03.Replay.Gbx")
+        self.assertIn("default_par_time_s", entry)
+
+    def test_upsert_overwrites_existing_track(self):
+        update_registry(self.registry_path, "a03", Path("tracks/a03_old.npy"), "replays/old.Replay.Gbx")
+        update_registry(self.registry_path, "a03", Path("tracks/a03_new.npy"), "replays/new.Replay.Gbx")
+        data = yaml.safe_load(self.registry_path.read_text())
+        self.assertEqual(data["a03"]["centerline_path"], "tracks/a03_new.npy")
+
+    def test_upsert_preserves_other_tracks(self):
+        update_registry(self.registry_path, "a03", Path("tracks/a03_centerline.npy"), "replays/a03.Replay.Gbx")
+        update_registry(self.registry_path, "b05", Path("tracks/b05_centerline.npy"), "replays/b05.Replay.Gbx")
+        data = yaml.safe_load(self.registry_path.read_text())
+        self.assertIn("a03", data)
+        self.assertIn("b05", data)
+        self.assertEqual(data["b05"]["centerline_path"], "tracks/b05_centerline.npy")
+
+    def test_multiple_tracks_sorted_keys(self):
+        update_registry(self.registry_path, "z99", Path("tracks/z99.npy"), "replays/z99.Replay.Gbx")
+        update_registry(self.registry_path, "a03", Path("tracks/a03.npy"), "replays/a03.Replay.Gbx")
+        data = yaml.safe_load(self.registry_path.read_text())
+        keys = list(data.keys())
+        self.assertEqual(keys, sorted(keys))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_reward.py
+++ b/tests/test_reward.py
@@ -200,5 +200,53 @@ class TestNTicksScaling(unittest.TestCase):
         self.assertAlmostEqual(per_tick_diff, expected_diff, places=5)
 
 
+class TestRewardConfigMultiTrack(unittest.TestCase):
+    """RewardConfig fields added for multi-track support (issue #14)."""
+
+    def test_default_track_name(self):
+        cfg = RewardConfig()
+        self.assertEqual(cfg.track_name, "a03")
+
+    def test_default_centerline_path(self):
+        cfg = RewardConfig()
+        self.assertEqual(cfg.centerline_path, "tracks/a03_centerline.npy")
+
+    def test_custom_track_fields(self):
+        cfg = RewardConfig(track_name="b05", centerline_path="tracks/b05_centerline.npy")
+        self.assertEqual(cfg.track_name, "b05")
+        self.assertEqual(cfg.centerline_path, "tracks/b05_centerline.npy")
+
+    def test_from_yaml_reads_track_fields(self):
+        import tempfile, os
+        yaml_content = (
+            "progress_weight: 10.0\n"
+            "track_name: b05\n"
+            "centerline_path: tracks/b05_centerline.npy\n"
+        )
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            tmp = f.name
+        try:
+            cfg = RewardConfig.from_yaml(tmp)
+            self.assertEqual(cfg.track_name, "b05")
+            self.assertEqual(cfg.centerline_path, "tracks/b05_centerline.npy")
+        finally:
+            os.unlink(tmp)
+
+    def test_from_yaml_backward_compat_missing_fields(self):
+        """Old YAML files without track_name/centerline_path fall back to defaults."""
+        import tempfile, os
+        yaml_content = "progress_weight: 10.0\nfinish_bonus: 100.0\n"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(yaml_content)
+            tmp = f.name
+        try:
+            cfg = RewardConfig.from_yaml(tmp)
+            self.assertEqual(cfg.track_name, "a03")
+            self.assertEqual(cfg.centerline_path, "tracks/a03_centerline.npy")
+        finally:
+            os.unlink(tmp)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
The multi-track implementation was already complete (RewardConfig fields,
make_env() wiring, build_centerline --track-name, tracks/registry.yaml)
but had no test coverage.

- Add TestRewardConfigMultiTrack to test_reward.py: verifies default
  values, custom values, from_yaml() reading the new fields, and
  backward-compat fallback for old YAML files missing the fields
- Add TestUpdateRegistry to test_build_centerline.py: verifies registry
  creation, entry fields, upsert, multi-track preservation, and sorted keys
- Move pygbx import inside extract_positions() so build_centerline can
  be imported without lzo installed (unblocks test collection)

https://claude.ai/code/session_01BE4oRhA9XKjWK4LLbcm48W