### PR TITLE
Add per-episode termination reason tracking

### DIFF
--- a/analytics.py
+++ b/analytics.py
@@ -48,6 +48,7 @@ from games.tmnf.analytics import (  # noqa: F401
     plot_greedy_progress,
     plot_weight_heatmap,
     plot_weight_evolution,
+    plot_termination_reasons,
     plot_gs_comparison_paths,
     plot_gs_comparison_progress,
 )
@@ -89,11 +90,13 @@ def save_experiment_results(data: ExperimentData, results_dir: str) -> None:
         plot_greedy_progress(data, results_dir)
         plot_greedy_best_run(data, results_dir)
         plot_weight_evolution(data, results_dir)
+        plot_termination_reasons(data, results_dir)
         sections.append(_greedy_table_md(data))
         sections.append("\n![Greedy rewards](greedy_rewards.png)\n\n")
         sections.append("![Greedy progress](greedy_progress.png)\n\n")
         sections.append("![Greedy best run](greedy_best_run.png)\n\n")
         sections.append("![Weight evolution](greedy_weight_evolution.png)\n\n")
+        sections.append("![Termination reasons](termination_reasons.png)\n\n")
 
     plot_greedy_action_dist(data, results_dir)
     plot_reward_trajectory(data, results_dir)

--- a/framework/analytics.py
+++ b/framework/analytics.py
@@ -66,6 +66,7 @@ class ColdStartSimResult:
     throttle_counts: list  # [brake_steps, coast_steps, accel_steps]
     total_steps: int
     trace: RunTrace | None = None
+    termination_reason: str | None = None
 
 
 @dataclass
@@ -88,6 +89,7 @@ class GreedySimResult:
     final_track_progress: float = 0.0
     laps_completed: int = 0
     mutation_scale: float | None = None
+    termination_reason: str | None = None
 
 
 @dataclass
@@ -292,12 +294,13 @@ def _greedy_table_md(data: ExperimentData) -> str:
     lines = [
         "## Greedy Phase\n\n",
         f"Best reward: **{best_r:+.1f}**\n\n",
-        "| Sim  | Reward   | Result       |\n",
-        "|------|----------|--------------|\n",
+        "| Sim  | Reward   | Reason       | Result       |\n",
+        "|------|----------|--------------|-------------|\n",
     ]
     for s in data.greedy_sims:
-        tag = "**NEW BEST**" if s.improved else ""
-        lines.append(f"| {s.sim:4d} | {s.reward:+8.1f} | {tag} |\n")
+        tag    = "**NEW BEST**" if s.improved else ""
+        reason = s.termination_reason or ""
+        lines.append(f"| {s.sim:4d} | {s.reward:+8.1f} | {reason:12s} | {tag} |\n")
     return "".join(lines)
 
 

--- a/framework/training.py
+++ b/framework/training.py
@@ -369,13 +369,14 @@ def _cold_start_search(
         for sim in range(1, sims_per_restart + 1):
             candidate = local_best_policy.mutated(scale=mutation_scale, share=mutation_share)
             obs, _ = env.reset()
-            reward, _, tc, total_steps, trace = _run_episode(
+            reward, info, tc, total_steps, trace = _run_episode(
                 env, candidate, obs,
                 warmup_action=warmup_action, warmup_steps=warmup_steps,
             )
             sim_results.append(ColdStartSimResult(
                 sim=sim, reward=reward,
                 throttle_counts=list(tc), total_steps=total_steps, trace=trace,
+                termination_reason=info.get("termination_reason"),
             ))
             if reward > local_best_reward:
                 local_best_reward = reward
@@ -472,6 +473,7 @@ def _greedy_loop(
                     final_track_progress=info.get("track_progress", 0.0),
                     laps_completed=info.get("laps_completed", 0),
                     mutation_scale=current_scale,
+                    termination_reason=info.get("termination_reason"),
                 ))
         except KeyboardInterrupt:
             logger.warning("Training interrupted.")
@@ -552,6 +554,7 @@ def _greedy_loop(
                 final_track_progress=best_info.get("track_progress", 0.0),
                 laps_completed=best_info.get("laps_completed", 0),
                 mutation_scale=current_scale,
+                termination_reason=best_info.get("termination_reason"),
             ))
     except KeyboardInterrupt:
         logger.warning("Training interrupted.")
@@ -633,6 +636,7 @@ def _greedy_loop_cmaes(
                 weights=policy.to_cfg(),
                 final_track_progress=info.get("track_progress", 0.0),
                 laps_completed=info.get("laps_completed", 0),
+                termination_reason=info.get("termination_reason"),
             ))
     except KeyboardInterrupt:
         logger.warning("Training interrupted.")
@@ -684,6 +688,7 @@ def _greedy_loop_q_learning(
                 weights=cfg,
                 final_track_progress=info.get("track_progress", 0.0),
                 laps_completed=info.get("laps_completed", 0),
+                termination_reason=info.get("termination_reason"),
             ))
     except KeyboardInterrupt:
         logger.warning("Training interrupted.")
@@ -749,6 +754,7 @@ def _greedy_loop_genetic(
                 weights=policy.to_cfg(),
                 final_track_progress=info.get("track_progress", 0.0),
                 laps_completed=info.get("laps_completed", 0),
+                termination_reason=info.get("termination_reason"),
             ))
     except KeyboardInterrupt:
         logger.warning("Training interrupted.")

--- a/games/tmnf/analytics.py
+++ b/games/tmnf/analytics.py
@@ -310,6 +310,56 @@ def plot_weight_evolution(data: ExperimentData, results_dir: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Termination reason breakdown
+# ---------------------------------------------------------------------------
+
+_REASON_COLORS = {
+    "finish":     "#27ae60",
+    "crash":      "#c0392b",
+    "hard_crash": "#e74c3c",
+    "timeout":    "#f39c12",
+}
+_REASON_ORDER = ["finish", "crash", "hard_crash", "timeout"]
+
+
+def plot_termination_reasons(data: ExperimentData, results_dir: str) -> None:
+    if not _HAS_MPL:
+        return
+    sims = data.greedy_sims
+    if not sims:
+        return
+
+    counts: dict[str, int] = {}
+    for s in sims:
+        r = s.termination_reason or "unknown"
+        counts[r] = counts.get(r, 0) + 1
+
+    order  = _REASON_ORDER + sorted(k for k in counts if k not in _REASON_ORDER)
+    labels = [r for r in order if r in counts]
+    values = [counts[r] for r in labels]
+    colors = [_REASON_COLORS.get(r, "#95a5a6") for r in labels]
+    total  = len(sims)
+
+    fig, ax = plt.subplots(figsize=(max(5, len(labels) * 1.4), 5))
+    bars = ax.bar(labels, values, color=colors, edgecolor="white", linewidth=0.6)
+    for bar, v in zip(bars, values):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            bar.get_height() + max(total * 0.005, 0.3),
+            f"{v} ({100 * v / total:.0f}%)",
+            ha="center", va="bottom", fontsize=9,
+        )
+    ax.set_title(
+        f"{data.experiment_name} — Greedy Phase: Termination Reasons ({total} sims)"
+    )
+    ax.set_xlabel("Reason")
+    ax.set_ylabel("Count")
+    ax.set_ylim(0, max(values) * 1.2)
+    fig.tight_layout()
+    _save(fig, os.path.join(results_dir, "termination_reasons.png"))
+
+
+# ---------------------------------------------------------------------------
 # Grid-search path comparison
 # ---------------------------------------------------------------------------
 
@@ -405,4 +455,5 @@ def save_tmnf_plots(data: ExperimentData, results_dir: str) -> None:
         plot_greedy_action_dist(data, results_dir)
         plot_greedy_progress(data, results_dir)
         plot_weight_evolution(data, results_dir)
+        plot_termination_reasons(data, results_dir)
     plot_weight_heatmap(data, results_dir)

--- a/games/tmnf/env.py
+++ b/games/tmnf/env.py
@@ -230,12 +230,24 @@ class TMNFEnv(BaseGameEnv):
                 "elapsed_s": self._elapsed_s,
                 "pos_x": init_step.state_data.position.x,
                 "pos_z": init_step.state_data.position.z,
+                "termination_reason": None,  # episode continues after lap
             }
             return obs, reward, False, False, info
 
         terminated = finished or crashed
         # step.done signals a hard crash (>50 m off, handled by client safety net)
         truncated = (step.done and not terminated) or time_over
+
+        if finished:
+            termination_reason: str | None = "finish"
+        elif crashed:
+            termination_reason = "crash"
+        elif step.done and not terminated:
+            termination_reason = "hard_crash"
+        elif time_over:
+            termination_reason = "timeout"
+        else:
+            termination_reason = None
 
         if terminated or truncated:
             self._log_skip_stats()
@@ -256,6 +268,7 @@ class TMNFEnv(BaseGameEnv):
             "ep_total_ticks": self._ep_total_ticks,
             "ep_skipped_ticks": self._ep_total_ticks - self._ep_rl_steps,
             "ep_max_skip": self._ep_max_skip,
+            "termination_reason": termination_reason,
         }
 
         return obs, reward, terminated, truncated, info

--- a/tests/test_env_termination.py
+++ b/tests/test_env_termination.py
@@ -1,0 +1,145 @@
+"""Unit tests for per-episode termination reason tracking in TMNFEnv.step()."""
+import time
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from games.tmnf.env import TMNFEnv
+from games.tmnf.reward import RewardConfig, RewardCalculator
+from games.tmnf.state import Vec3
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_step_state(
+    *,
+    finished: bool = False,
+    done: bool = False,
+    track_progress: float = 0.5,
+    lateral_offset: float = 0.0,
+    ticks_this_step: int = 1,
+) -> MagicMock:
+    """Build a minimal StepState mock covering all fields read by step()."""
+    step = MagicMock()
+    step.finished = finished
+    step.done = done
+    step.ticks_this_step = ticks_this_step
+    step.yaw_error = 0.0
+
+    sd = MagicMock()
+    sd.track_progress = track_progress
+    sd.lateral_offset = lateral_offset
+    sd.vertical_offset = 0.0
+    sd.turning_rate = 0.0
+    sd.velocity = Vec3(5.0, 0.0, 0.0)
+    sd.angular_velocity = Vec3(0.0, 0.0, 0.0)
+    sd.position = Vec3(0.0, 0.0, 0.0)
+    sd.rotation = MagicMock()
+    sd.rotation.pitch.return_value = 0.0
+    sd.rotation.roll.return_value = 0.0
+    sd.wheels = [MagicMock(contact=True) for _ in range(4)]
+    sd.lookahead = [(0.0, 0.0)] * 3
+    step.state_data = sd
+    return step
+
+
+def _make_env(
+    crash_threshold_m: float = 10.0,
+    max_episode_time_s: float = 60.0,
+    auto_respawn_on_finish: bool = False,
+) -> TMNFEnv:
+    """Instantiate TMNFEnv bypassing __init__, wiring only what step() needs."""
+    env = TMNFEnv.__new__(TMNFEnv)
+    env._reward_config = RewardConfig(crash_threshold_m=crash_threshold_m)
+    env._reward_calc = RewardCalculator(env._reward_config)
+    env._max_episode_time_s = max_episode_time_s
+    env._auto_respawn_on_finish = auto_respawn_on_finish
+    env._lidar = None
+    env._prev_state = MagicMock()
+    env._elapsed_s = 0.0
+    env._episode_start_s = time.monotonic()
+    env._laps_completed = 0
+    env._ep_rl_steps = 0
+    env._ep_total_ticks = 0
+    env._ep_max_skip = 0
+    env._total_rl_steps = 0
+    env._client = MagicMock()
+    env._log_skip_stats = MagicMock()
+    return env
+
+
+def _do_step(env: TMNFEnv, step_state: MagicMock) -> tuple:
+    env._client.get_step_state.return_value = step_state
+    action = np.array([0.0, 0.5, 0.0], dtype=np.float32)
+    dummy_obs = np.zeros(21, dtype=np.float32)
+    with patch.object(env, "_build_obs", return_value=dummy_obs):
+        return env.step(action)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestTerminationReason(unittest.TestCase):
+
+    def test_finish(self):
+        env = _make_env()
+        step = _make_step_state(finished=True, track_progress=1.0)
+        _, _, terminated, truncated, info = _do_step(env, step)
+        self.assertEqual(info["termination_reason"], "finish")
+        self.assertTrue(terminated)
+        self.assertFalse(truncated)
+
+    def test_crash(self):
+        env = _make_env(crash_threshold_m=10.0)
+        step = _make_step_state(lateral_offset=15.0)
+        _, _, terminated, truncated, info = _do_step(env, step)
+        self.assertEqual(info["termination_reason"], "crash")
+        self.assertTrue(terminated)
+        self.assertFalse(truncated)
+
+    def test_hard_crash(self):
+        # done=True but lateral offset within threshold (not crashed) and not finished
+        env = _make_env(crash_threshold_m=10.0)
+        step = _make_step_state(done=True, lateral_offset=0.0)
+        _, _, terminated, truncated, info = _do_step(env, step)
+        self.assertEqual(info["termination_reason"], "hard_crash")
+        self.assertFalse(terminated)
+        self.assertTrue(truncated)
+
+    def test_timeout(self):
+        # max_episode_time_s=0.0 ensures time_over is True immediately
+        env = _make_env(max_episode_time_s=0.0)
+        step = _make_step_state()
+        _, _, terminated, truncated, info = _do_step(env, step)
+        self.assertEqual(info["termination_reason"], "timeout")
+        self.assertFalse(terminated)
+        self.assertTrue(truncated)
+
+    def test_still_running(self):
+        env = _make_env(max_episode_time_s=9999.0)
+        step = _make_step_state(track_progress=0.3)
+        _, _, terminated, truncated, info = _do_step(env, step)
+        self.assertIsNone(info["termination_reason"])
+        self.assertFalse(terminated)
+        self.assertFalse(truncated)
+
+    def test_finish_takes_priority_over_crash(self):
+        env = _make_env(crash_threshold_m=10.0)
+        step = _make_step_state(finished=True, track_progress=1.0, lateral_offset=20.0)
+        _, _, _, _, info = _do_step(env, step)
+        self.assertEqual(info["termination_reason"], "finish")
+
+    def test_reason_key_always_present(self):
+        # termination_reason must always be in info, not just on episode end
+        env = _make_env(max_episode_time_s=9999.0)
+        step = _make_step_state(track_progress=0.1)
+        _, _, _, _, info = _do_step(env, step)
+        self.assertIn("termination_reason", info)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_env_termination.py
+++ b/tests/test_env_termination.py
@@ -54,13 +54,16 @@ def _make_env(
     """Instantiate TMNFEnv bypassing __init__, wiring only what step() needs."""
     env = TMNFEnv.__new__(TMNFEnv)
     env._reward_config = RewardConfig(crash_threshold_m=crash_threshold_m)
-    env._reward_calc = RewardCalculator(env._reward_config)
+    # Stub reward computation so MagicMock prev_state fields never reach arithmetic.
+    env._reward_calc = MagicMock()
+    env._reward_calc.compute.return_value = 0.0
     env._max_episode_time_s = max_episode_time_s
     env._auto_respawn_on_finish = auto_respawn_on_finish
     env._lidar = None
     env._prev_state = MagicMock()
     env._elapsed_s = 0.0
-    env._episode_start_s = time.monotonic()
+    # Place episode start 1 s in the past so elapsed_s is deterministically > 0.
+    env._episode_start_s = time.monotonic() - 1.0
     env._laps_completed = 0
     env._ep_rl_steps = 0
     env._ep_total_ticks = 0


### PR DESCRIPTION
## Summary

- `TMNFEnv.step()` now populates `info["termination_reason"]` with `"finish"`, `"crash"`, `"hard_crash"`, `"timeout"`, or `None` (episode still running) on every step
- `GreedySimResult` and `ColdStartSimResult` dataclasses gain a `termination_reason` field, threaded through all five greedy loop variants (hill-climbing/ES, neural-net, Q-learning, genetic, CMA-ES) and the cold-start loop
- New `plot_termination_reasons()` bar chart in `games/tmnf/analytics.py` → saved as `results/termination_reasons.png` and linked in `results.md`
- `_greedy_table_md()` gains a **Reason** column so the per-sim breakdown is visible in the markdown report
- 7 unit tests in `tests/test_env_termination.py` covering all four terminal outcomes, the still-running case, priority ordering (finish beats crash), and presence of the key on every step

## Test plan

- [ ] Run `python -m pytest tests/test_env_termination.py` — all 7 tests should pass
- [ ] Run a short training session (10 sims) and confirm `results/termination_reasons.png` is generated
- [ ] Inspect `results/results.md` and confirm the greedy table includes a **Reason** column
- [ ] Regression: existing tests should still pass (new fields are additive with defaults)

Closes #16

https://claude.ai/code/session_01KVy18bJicdouv55qVbUP7y