### PR TITLE
Add patience-based early stopping to greedy training loops

### DIFF
--- a/config/training_params.yaml
+++ b/config/training_params.yaml
@@ -9,6 +9,7 @@ probe_s: 15.0             # in-game seconds for each of the 9 single-action prob
 cold_restarts: 20         # max random restarts during cold-start search (hill_climbing only)
 cold_sims: 5            # hill-climb sims per cold-start restart (hill_climbing only)
 n_lidar_rays: 8          # LIDAR wall-distance rays appended to observation (0 = disabled)
+patience: 0              # stop greedy loop if no improvement for this many sims (0 = run all)
 
 
 # Policy algorithm for the greedy training phase.

--- a/framework/analytics.py
+++ b/framework/analytics.py
@@ -102,6 +102,8 @@ class ExperimentData:
     training_params: dict      # hyperparams dict
     timings: dict              # start, end, total_s, probe_s, cold_start_s, greedy_s
     track: str = ""
+    early_stopped: bool = False          # True if patience-based early stopping fired
+    early_stop_sim: int | None = None    # sim index where early stopping fired
 
 
 # ---------------------------------------------------------------------------
@@ -193,6 +195,9 @@ def plot_greedy_rewards(data: ExperimentData, results_dir: str) -> None:
             linewidth=2.0, zorder=3, label="best so far")
     ax.scatter(improvement_xs, improvement_ys, color="#27ae60",
                s=60, zorder=4, marker="^", label="improvement")
+    if getattr(data, "early_stopped", False) and data.early_stop_sim is not None:
+        ax.axvline(data.early_stop_sim, color="#e74c3c", linestyle="--",
+                   linewidth=1.5, label=f"early stop (sim {data.early_stop_sim})")
     ax.set_title(f"{data.experiment_name} — Greedy Phase: Reward per Simulation")
     ax.set_xlabel("Simulation")
     ax.set_ylabel("Total Episode Reward")

--- a/framework/training.py
+++ b/framework/training.py
@@ -424,7 +424,8 @@ def _greedy_loop(
     adaptive_mutation: bool = True,
     warmup_action: np.ndarray | None = None,
     warmup_steps: int = 0,
-) -> tuple[BasePolicy, float, list[GreedySimResult]]:
+    patience: int = 0,
+) -> tuple[BasePolicy, float, list[GreedySimResult], bool, int | None]:
     """ES gradient-estimation loop for WeightedLinearPolicy / NeuralNetPolicy."""
     ADAPT_WINDOW = 20
     ADAPT_UP     = 1.2
@@ -439,6 +440,9 @@ def _greedy_loop(
 
     if isinstance(best_policy, NeuralNetPolicy):
         # Single-candidate hill-climbing for neural_net
+        no_improve_streak = 0
+        early_stopped     = False
+        early_stop_sim    = None
         try:
             for sim in range(1, n_sims + 1):
                 candidate = best_policy.mutated(scale=current_scale)
@@ -473,9 +477,19 @@ def _greedy_loop(
                     laps_completed=info.get("laps_completed", 0),
                     mutation_scale=current_scale,
                 ))
+                no_improve_streak = 0 if improved else no_improve_streak + 1
+                if patience > 0 and no_improve_streak >= patience:
+                    logger.info(
+                        "Early stopping: no improvement in last %d sims (best=%.1f). "
+                        "Stopping at sim %d/%d.",
+                        patience, best_reward, sim, n_sims,
+                    )
+                    early_stopped  = True
+                    early_stop_sim = sim
+                    break
         except KeyboardInterrupt:
             logger.warning("Training interrupted.")
-        return best_policy, best_reward, greedy_sims
+        return best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim
 
     if not isinstance(best_policy, WeightedLinearPolicy):
         raise TypeError(
@@ -487,6 +501,9 @@ def _greedy_loop(
     theta = best_policy.to_flat()
     full_episode_time_s = env.get_episode_time_limit()
     has_episode_time_limit = full_episode_time_s is not None
+    no_improve_streak = 0
+    early_stopped     = False
+    early_stop_sim    = None
 
     try:
         for sim in range(1, n_sims + 1):
@@ -553,10 +570,20 @@ def _greedy_loop(
                 laps_completed=best_info.get("laps_completed", 0),
                 mutation_scale=current_scale,
             ))
+            no_improve_streak = 0 if improved else no_improve_streak + 1
+            if patience > 0 and no_improve_streak >= patience:
+                logger.info(
+                    "Early stopping: no improvement in last %d sims (best=%.1f). "
+                    "Stopping at sim %d/%d.",
+                    patience, best_reward, sim, n_sims,
+                )
+                early_stopped  = True
+                early_stop_sim = sim
+                break
     except KeyboardInterrupt:
         logger.warning("Training interrupted.")
 
-    return best_policy, best_reward, greedy_sims
+    return best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim
 
 
 def _maybe_adapt_scale(history, current, sim, window, up, down, mn, mx, enabled, out):
@@ -582,12 +609,16 @@ def _greedy_loop_cmaes(
     weights_file: str,
     warmup_action: np.ndarray | None = None,
     warmup_steps: int = 0,
-) -> tuple[Any, float, list[GreedySimResult]]:
+    patience: int = 0,
+) -> tuple[Any, float, list[GreedySimResult], bool, int | None]:
     """CMA-ES loop: sample λ offspring, evaluate each for one episode, update distribution."""
-    pop_size    = policy.population_size
-    best_reward = policy.champion_reward
+    pop_size          = policy.population_size
+    best_reward       = policy.champion_reward
     greedy_sims: list[GreedySimResult] = []
     full_episode_time_s = env.get_episode_time_limit()
+    no_improve_streak = 0
+    early_stopped     = False
+    early_stop_sim    = None
 
     logger.info("[CMA-ES] population_size=%d, total episodes = %d × %d = %d",
                 pop_size, n_generations, pop_size, n_generations * pop_size)
@@ -634,10 +665,20 @@ def _greedy_loop_cmaes(
                 final_track_progress=info.get("track_progress", 0.0),
                 laps_completed=info.get("laps_completed", 0),
             ))
+            no_improve_streak = 0 if improved else no_improve_streak + 1
+            if patience > 0 and no_improve_streak >= patience:
+                logger.info(
+                    "Early stopping: no improvement in last %d gens (best=%.1f). "
+                    "Stopping at gen %d/%d.",
+                    patience, best_reward, gen, n_generations,
+                )
+                early_stopped  = True
+                early_stop_sim = gen
+                break
     except KeyboardInterrupt:
         logger.warning("Training interrupted.")
 
-    return policy, best_reward, greedy_sims
+    return policy, best_reward, greedy_sims, early_stopped, early_stop_sim
 
 
 def _greedy_loop_q_learning(
@@ -647,11 +688,15 @@ def _greedy_loop_q_learning(
     weights_file: str,
     warmup_action: np.ndarray | None = None,
     warmup_steps: int = 0,
-) -> tuple[BasePolicy, float, list[GreedySimResult]]:
+    patience: int = 0,
+) -> tuple[BasePolicy, float, list[GreedySimResult], bool, int | None]:
     """Q-learning greedy loop for epsilon_greedy and mcts policy types."""
-    best_reward = float("-inf")
+    best_reward       = float("-inf")
     greedy_sims: list[GreedySimResult] = []
     full_episode_time_s = env.get_episode_time_limit()
+    no_improve_streak = 0
+    early_stopped     = False
+    early_stop_sim    = None
 
     try:
         for episode in range(1, n_episodes + 1):
@@ -685,10 +730,20 @@ def _greedy_loop_q_learning(
                 final_track_progress=info.get("track_progress", 0.0),
                 laps_completed=info.get("laps_completed", 0),
             ))
+            no_improve_streak = 0 if improved else no_improve_streak + 1
+            if patience > 0 and no_improve_streak >= patience:
+                logger.info(
+                    "Early stopping: no improvement in last %d episodes (best=%.1f). "
+                    "Stopping at episode %d/%d.",
+                    patience, best_reward, episode, n_episodes,
+                )
+                early_stopped  = True
+                early_stop_sim = episode
+                break
     except KeyboardInterrupt:
         logger.warning("Training interrupted.")
 
-    return policy, best_reward, greedy_sims
+    return policy, best_reward, greedy_sims, early_stopped, early_stop_sim
 
 
 def _greedy_loop_genetic(
@@ -698,12 +753,16 @@ def _greedy_loop_genetic(
     weights_file: str,
     warmup_action: np.ndarray | None = None,
     warmup_steps: int = 0,
-) -> tuple[GeneticPolicy, float, list[GreedySimResult]]:
+    patience: int = 0,
+) -> tuple[GeneticPolicy, float, list[GreedySimResult], bool, int | None]:
     """Genetic algorithm loop: N_pop episodes per generation."""
-    pop_size    = len(policy.population)
-    best_reward = policy.champion_reward
+    pop_size          = len(policy.population)
+    best_reward       = policy.champion_reward
     greedy_sims: list[GreedySimResult] = []
     full_episode_time_s = env.get_episode_time_limit()
+    no_improve_streak = 0
+    early_stopped     = False
+    early_stop_sim    = None
 
     logger.info("[Genetic] population_size=%d, total episodes = %d × %d = %d",
                 pop_size, n_generations, pop_size, n_generations * pop_size)
@@ -750,10 +809,20 @@ def _greedy_loop_genetic(
                 final_track_progress=info.get("track_progress", 0.0),
                 laps_completed=info.get("laps_completed", 0),
             ))
+            no_improve_streak = 0 if improved else no_improve_streak + 1
+            if patience > 0 and no_improve_streak >= patience:
+                logger.info(
+                    "Early stopping: no improvement in last %d gens (best=%.1f). "
+                    "Stopping at gen %d/%d.",
+                    patience, best_reward, gen, n_generations,
+                )
+                early_stopped  = True
+                early_stop_sim = gen
+                break
     except KeyboardInterrupt:
         logger.warning("Training interrupted.")
 
-    return policy, best_reward, greedy_sims
+    return policy, best_reward, greedy_sims, early_stopped, early_stop_sim
 
 
 # ---------------------------------------------------------------------------
@@ -790,6 +859,7 @@ def train_rl(
     save_results_fn: Callable[[ExperimentData, str], None] | None = None,
     extra_policy_types: dict[str, Callable[[], BasePolicy]] | None = None,
     extra_loop_dispatch: dict[str, str] | None = None,
+    patience: int = 0,
 ) -> ExperimentData:
     """
     Train a policy via the selected algorithm.
@@ -896,38 +966,38 @@ def train_rl(
     _extra_dispatch = extra_loop_dispatch or {}
 
     if policy_type in ("hill_climbing", "neural_net"):
-        best_policy, best_reward, greedy_sims = _greedy_loop(
+        best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop(
             env=env, policy=best_policy, n_sims=n_sims,
             mutation_scale=mutation_scale, mutation_share=mutation_share,
             best_reward=best_reward, weights_file=weights_file,
-            adaptive_mutation=adaptive_mutation, **kw,
+            adaptive_mutation=adaptive_mutation, patience=patience, **kw,
         )
     elif policy_type in ("epsilon_greedy", "mcts"):
-        best_policy, best_reward, greedy_sims = _greedy_loop_q_learning(
+        best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop_q_learning(
             env=env, policy=best_policy, n_episodes=n_sims,
-            weights_file=weights_file, **kw,
+            weights_file=weights_file, patience=patience, **kw,
         )
     elif policy_type == "genetic":
-        best_policy, best_reward, greedy_sims = _greedy_loop_genetic(
+        best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop_genetic(
             env=env, policy=best_policy,  # type: ignore[arg-type]
-            n_generations=n_sims, weights_file=weights_file, **kw,
+            n_generations=n_sims, weights_file=weights_file, patience=patience, **kw,
         )
     elif _extra_dispatch.get(policy_type) == "q_learning":
-        best_policy, best_reward, greedy_sims = _greedy_loop_q_learning(
+        best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop_q_learning(
             env=env, policy=best_policy, n_episodes=n_sims,
-            weights_file=weights_file, **kw,
+            weights_file=weights_file, patience=patience, **kw,
         )
     elif _extra_dispatch.get(policy_type) == "cmaes":
-        best_policy, best_reward, greedy_sims = _greedy_loop_cmaes(
+        best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop_cmaes(
             env=env, policy=best_policy,
-            n_generations=n_sims, weights_file=weights_file, **kw,
+            n_generations=n_sims, weights_file=weights_file, patience=patience, **kw,
         )
     else:
-        best_policy, best_reward, greedy_sims = _greedy_loop(
+        best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop(
             env=env, policy=best_policy, n_sims=n_sims,
             mutation_scale=mutation_scale, mutation_share=mutation_share,
             best_reward=best_reward, weights_file=weights_file,
-            adaptive_mutation=adaptive_mutation, **kw,
+            adaptive_mutation=adaptive_mutation, patience=patience, **kw,
         )
 
     env.close()
@@ -956,6 +1026,8 @@ def train_rl(
         training_params    = training_params or {},
         timings            = timings,
         track              = track,
+        early_stopped      = early_stopped,
+        early_stop_sim     = early_stop_sim,
     )
 
     if save_results_fn is not None:

--- a/grid_search.py
+++ b/grid_search.py
@@ -56,6 +56,7 @@ _ABBREV = {
     "cold_sims":       "cs",
     "policy_type":     "pt",
     "do_pretrain":     "dpt",
+    "patience":        "pat",
     # neural_net policy params
     "hidden_sizes":    "hs",
     # genetic policy params
@@ -317,6 +318,7 @@ def main() -> None:
             policy_params       = _build_policy_params(t),
             track               = track,
             do_pretrain         = t.get("do_pretrain", False),
+            patience            = t.get("patience", 0),
         )
 
         save_experiment_results(data, results_dir=f"{experiment_dir}/results")

--- a/main.py
+++ b/main.py
@@ -158,6 +158,7 @@ def main() -> None:
         adaptive_mutation   = p.get("adaptive_mutation", True),
         extra_policy_types  = extra_policy_types,
         extra_loop_dispatch = extra_loop_dispatch,
+        patience            = p.get("patience", 0),
     )
 
     save_experiment_results(data, results_dir=f"{experiment_dir}/results")

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -1,0 +1,193 @@
+"""Unit tests for patience-based early stopping in greedy training loops."""
+import os
+import sys
+import unittest
+import tempfile
+
+import numpy as np
+
+# Ensure project root is on path (conftest.py handles this for pytest,
+# but we also need it when running this file directly).
+_root = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+if _root not in sys.path:
+    sys.path.insert(0, _root)
+
+from framework.training import _greedy_loop
+from framework.policies import WeightedLinearPolicy
+from framework.obs_spec import ObsSpec, ObsDim
+
+
+# ---------------------------------------------------------------------------
+# Minimal stub env that returns a fixed reward each episode
+# ---------------------------------------------------------------------------
+
+class _FixedRewardEnv:
+    """Minimal env stub: every episode returns a fixed reward."""
+
+    def __init__(self, reward: float) -> None:
+        self._reward = reward
+
+    def reset(self):
+        obs = np.zeros(3, dtype=np.float32)
+        return obs, {}
+
+    def step(self, action):
+        obs  = np.zeros(3, dtype=np.float32)
+        info = {"track_progress": 0.5, "laps_completed": 0, "pos_x": 0.0, "pos_z": 0.0}
+        return obs, self._reward, True, False, info  # terminated after 1 step
+
+    def get_episode_time_limit(self):
+        return None
+
+    def set_episode_time_limit(self, _):
+        pass
+
+    def close(self):
+        pass
+
+
+class _IncreasingRewardEnv:
+    """Env that returns reward = call_count (always improving)."""
+
+    def __init__(self) -> None:
+        self._call = 0
+
+    def reset(self):
+        return np.zeros(3, dtype=np.float32), {}
+
+    def step(self, action):
+        self._call += 1
+        info = {"track_progress": 0.5, "laps_completed": 0, "pos_x": 0.0, "pos_z": 0.0}
+        return np.zeros(3, dtype=np.float32), float(self._call), True, False, info
+
+    def get_episode_time_limit(self):
+        return None
+
+    def set_episode_time_limit(self, _):
+        pass
+
+    def close(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_OBS_SPEC = ObsSpec([
+    ObsDim("a", 1.0, ""),
+    ObsDim("b", 1.0, ""),
+    ObsDim("c", 1.0, ""),
+])
+_HEAD_NAMES = ["steer", "accel", "brake"]
+
+
+def _make_wlp(weights_file: str) -> WeightedLinearPolicy:
+    """Create a trivial WeightedLinearPolicy with zero weights."""
+    cfg = {
+        h + "_weights": {n: 0.0 for n in _OBS_SPEC.names}
+        for h in _HEAD_NAMES
+    }
+    p = WeightedLinearPolicy.from_cfg(cfg, _OBS_SPEC, _HEAD_NAMES)
+    p.save(weights_file)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestPatientEarlyStopping(unittest.TestCase):
+
+    def test_stops_after_patience_sims_no_improvement(self):
+        """With a fixed-reward env and a high best_reward seed, early stopping fires
+        after exactly `patience` sims (none of which improve)."""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            wf = f.name
+        try:
+            policy = _make_wlp(wf)
+            env    = _FixedRewardEnv(reward=10.0)
+            n_sims   = 100
+            patience = 5
+
+            _, _, sims, early_stopped, early_stop_sim = _greedy_loop(
+                env=env, policy=policy, n_sims=n_sims,
+                mutation_scale=0.01, weights_file=wf,
+                best_reward=100.0,  # higher than any candidate reward → never improves
+                patience=patience, adaptive_mutation=False,
+            )
+
+            self.assertTrue(early_stopped)
+            self.assertEqual(early_stop_sim, patience)
+            self.assertEqual(len(sims), patience)
+        finally:
+            os.unlink(wf)
+
+    def test_patience_zero_runs_all_sims(self):
+        """patience=0 disables early stopping — all n_sims run."""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            wf = f.name
+        try:
+            policy = _make_wlp(wf)
+            env    = _FixedRewardEnv(reward=10.0)
+            n_sims   = 10
+
+            _, _, sims, early_stopped, early_stop_sim = _greedy_loop(
+                env=env, policy=policy, n_sims=n_sims,
+                mutation_scale=0.01, weights_file=wf,
+                patience=0, adaptive_mutation=False,
+            )
+
+            self.assertFalse(early_stopped)
+            self.assertIsNone(early_stop_sim)
+            self.assertEqual(len(sims), n_sims)
+        finally:
+            os.unlink(wf)
+
+    def test_streak_resets_on_improvement(self):
+        """When reward improves mid-run, the no-improve streak resets."""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            wf = f.name
+        try:
+            policy = _make_wlp(wf)
+            # Always improving → streak never reaches patience, so all sims run.
+            env    = _IncreasingRewardEnv()
+            n_sims   = 20
+            patience = 5
+
+            _, _, sims, early_stopped, early_stop_sim = _greedy_loop(
+                env=env, policy=policy, n_sims=n_sims,
+                mutation_scale=0.01, weights_file=wf,
+                patience=patience, adaptive_mutation=False,
+            )
+
+            self.assertFalse(early_stopped)
+            self.assertIsNone(early_stop_sim)
+            self.assertEqual(len(sims), n_sims)
+        finally:
+            os.unlink(wf)
+
+    def test_early_stop_sim_is_last_recorded_sim(self):
+        """early_stop_sim matches the last sim index stored in greedy_sims."""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            wf = f.name
+        try:
+            policy = _make_wlp(wf)
+            env    = _FixedRewardEnv(reward=5.0)
+            patience = 3
+
+            _, _, sims, early_stopped, early_stop_sim = _greedy_loop(
+                env=env, policy=policy, n_sims=50,
+                mutation_scale=0.01, weights_file=wf,
+                patience=patience, adaptive_mutation=False,
+            )
+
+            self.assertTrue(early_stopped)
+            self.assertIsNotNone(early_stop_sim)
+            self.assertEqual(sims[-1].sim, early_stop_sim)
+        finally:
+            os.unlink(wf)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -12,9 +12,14 @@ _root = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
 if _root not in sys.path:
     sys.path.insert(0, _root)
 
-from framework.training import _greedy_loop
+# framework.training has no top-level shim; import directly.
+from framework.training import _greedy_loop, _greedy_loop_q_learning
+# framework.policies.WeightedLinearPolicy is used directly because the TMNF shim
+# in policies.py bakes in TMNF's obs_spec and a different from_cfg signature;
+# these tests exercise framework internals with a custom 3-dim obs_spec.
 from framework.policies import WeightedLinearPolicy
-from framework.obs_spec import ObsSpec, ObsDim
+# obs_spec shim re-exports ObsSpec/ObsDim unchanged — use it for consistency.
+from obs_spec import ObsSpec, ObsDim
 
 
 # ---------------------------------------------------------------------------
@@ -28,13 +33,11 @@ class _FixedRewardEnv:
         self._reward = reward
 
     def reset(self):
-        obs = np.zeros(3, dtype=np.float32)
-        return obs, {}
+        return np.zeros(3, dtype=np.float32), {}
 
     def step(self, action):
-        obs  = np.zeros(3, dtype=np.float32)
         info = {"track_progress": 0.5, "laps_completed": 0, "pos_x": 0.0, "pos_z": 0.0}
-        return obs, self._reward, True, False, info  # terminated after 1 step
+        return np.zeros(3, dtype=np.float32), self._reward, True, False, info
 
     def get_episode_time_limit(self):
         return None
@@ -71,6 +74,31 @@ class _IncreasingRewardEnv:
 
 
 # ---------------------------------------------------------------------------
+# Minimal stub policy for Q-learning loop tests
+# ---------------------------------------------------------------------------
+
+class _StubQPolicy:
+    """Minimal policy compatible with _greedy_loop_q_learning."""
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        return np.array([0.0, 1.0, 0.0], dtype=np.float32)
+
+    def update(self, *_) -> None:
+        pass
+
+    def on_episode_end(self) -> None:
+        pass
+
+    def save(self, path: str) -> None:
+        import yaml
+        with open(path, "w") as f:
+            yaml.dump({}, f)
+
+    def to_cfg(self) -> dict:
+        return {}
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -94,10 +122,10 @@ def _make_wlp(weights_file: str) -> WeightedLinearPolicy:
 
 
 # ---------------------------------------------------------------------------
-# Tests
+# Tests — _greedy_loop (hill_climbing / neural_net)
 # ---------------------------------------------------------------------------
 
-class TestPatientEarlyStopping(unittest.TestCase):
+class TestPatienceEarlyStopping(unittest.TestCase):
 
     def test_stops_after_patience_sims_no_improvement(self):
         """With a fixed-reward env and a high best_reward seed, early stopping fires
@@ -150,7 +178,6 @@ class TestPatientEarlyStopping(unittest.TestCase):
             wf = f.name
         try:
             policy = _make_wlp(wf)
-            # Always improving → streak never reaches patience, so all sims run.
             env    = _IncreasingRewardEnv()
             n_sims   = 20
             patience = 5
@@ -185,6 +212,56 @@ class TestPatientEarlyStopping(unittest.TestCase):
             self.assertTrue(early_stopped)
             self.assertIsNotNone(early_stop_sim)
             self.assertEqual(sims[-1].sim, early_stop_sim)
+        finally:
+            os.unlink(wf)
+
+
+# ---------------------------------------------------------------------------
+# Tests — _greedy_loop_q_learning (epsilon_greedy / mcts)
+# ---------------------------------------------------------------------------
+
+class TestPatienceEarlyStoppingQLoop(unittest.TestCase):
+
+    def test_q_loop_stops_after_patience_no_improvement(self):
+        """Q-learning loop stops after exactly `patience` episodes when reward never improves."""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            wf = f.name
+        try:
+            policy   = _StubQPolicy()
+            env      = _FixedRewardEnv(reward=5.0)
+            patience = 4
+
+            # Seed best_reward above the fixed reward so nothing ever improves.
+            _, _, sims, early_stopped, early_stop_sim = _greedy_loop_q_learning(
+                env=env, policy=policy, n_episodes=100,
+                weights_file=wf, patience=patience,
+            )
+
+            # The stub always returns reward=5.0; first episode sets best from -inf,
+            # so streak starts counting from episode 2. Stop at episode 1+patience.
+            self.assertTrue(early_stopped)
+            self.assertEqual(len(sims), 1 + patience)
+            self.assertEqual(sims[-1].sim, early_stop_sim)
+        finally:
+            os.unlink(wf)
+
+    def test_q_loop_patience_zero_runs_all(self):
+        """patience=0 in Q-loop disables early stopping."""
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            wf = f.name
+        try:
+            policy   = _StubQPolicy()
+            env      = _FixedRewardEnv(reward=5.0)
+            n_eps    = 8
+
+            _, _, sims, early_stopped, early_stop_sim = _greedy_loop_q_learning(
+                env=env, policy=policy, n_episodes=n_eps,
+                weights_file=wf, patience=0,
+            )
+
+            self.assertFalse(early_stopped)
+            self.assertIsNone(early_stop_sim)
+            self.assertEqual(len(sims), n_eps)
         finally:
             os.unlink(wf)
 


### PR DESCRIPTION
## Summary

- Adds `patience: int = 0` to all four greedy loop functions and `train_rl()`; when `patience > 0` and best reward hasn't improved for `patience` consecutive sims, the loop stops early
- `patience=0` (default) preserves current behaviour exactly — no behavioural change unless opted in
- `ExperimentData` gains `early_stopped: bool` and `early_stop_sim: int | None` fields; `plot_greedy_rewards` annotates the reward curve with a vertical dashed line when early stopping fires
- `main.py` and `grid_search.py` read `patience` from `training_params.yaml` and forward to `train_rl()`; `patience` added to `_ABBREV` so it can be a grid search axis
- `config/training_params.yaml` documents the new `patience: 0` default
- 4 unit tests in `tests/test_early_stopping.py`

## Test plan

- [x] `test_stops_after_patience_sims_no_improvement` — stops at exactly `patience` sims when reward never improves
- [x] `test_patience_zero_runs_all_sims` — `patience=0` runs all `n_sims`
- [x] `test_streak_resets_on_improvement` — no early stop when reward always improves
- [x] `test_early_stop_sim_is_last_recorded_sim` — `early_stop_sim` matches last recorded sim index
- [x] Full existing test suite passes (123 tests OK, 4 pre-existing failures due to missing `scipy`/`cv2`)

Closes #17

https://claude.ai/code/session_016vtrMqLTgZCptAifopPo8V