### PR TITLE
feat: add REINFORCEPolicy (#21) and LSTMPolicy (#22)

### DIFF
--- a/config/training_params.yaml
+++ b/config/training_params.yaml
@@ -12,7 +12,7 @@ n_lidar_rays: 8          # LIDAR wall-distance rays appended to observation (0 =
 
 
 # Policy algorithm for the greedy training phase.
-# Options: hill_climbing | neural_net | epsilon_greedy | mcts | genetic | neural_dqn
+# Options: hill_climbing | neural_net | epsilon_greedy | mcts | genetic | neural_dqn | cmaes | reinforce | lstm
 policy_type: genetic
 
 # Type-specific hyperparams.  Only the block matching policy_type is used.
@@ -63,3 +63,15 @@ policy_params:
   # cmaes — CMA-ES over flat WeightedLinearPolicy weight vector (Hansen 2016)
   #population_size: 20     # λ — offspring sampled each generation
   #initial_sigma: 0.3      # initial step size (adapted automatically)
+
+  # reinforce — Monte Carlo policy gradient (pure numpy MLP, softmax over 9 discrete actions)
+  #hidden_sizes: [64, 64]  # MLP hidden layer sizes
+  #learning_rate: 0.001    # gradient ascent step size
+  #gamma: 0.99             # reward discount factor
+  #entropy_coeff: 0.01     # H(π) bonus coefficient (0 = disabled)
+  #baseline: running_mean  # variance reduction baseline ("running_mean" or "none")
+
+  # lstm — LSTM policy trained via isotropic (μ/μ_w, λ)-ES (1/5 success rule for σ)
+  #hidden_size: 32         # LSTM hidden units (flat param dim ≈ 4×(h+obs_dim)×h + 3h)
+  #population_size: 20     # λ — offspring sampled per generation
+  #initial_sigma: 0.05     # initial step size (adapted via 1/5 rule)

--- a/games/tmnf/policies.py
+++ b/games/tmnf/policies.py
@@ -638,6 +638,10 @@ class REINFORCEPolicy(BasePolicy):
             running = self._ep_rewards[t] + self._gamma * running
             G[t]    = running
 
+        # Capture baseline before updating so this episode's returns don't bias
+        # the advantages computed below (avoids action-dependent baseline).
+        baseline_for_advantages = self._baseline_val
+
         # Baseline update (EMA of total episode return)
         if self._baseline_type == "running_mean":
             self._baseline_val = ((1 - self._baseline_alpha) * self._baseline_val
@@ -650,7 +654,7 @@ class REINFORCEPolicy(BasePolicy):
         if G_std > 1e-6:
             G_norm = (G - G.mean()) / (G_std + 1e-8)
         else:
-            G_norm = G - self._baseline_val
+            G_norm = G - baseline_for_advantages
 
         # Accumulate gradients
         dW = [np.zeros_like(w, dtype=np.float64) for w in self._weights]
@@ -798,6 +802,13 @@ class LSTMPolicy(BasePolicy):
 
     def with_flat(self, flat: np.ndarray) -> "LSTMPolicy":
         """Return a new LSTMPolicy whose weights come from a flat parameter vector."""
+        flat = np.asarray(flat, dtype=np.float32)
+        if flat.shape[0] != self.flat_dim:
+            raise ValueError(
+                f"LSTMPolicy.with_flat: expected flat vector of size {self.flat_dim}, "
+                f"got {flat.shape[0]}"
+            )
+
         obj = object.__new__(LSTMPolicy)
         obj._hidden_size  = self._hidden_size
         obj._n_lidar_rays = self._n_lidar_rays
@@ -806,7 +817,6 @@ class LSTMPolicy(BasePolicy):
 
         h    = self._hidden_size
         c_in = h + self._obs_dim
-        flat = np.asarray(flat, dtype=np.float32)
 
         off = 0
         def _take(shape: tuple) -> np.ndarray:
@@ -1025,6 +1035,12 @@ class LSTMEvolutionPolicy(BasePolicy):
     def update_distribution(self, rewards: list[float]) -> bool:
         if len(rewards) != self._lam:
             raise ValueError(f"Expected {self._lam} rewards, got {len(rewards)}")
+        if len(self._pop) != self._lam:
+            raise RuntimeError(
+                "update_distribution() called before a matching sample_population(). "
+                f"Expected {self._lam} samples in _pop, got {len(self._pop)}. "
+                "Call sample_population() first."
+            )
 
         order     = np.argsort(rewards)[::-1]
         prev_best = self._champion_reward

--- a/games/tmnf/policies.py
+++ b/games/tmnf/policies.py
@@ -532,3 +532,503 @@ class CMAESPolicy(BasePolicy):
         """Save champion in WeightedLinearPolicy YAML format for analytics compatibility."""
         if self._champion is not None:
             self._champion.save(path)
+
+
+# ---------------------------------------------------------------------------
+# REINFORCEPolicy
+# ---------------------------------------------------------------------------
+
+class REINFORCEPolicy(BasePolicy):
+    """
+    REINFORCE (Monte Carlo Policy Gradient) with optional entropy regularisation.
+
+    Action head: softmax over the 9 discrete TMNF actions.
+    Each episode accumulates (log_prob, reward) pairs; gradient update fires
+    on episode end using discounted, normalised returns.
+
+    Training loop dispatch: "q_learning" (update() per step, on_episode_end() per episode).
+    """
+
+    def __init__(
+        self,
+        hidden_sizes: list[int] | None = None,
+        learning_rate: float = 0.001,
+        gamma: float = 0.99,
+        entropy_coeff: float = 0.01,
+        baseline: str = "running_mean",
+        n_lidar_rays: int = 0,
+        seed: int | None = None,
+    ) -> None:
+        self._hidden       = list(hidden_sizes or [64, 64])
+        self._lr           = float(learning_rate)
+        self._gamma        = float(gamma)
+        self._entropy_coeff = float(entropy_coeff)
+        self._baseline_type = baseline
+        self._n_lidar_rays = n_lidar_rays
+        self._obs_dim      = BASE_OBS_DIM + n_lidar_rays
+        self._scales       = obs_scales_with_lidar(n_lidar_rays)
+
+        self._weights, self._biases = self._build_net(seed)
+
+        # Episode buffers (aligned: one entry per non-warmup step)
+        self._ep_grads: list[tuple]   = []  # (layer_inputs, pre_relu, probs, action_idx)
+        self._ep_rewards: list[float] = []
+
+        # Running-mean baseline (EMA of total episode returns)
+        self._baseline_val   = 0.0
+        self._baseline_alpha = 0.05
+
+    def _build_net(self, seed: int | None) -> tuple[list[np.ndarray], list[np.ndarray]]:
+        rng  = np.random.default_rng(seed)
+        dims = [self._obs_dim] + self._hidden + [_N_DISCRETE_ACTIONS]
+        weights, biases = [], []
+        for i in range(len(dims) - 1):
+            fan_in = dims[i]
+            w = rng.standard_normal((dims[i + 1], fan_in)).astype(np.float32)
+            w *= np.sqrt(2.0 / fan_in)
+            b = np.zeros(dims[i + 1], dtype=np.float32)
+            weights.append(w)
+            biases.append(b)
+        return weights, biases
+
+    @staticmethod
+    def _softmax(z: np.ndarray) -> np.ndarray:
+        z_s = z - z.max()
+        e   = np.exp(z_s)
+        return e / e.sum()
+
+    def _forward(self, obs_norm: np.ndarray):
+        """Forward pass; caches (layer_inputs, pre_relu) for backprop."""
+        x: np.ndarray         = obs_norm.astype(np.float32)
+        layer_inputs: list    = []
+        pre_relu: list        = []
+        for i, (w, b) in enumerate(zip(self._weights, self._biases)):
+            layer_inputs.append(x.copy())
+            z = w @ x + b
+            if i < len(self._weights) - 1:
+                pre_relu.append(z.copy())
+                x = np.maximum(0.0, z)
+            else:
+                logits = z
+        probs = self._softmax(logits)
+        return probs, layer_inputs, pre_relu
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        obs_norm               = obs / self._scales
+        probs, l_in, pre_r    = self._forward(obs_norm)
+        action_idx             = int(np.random.choice(_N_DISCRETE_ACTIONS, p=probs))
+        self._ep_grads.append((l_in, pre_r, probs.copy(), action_idx))
+        return _DISCRETE_ACTIONS[action_idx].copy()
+
+    def update(self, obs: np.ndarray, action: np.ndarray | int, reward: float,
+               next_obs: np.ndarray, done: bool) -> None:
+        self._ep_rewards.append(float(reward))
+
+    def on_episode_end(self) -> None:
+        T = min(len(self._ep_grads), len(self._ep_rewards))
+        if T == 0:
+            self._ep_grads.clear()
+            self._ep_rewards.clear()
+            return
+
+        # Discounted returns
+        G = np.zeros(T, dtype=np.float64)
+        running = 0.0
+        for t in reversed(range(T)):
+            running = self._ep_rewards[t] + self._gamma * running
+            G[t]    = running
+
+        # Baseline update (EMA of total episode return)
+        if self._baseline_type == "running_mean":
+            self._baseline_val = ((1 - self._baseline_alpha) * self._baseline_val
+                                  + self._baseline_alpha * float(G[0]))
+
+        # Normalise returns: scale by std when there is within-episode variance;
+        # otherwise fall back to baseline-centred raw returns so single-step
+        # episodes still produce a non-zero gradient.
+        G_std = float(G.std())
+        if G_std > 1e-6:
+            G_norm = (G - G.mean()) / (G_std + 1e-8)
+        else:
+            G_norm = G - self._baseline_val
+
+        # Accumulate gradients
+        dW = [np.zeros_like(w, dtype=np.float64) for w in self._weights]
+        dB = [np.zeros_like(b, dtype=np.float64) for b in self._biases]
+
+        for t in range(T):
+            l_in, pre_r, probs, a_idx = self._ep_grads[t]
+            advantage = float(G_norm[t])
+
+            # Output-layer gradient: ∂J/∂z = advantage * (one_hot(a) - probs) + entropy term
+            delta                  = -probs.copy().astype(np.float64)
+            delta[a_idx]          += 1.0
+            delta                 *= advantage
+
+            if self._entropy_coeff > 0.0:
+                # ∂H/∂z_j = -p_j * (log(p_j) + H)  [gradient of entropy w.r.t. logits]
+                log_p        = np.log(probs.astype(np.float64) + 1e-8)
+                H            = -float(np.dot(probs, log_p))
+                entropy_grad = -probs.astype(np.float64) * (log_p + H)
+                delta       += self._entropy_coeff * entropy_grad
+
+            # Backprop through MLP (gradient ascent)
+            g = delta
+            for i in range(len(self._weights) - 1, -1, -1):
+                dW[i] += np.outer(g, l_in[i])
+                dB[i] += g
+                if i > 0:
+                    g = self._weights[i].T @ g * (pre_r[i - 1] > 0)
+
+        # Parameter update (gradient ascent: θ += lr * grad / T)
+        lr_t = self._lr / T
+        for i in range(len(self._weights)):
+            self._weights[i] += (lr_t * dW[i]).astype(np.float32)
+            self._biases[i]  += (lr_t * dB[i]).astype(np.float32)
+
+        self._ep_grads.clear()
+        self._ep_rewards.clear()
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type":    "reinforce",
+            "hidden_sizes":   self._hidden,
+            "learning_rate":  float(self._lr),
+            "gamma":          float(self._gamma),
+            "entropy_coeff":  float(self._entropy_coeff),
+            "baseline":       self._baseline_type,
+            "n_lidar_rays":   self._n_lidar_rays,
+            "baseline_value": float(self._baseline_val),
+            "weights":        [w.tolist() for w in self._weights],
+            "biases":         [b.tolist() for b in self._biases],
+        }
+
+    @classmethod
+    def from_cfg(cls, cfg: dict, n_lidar_rays: int = 0) -> "REINFORCEPolicy":
+        obj = cls(
+            hidden_sizes  = cfg.get("hidden_sizes",  [64, 64]),
+            learning_rate = cfg.get("learning_rate", 0.001),
+            gamma         = cfg.get("gamma",         0.99),
+            entropy_coeff = cfg.get("entropy_coeff", 0.01),
+            baseline      = cfg.get("baseline",      "running_mean"),
+            n_lidar_rays  = n_lidar_rays,
+        )
+        if "weights" in cfg:
+            obj._weights = [np.array(w, dtype=np.float32) for w in cfg["weights"]]
+            obj._biases  = [np.array(b, dtype=np.float32) for b in cfg["biases"]]
+        if "baseline_value" in cfg:
+            obj._baseline_val = float(cfg["baseline_value"])
+        return obj
+
+
+# ---------------------------------------------------------------------------
+# LSTMPolicy
+# ---------------------------------------------------------------------------
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-np.clip(x, -20.0, 20.0)))
+
+
+class LSTMPolicy(BasePolicy):
+    """
+    Single-layer LSTM policy (pure numpy).
+
+    Hidden state (h, c) persists across steps within an episode.
+    Trained via an outer evolutionary optimiser (LSTMEvolutionPolicy).
+    on_episode_end() resets (h, c) to zeros.
+
+    Output heads:
+      steer = tanh(W_steer · h)           → [-1, 1]
+      accel = sigmoid(W_accel · h) > 0.5  → {0, 1}
+      brake = sigmoid(W_brake · h) > 0.5  → {0, 1}
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 32,
+        n_lidar_rays: int = 0,
+        seed: int | None = None,
+    ) -> None:
+        self._hidden_size  = hidden_size
+        self._n_lidar_rays = n_lidar_rays
+        self._obs_dim      = BASE_OBS_DIM + n_lidar_rays
+        self._scales       = obs_scales_with_lidar(n_lidar_rays)
+
+        h    = hidden_size
+        c_in = h + self._obs_dim
+        rng  = np.random.default_rng(seed)
+        gain = np.sqrt(2.0 / c_in)
+
+        self._W_f = rng.standard_normal((h, c_in)).astype(np.float32) * gain
+        self._b_f = np.zeros(h, dtype=np.float32)
+        self._W_i = rng.standard_normal((h, c_in)).astype(np.float32) * gain
+        self._b_i = np.zeros(h, dtype=np.float32)
+        self._W_g = rng.standard_normal((h, c_in)).astype(np.float32) * gain
+        self._b_g = np.zeros(h, dtype=np.float32)
+        self._W_o = rng.standard_normal((h, c_in)).astype(np.float32) * gain
+        self._b_o = np.zeros(h, dtype=np.float32)
+
+        self._W_steer = rng.standard_normal(h).astype(np.float32) * np.sqrt(2.0 / h)
+        self._W_accel = rng.standard_normal(h).astype(np.float32) * np.sqrt(2.0 / h)
+        self._W_brake = rng.standard_normal(h).astype(np.float32) * np.sqrt(2.0 / h)
+
+        self._h = np.zeros(h, dtype=np.float32)
+        self._c = np.zeros(h, dtype=np.float32)
+
+    # ------------------------------------------------------------------
+    # Flat parameter interface (used by LSTMEvolutionPolicy)
+    # ------------------------------------------------------------------
+
+    @property
+    def flat_dim(self) -> int:
+        h    = self._hidden_size
+        c_in = h + self._obs_dim
+        return 4 * (h * c_in + h) + 3 * h
+
+    def to_flat(self) -> np.ndarray:
+        return np.concatenate([
+            self._W_f.ravel(), self._b_f,
+            self._W_i.ravel(), self._b_i,
+            self._W_g.ravel(), self._b_g,
+            self._W_o.ravel(), self._b_o,
+            self._W_steer,
+            self._W_accel,
+            self._W_brake,
+        ]).astype(np.float32)
+
+    def with_flat(self, flat: np.ndarray) -> "LSTMPolicy":
+        """Return a new LSTMPolicy whose weights come from a flat parameter vector."""
+        obj = object.__new__(LSTMPolicy)
+        obj._hidden_size  = self._hidden_size
+        obj._n_lidar_rays = self._n_lidar_rays
+        obj._obs_dim      = self._obs_dim
+        obj._scales       = self._scales
+
+        h    = self._hidden_size
+        c_in = h + self._obs_dim
+        flat = np.asarray(flat, dtype=np.float32)
+
+        off = 0
+        def _take(shape: tuple) -> np.ndarray:
+            nonlocal off
+            n   = int(np.prod(shape))
+            out = flat[off: off + n].reshape(shape).copy()
+            off += n
+            return out
+
+        obj._W_f    = _take((h, c_in))
+        obj._b_f    = _take((h,))
+        obj._W_i    = _take((h, c_in))
+        obj._b_i    = _take((h,))
+        obj._W_g    = _take((h, c_in))
+        obj._b_g    = _take((h,))
+        obj._W_o    = _take((h, c_in))
+        obj._b_o    = _take((h,))
+        obj._W_steer = _take((h,))
+        obj._W_accel = _take((h,))
+        obj._W_brake = _take((h,))
+        obj._h      = np.zeros(h, dtype=np.float32)
+        obj._c      = np.zeros(h, dtype=np.float32)
+        return obj
+
+    def mutated(self, scale: float, **_) -> "LSTMPolicy":
+        """Return a new LSTMPolicy with Gaussian noise applied to all parameters."""
+        flat  = self.to_flat()
+        noise = np.random.default_rng().standard_normal(len(flat)).astype(np.float32)
+        return self.with_flat(flat + scale * noise)
+
+    # ------------------------------------------------------------------
+    # Policy interface
+    # ------------------------------------------------------------------
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        x  = (obs / self._scales).astype(np.float32)
+        hx = np.concatenate([self._h, x])
+
+        f = _sigmoid(self._W_f @ hx + self._b_f)
+        i = _sigmoid(self._W_i @ hx + self._b_i)
+        g = np.tanh(self._W_g   @ hx + self._b_g)
+        o = _sigmoid(self._W_o  @ hx + self._b_o)
+
+        self._c = f * self._c + i * g
+        self._h = o * np.tanh(self._c)
+
+        steer = float(np.tanh(np.dot(self._W_steer, self._h)))
+        accel = float(_sigmoid(np.dot(self._W_accel, self._h)) > 0.5)
+        brake = float(_sigmoid(np.dot(self._W_brake, self._h)) > 0.5)
+        return np.array([steer, accel, brake], dtype=np.float32)
+
+    def update(self, obs: np.ndarray, action: np.ndarray | int, reward: float,
+               next_obs: np.ndarray, done: bool) -> None:
+        pass  # no online update; training via outer evolutionary optimiser
+
+    def on_episode_end(self) -> None:
+        self._h = np.zeros(self._hidden_size, dtype=np.float32)
+        self._c = np.zeros(self._hidden_size, dtype=np.float32)
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type": "lstm",
+            "hidden_size": self._hidden_size,
+            "n_lidar_rays": self._n_lidar_rays,
+            "obs_dim":     self._obs_dim,
+            "W_f": self._W_f.tolist(), "b_f": self._b_f.tolist(),
+            "W_i": self._W_i.tolist(), "b_i": self._b_i.tolist(),
+            "W_g": self._W_g.tolist(), "b_g": self._b_g.tolist(),
+            "W_o": self._W_o.tolist(), "b_o": self._b_o.tolist(),
+            "W_steer": self._W_steer.tolist(),
+            "W_accel": self._W_accel.tolist(),
+            "W_brake": self._W_brake.tolist(),
+        }
+
+    @classmethod
+    def from_cfg(cls, cfg: dict) -> "LSTMPolicy":
+        obj = object.__new__(cls)
+        obj._hidden_size  = int(cfg["hidden_size"])
+        obj._n_lidar_rays = int(cfg.get("n_lidar_rays", 0))
+        obj._obs_dim      = int(cfg.get("obs_dim", BASE_OBS_DIM + obj._n_lidar_rays))
+        obj._scales       = obs_scales_with_lidar(obj._n_lidar_rays)
+        obj._W_f    = np.array(cfg["W_f"],    dtype=np.float32)
+        obj._b_f    = np.array(cfg["b_f"],    dtype=np.float32)
+        obj._W_i    = np.array(cfg["W_i"],    dtype=np.float32)
+        obj._b_i    = np.array(cfg["b_i"],    dtype=np.float32)
+        obj._W_g    = np.array(cfg["W_g"],    dtype=np.float32)
+        obj._b_g    = np.array(cfg["b_g"],    dtype=np.float32)
+        obj._W_o    = np.array(cfg["W_o"],    dtype=np.float32)
+        obj._b_o    = np.array(cfg["b_o"],    dtype=np.float32)
+        obj._W_steer = np.array(cfg["W_steer"], dtype=np.float32)
+        obj._W_accel = np.array(cfg["W_accel"], dtype=np.float32)
+        obj._W_brake = np.array(cfg["W_brake"], dtype=np.float32)
+        h = obj._hidden_size
+        obj._h = np.zeros(h, dtype=np.float32)
+        obj._c = np.zeros(h, dtype=np.float32)
+        return obj
+
+
+# ---------------------------------------------------------------------------
+# LSTMEvolutionPolicy
+# ---------------------------------------------------------------------------
+
+class LSTMEvolutionPolicy(BasePolicy):
+    """
+    (μ/μ_w, λ)-ES outer optimiser wrapping LSTMPolicy as the inner individual.
+
+    Uses the _greedy_loop_cmaes interface: sample_population() / update_distribution().
+    Maintains an isotropic Gaussian search distribution (no full covariance matrix —
+    infeasible for the ~7 K-dimensional LSTM parameter space).
+    Step size is adapted via the 1/5 success rule.
+
+    Inference delegates to the champion LSTMPolicy.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int = 32,
+        population_size: int = 20,
+        initial_sigma: float = 0.05,
+        n_lidar_rays: int = 0,
+        seed: int | None = None,
+    ) -> None:
+        self._lam          = int(population_size)
+        self._sigma        = float(initial_sigma)
+        self._n_lidar_rays = n_lidar_rays
+        self._rng          = np.random.default_rng(seed)
+
+        self._template = LSTMPolicy(hidden_size=hidden_size, n_lidar_rays=n_lidar_rays)
+        self._flat_dim = self._template.flat_dim
+        self._mean     = self._template.to_flat().astype(np.float64)
+
+        # Weighted recombination (log-based, top-mu elites)
+        mu         = self._lam // 2
+        self._mu   = mu
+        raw_w      = np.array([np.log(mu + 0.5) - np.log(i + 1)
+                               for i in range(mu)], dtype=np.float64)
+        self._recomb_w = raw_w / raw_w.sum()
+
+        self._pop: list[np.ndarray] = []
+        self._champion: LSTMPolicy | None        = None
+        self._champion_reward: float             = float("-inf")
+
+    @property
+    def population_size(self) -> int:
+        return self._lam
+
+    @property
+    def champion_reward(self) -> float:
+        return self._champion_reward
+
+    @property
+    def sigma(self) -> float:
+        return self._sigma
+
+    def initialize_from_champion(self, champion: LSTMPolicy) -> None:
+        self._champion = champion
+        self._mean     = champion.to_flat().astype(np.float64)
+        logger.info("[LSTMEvolutionPolicy] seeded mean from champion")
+
+    def sample_population(self) -> list[LSTMPolicy]:
+        self._pop = []
+        for _ in range(self._lam):
+            z = self._rng.standard_normal(self._flat_dim)
+            self._pop.append(self._mean + self._sigma * z)
+        return [self._template.with_flat(x) for x in self._pop]
+
+    def update_distribution(self, rewards: list[float]) -> bool:
+        if len(rewards) != self._lam:
+            raise ValueError(f"Expected {self._lam} rewards, got {len(rewards)}")
+
+        order     = np.argsort(rewards)[::-1]
+        prev_best = self._champion_reward
+        improved  = False
+
+        best_r = rewards[order[0]]
+        if best_r > self._champion_reward:
+            self._champion_reward = best_r
+            self._champion        = self._template.with_flat(
+                np.array(self._pop[order[0]], dtype=np.float32)
+            )
+            improved = True
+
+        # Weighted mean recombination (top-mu elites)
+        elite_xs   = np.stack([self._pop[order[i]] for i in range(self._mu)])
+        self._mean = np.einsum("i,ij->j", self._recomb_w, elite_xs)
+
+        # 1/5 success rule for isotropic step-size adaptation
+        n_success    = sum(1 for r in rewards if r > prev_best)
+        success_rate = n_success / self._lam
+        self._sigma  = float(np.clip(
+            self._sigma * (1.2 if success_rate > 0.2 else 0.85),
+            1e-6, 1e2,
+        ))
+
+        return improved
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        if self._champion is None:
+            raise RuntimeError(
+                "LSTMEvolutionPolicy: no champion yet — call sample_population() "
+                "and update_distribution() for at least one generation first."
+            )
+        return self._champion(obs)
+
+    def on_episode_end(self) -> None:
+        if self._champion is not None:
+            self._champion.on_episode_end()
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type":    "lstm",
+            "hidden_size":    self._template._hidden_size,
+            "population_size": self._lam,
+            "sigma":          float(self._sigma),
+            "n_lidar_rays":   self._n_lidar_rays,
+            "champion_reward": float(self._champion_reward),
+        }
+
+    def save(self, path: str) -> None:
+        if self._champion is not None:
+            self._champion.save(path)

--- a/games/tmnf/policies.py
+++ b/games/tmnf/policies.py
@@ -966,6 +966,51 @@ class LSTMEvolutionPolicy(BasePolicy):
         return self._sigma
 
     def initialize_from_champion(self, champion: LSTMPolicy) -> None:
+        champion_flat_dim = champion.flat_dim
+        expected_hidden_size = getattr(self._template, "_hidden_size", None)
+        champion_hidden_size = getattr(champion, "_hidden_size", None)
+        expected_obs_dim = getattr(self._template, "obs_dim", None)
+        champion_obs_dim = getattr(champion, "obs_dim", None)
+        expected_lidar_rays = getattr(self, "_n_lidar_rays", None)
+        champion_lidar_rays = getattr(champion, "_n_lidar_rays", None)
+
+        mismatch_reasons: list[str] = []
+        if champion_flat_dim != self._flat_dim:
+            mismatch_reasons.append(
+                f"flat_dim mismatch (expected {self._flat_dim}, got {champion_flat_dim})"
+            )
+        if (
+            expected_hidden_size is not None
+            and champion_hidden_size is not None
+            and champion_hidden_size != expected_hidden_size
+        ):
+            mismatch_reasons.append(
+                "hidden_size mismatch "
+                f"(expected {expected_hidden_size}, got {champion_hidden_size})"
+            )
+        if (
+            expected_obs_dim is not None
+            and champion_obs_dim is not None
+            and champion_obs_dim != expected_obs_dim
+        ):
+            mismatch_reasons.append(
+                f"obs_dim mismatch (expected {expected_obs_dim}, got {champion_obs_dim})"
+            )
+        if (
+            expected_lidar_rays is not None
+            and champion_lidar_rays is not None
+            and champion_lidar_rays != expected_lidar_rays
+        ):
+            mismatch_reasons.append(
+                "n_lidar_rays mismatch "
+                f"(expected {expected_lidar_rays}, got {champion_lidar_rays})"
+            )
+
+        if mismatch_reasons:
+            raise ValueError(
+                "Cannot initialize LSTMEvolutionPolicy from an incompatible champion: "
+                + "; ".join(mismatch_reasons)
+            )
         self._champion = champion
         self._mean     = champion.to_flat().astype(np.float64)
         logger.info("[LSTMEvolutionPolicy] seeded mean from champion")

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from framework.training import train_rl
 from games.tmnf.obs_spec import TMNF_OBS_SPEC
 from games.tmnf.actions import DISCRETE_ACTIONS, PROBE_ACTIONS, WARMUP_ACTION
 from games.tmnf.env import make_env
-from games.tmnf.policies import NeuralDQNPolicy, CMAESPolicy
+from games.tmnf.policies import NeuralDQNPolicy, CMAESPolicy, REINFORCEPolicy, LSTMPolicy, LSTMEvolutionPolicy
 from analytics import save_experiment_results  # backward-compat shim
 
 logger = logging.getLogger(__name__)
@@ -121,8 +121,51 @@ def main() -> None:
             policy.initialize_random()
         return policy
 
-    extra_policy_types = {"neural_dqn": _make_neural_dqn, "cmaes": _make_cmaes}
-    extra_loop_dispatch = {"neural_dqn": "q_learning", "cmaes": "cmaes"}
+    def _make_reinforce() -> REINFORCEPolicy:
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as _f:
+                _cfg = yaml.safe_load(_f) or {}
+            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "reinforce":
+                return REINFORCEPolicy.from_cfg(_cfg, n_lidar_rays=n_lidar_rays)
+        return REINFORCEPolicy(
+            hidden_sizes  = policy_params.get("hidden_sizes",  [64, 64]),
+            learning_rate = policy_params.get("learning_rate", 0.001),
+            gamma         = policy_params.get("gamma",         0.99),
+            entropy_coeff = policy_params.get("entropy_coeff", 0.01),
+            baseline      = policy_params.get("baseline",      "running_mean"),
+            n_lidar_rays  = n_lidar_rays,
+        )
+
+    def _make_lstm() -> LSTMEvolutionPolicy:
+        hidden_size = policy_params.get("hidden_size",     32)
+        pop_size    = policy_params.get("population_size", 20)
+        sigma       = policy_params.get("initial_sigma",   0.05)
+        policy      = LSTMEvolutionPolicy(
+            hidden_size     = hidden_size,
+            population_size = pop_size,
+            initial_sigma   = sigma,
+            n_lidar_rays    = n_lidar_rays,
+        )
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as _f:
+                _cfg = yaml.safe_load(_f) or {}
+            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "lstm":
+                champion = LSTMPolicy.from_cfg(_cfg)
+                policy.initialize_from_champion(champion)
+        return policy
+
+    extra_policy_types = {
+        "neural_dqn": _make_neural_dqn,
+        "cmaes":      _make_cmaes,
+        "reinforce":  _make_reinforce,
+        "lstm":       _make_lstm,
+    }
+    extra_loop_dispatch = {
+        "neural_dqn": "q_learning",
+        "cmaes":      "cmaes",
+        "reinforce":  "q_learning",
+        "lstm":       "cmaes",
+    }
 
     data = train_rl(
         experiment_name     = args.experiment,

--- a/main.py
+++ b/main.py
@@ -150,6 +150,18 @@ def main() -> None:
             with open(weights_file) as _f:
                 _cfg = yaml.safe_load(_f) or {}
             if isinstance(_cfg, dict) and _cfg.get("policy_type") == "lstm":
+                saved_hidden_size = _cfg.get("hidden_size")
+                saved_n_lidar_rays = _cfg.get("n_lidar_rays")
+                if saved_hidden_size is not None and saved_hidden_size != hidden_size:
+                    raise ValueError(
+                        "Saved LSTM champion hidden_size does not match current run: "
+                        f"saved={saved_hidden_size}, current={hidden_size}"
+                    )
+                if saved_n_lidar_rays is not None and saved_n_lidar_rays != n_lidar_rays:
+                    raise ValueError(
+                        "Saved LSTM champion n_lidar_rays does not match current run: "
+                        f"saved={saved_n_lidar_rays}, current={n_lidar_rays}"
+                    )
                 champion = LSTMPolicy.from_cfg(_cfg)
                 policy.initialize_from_champion(champion)
         return policy

--- a/policies.py
+++ b/policies.py
@@ -42,6 +42,9 @@ from games.tmnf.policies import (  # noqa: F401
     ReplayBuffer,
     NeuralDQNPolicy,
     CMAESPolicy,
+    REINFORCEPolicy,
+    LSTMPolicy,
+    LSTMEvolutionPolicy,
 )
 
 logger = logging.getLogger(__name__)

--- a/tests/test_lstm_policy.py
+++ b/tests/test_lstm_policy.py
@@ -134,6 +134,11 @@ class TestLSTMFlatInterface(unittest.TestCase):
         np.testing.assert_array_almost_equal(
             self.policy._W_steer, policy2._W_steer, decimal=6)
 
+    def test_with_flat_wrong_size_raises(self):
+        wrong_flat = np.zeros(self.policy.flat_dim + 1, dtype=np.float32)
+        with self.assertRaises(ValueError):
+            self.policy.with_flat(wrong_flat)
+
     def test_mutated_differs_from_original(self):
         mutant = self.policy.mutated(scale=0.1)
         flat_o = self.policy.to_flat()
@@ -288,6 +293,12 @@ class TestLSTMEvolutionPolicyUpdate(unittest.TestCase):
         policy = self._setup()
         with self.assertRaises(ValueError):
             policy.update_distribution([0.0] * 5)  # wrong count
+
+    def test_update_without_sample_raises(self):
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=8, seed=0)
+        # Never called sample_population() — _pop is empty
+        with self.assertRaises(RuntimeError):
+            policy.update_distribution([0.0] * 8)
 
     def test_sigma_adapts(self):
         policy   = self._setup()

--- a/tests/test_lstm_policy.py
+++ b/tests/test_lstm_policy.py
@@ -1,0 +1,393 @@
+"""Tests for LSTMPolicy and LSTMEvolutionPolicy in games/tmnf/policies.py."""
+import unittest
+
+import numpy as np
+
+from policies import LSTMPolicy, LSTMEvolutionPolicy
+from games.tmnf.obs_spec import BASE_OBS_DIM
+
+
+_OBS_DIM = BASE_OBS_DIM
+
+
+def _zero_obs(n_lidar_rays: int = 0) -> np.ndarray:
+    return np.zeros(_OBS_DIM + n_lidar_rays, dtype=np.float32)
+
+
+def _rand_obs(n_lidar_rays: int = 0, seed: int = 0) -> np.ndarray:
+    return np.random.default_rng(seed).standard_normal(_OBS_DIM + n_lidar_rays).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# LSTMPolicy unit tests
+# ---------------------------------------------------------------------------
+
+class TestLSTMPolicyStructure(unittest.TestCase):
+
+    def setUp(self):
+        self.policy = LSTMPolicy(hidden_size=8, n_lidar_rays=0, seed=0)
+
+    def test_action_shape(self):
+        action = self.policy(_zero_obs())
+        self.assertEqual(action.shape, (3,))
+
+    def test_steer_in_range(self):
+        for _ in range(20):
+            action = self.policy(_zero_obs())
+            self.assertGreaterEqual(float(action[0]), -1.0)
+            self.assertLessEqual(float(action[0]),     1.0)
+
+    def test_accel_binary(self):
+        for _ in range(20):
+            action = self.policy(_zero_obs())
+            self.assertIn(float(action[1]), (0.0, 1.0))
+
+    def test_brake_binary(self):
+        for _ in range(20):
+            action = self.policy(_zero_obs())
+            self.assertIn(float(action[2]), (0.0, 1.0))
+
+    def test_hidden_state_updates_after_call(self):
+        h_before = self.policy._h.copy()
+        c_before = self.policy._c.copy()
+        self.policy(_rand_obs())
+        self.assertFalse(np.allclose(self.policy._h, h_before) and
+                         np.allclose(self.policy._c, c_before),
+                         "Hidden state (h, c) did not change after __call__")
+
+    def test_episode_reset_zeros_hidden_state(self):
+        # Drive the hidden state to non-zero values
+        for _ in range(5):
+            self.policy(_rand_obs())
+        self.policy.on_episode_end()
+        np.testing.assert_array_equal(self.policy._h, np.zeros(8))
+        np.testing.assert_array_equal(self.policy._c, np.zeros(8))
+
+    def test_update_is_noop(self):
+        obs    = _zero_obs()
+        w_snap = [w.copy() for w in [
+            self.policy._W_f, self.policy._W_i,
+            self.policy._W_g, self.policy._W_o,
+        ]]
+        self.policy.update(obs, np.array([0, 1, 0]), 1.0, obs, False)
+        for i, w in enumerate([self.policy._W_f, self.policy._W_i,
+                                self.policy._W_g, self.policy._W_o]):
+            np.testing.assert_array_equal(w, w_snap[i])
+
+    def test_different_history_gives_different_action(self):
+        """Same final observation but different prior history → different action."""
+        obs_seq  = [_rand_obs(seed=i) for i in range(5)]
+        final    = _rand_obs(seed=99)
+
+        policy_a = LSTMPolicy(hidden_size=16, seed=7)
+        policy_b = LSTMPolicy(hidden_size=16, seed=7)
+
+        # Feed different history to each
+        for obs in obs_seq:
+            policy_a(obs)
+        # policy_b stays at h=c=0
+
+        action_a = policy_a(final)
+        action_b = policy_b(final)
+
+        self.assertFalse(np.allclose(action_a, action_b),
+                         "Policies with different histories produced identical actions")
+
+
+class TestLSTMFlatInterface(unittest.TestCase):
+
+    def setUp(self):
+        self.policy = LSTMPolicy(hidden_size=8, n_lidar_rays=0, seed=1)
+
+    def test_flat_dim_correct(self):
+        h    = 8
+        d    = _OBS_DIM
+        c_in = h + d
+        expected = 4 * (h * c_in + h) + 3 * h
+        self.assertEqual(self.policy.flat_dim, expected)
+
+    def test_to_flat_shape(self):
+        flat = self.policy.to_flat()
+        self.assertEqual(flat.shape, (self.policy.flat_dim,))
+
+    def test_flat_roundtrip_values(self):
+        flat1  = self.policy.to_flat()
+        policy2 = self.policy.with_flat(flat1)
+        flat2  = policy2.to_flat()
+        np.testing.assert_array_almost_equal(flat1, flat2, decimal=6)
+
+    def test_with_flat_zeroed_hidden_state(self):
+        """with_flat must produce h=c=0 regardless of original state."""
+        # Advance hidden state
+        for _ in range(3):
+            self.policy(_rand_obs())
+        flat     = self.policy.to_flat()
+        policy2  = self.policy.with_flat(flat)
+        np.testing.assert_array_equal(policy2._h, np.zeros(8))
+        np.testing.assert_array_equal(policy2._c, np.zeros(8))
+
+    def test_with_flat_preserves_weights(self):
+        flat    = self.policy.to_flat()
+        policy2 = self.policy.with_flat(flat)
+        np.testing.assert_array_almost_equal(
+            self.policy._W_f, policy2._W_f, decimal=6)
+        np.testing.assert_array_almost_equal(
+            self.policy._W_steer, policy2._W_steer, decimal=6)
+
+    def test_mutated_differs_from_original(self):
+        mutant = self.policy.mutated(scale=0.1)
+        flat_o = self.policy.to_flat()
+        flat_m = mutant.to_flat()
+        self.assertFalse(np.allclose(flat_o, flat_m))
+
+    def test_mutated_same_hidden_size(self):
+        mutant = self.policy.mutated(scale=0.5)
+        self.assertEqual(mutant._hidden_size, self.policy._hidden_size)
+        self.assertEqual(mutant._obs_dim,     self.policy._obs_dim)
+
+    def test_flat_roundtrip_with_lidar(self):
+        p    = LSTMPolicy(hidden_size=4, n_lidar_rays=3, seed=5)
+        flat = p.to_flat()
+        p2   = p.with_flat(flat)
+        np.testing.assert_array_almost_equal(flat, p2.to_flat(), decimal=6)
+
+
+class TestLSTMPolicySerialisation(unittest.TestCase):
+
+    def test_to_cfg_contains_required_keys(self):
+        p   = LSTMPolicy(hidden_size=8)
+        cfg = p.to_cfg()
+        for key in ("policy_type", "hidden_size", "n_lidar_rays", "obs_dim",
+                    "W_f", "b_f", "W_i", "b_i", "W_g", "b_g", "W_o", "b_o",
+                    "W_steer", "W_accel", "W_brake"):
+            self.assertIn(key, cfg)
+
+    def test_policy_type_string(self):
+        p = LSTMPolicy(hidden_size=8)
+        self.assertEqual(p.to_cfg()["policy_type"], "lstm")
+
+    def test_from_cfg_roundtrip(self):
+        p   = LSTMPolicy(hidden_size=8, seed=3)
+        cfg = p.to_cfg()
+        p2  = LSTMPolicy.from_cfg(cfg)
+        np.testing.assert_array_almost_equal(p._W_f,    p2._W_f,    decimal=6)
+        np.testing.assert_array_almost_equal(p._W_steer, p2._W_steer, decimal=6)
+        self.assertEqual(p2._hidden_size, 8)
+        np.testing.assert_array_equal(p2._h, np.zeros(8))
+
+    def test_save_and_reload(self):
+        import tempfile, os, yaml
+        p = LSTMPolicy(hidden_size=4, seed=42)
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            path = f.name
+        try:
+            p.save(path)
+            with open(path) as f:
+                cfg = yaml.safe_load(f)
+            self.assertEqual(cfg["policy_type"], "lstm")
+            p2 = LSTMPolicy.from_cfg(cfg)
+            np.testing.assert_array_almost_equal(p._W_i, p2._W_i, decimal=5)
+        finally:
+            os.unlink(path)
+
+
+# ---------------------------------------------------------------------------
+# LSTMEvolutionPolicy unit tests
+# ---------------------------------------------------------------------------
+
+class TestLSTMEvolutionPolicyInit(unittest.TestCase):
+
+    def test_population_size_property(self):
+        policy = LSTMEvolutionPolicy(population_size=12)
+        self.assertEqual(policy.population_size, 12)
+
+    def test_sigma_property(self):
+        policy = LSTMEvolutionPolicy(initial_sigma=0.07)
+        self.assertAlmostEqual(policy.sigma, 0.07)
+
+    def test_champion_reward_starts_at_neg_inf(self):
+        policy = LSTMEvolutionPolicy()
+        self.assertEqual(policy.champion_reward, float("-inf"))
+
+    def test_flat_dim_matches_template(self):
+        policy = LSTMEvolutionPolicy(hidden_size=8)
+        self.assertEqual(policy._flat_dim, policy._template.flat_dim)
+
+    def test_mu_is_half_lambda(self):
+        policy = LSTMEvolutionPolicy(population_size=20)
+        self.assertEqual(policy._mu, 10)
+
+    def test_recomb_weights_sum_to_one(self):
+        policy = LSTMEvolutionPolicy(population_size=16)
+        self.assertAlmostEqual(float(policy._recomb_w.sum()), 1.0, places=10)
+
+
+class TestLSTMEvolutionPolicySampling(unittest.TestCase):
+
+    def test_sample_population_count(self):
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=8, seed=0)
+        pop    = policy.sample_population()
+        self.assertEqual(len(pop), 8)
+
+    def test_sample_population_returns_lstm_policies(self):
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=6, seed=1)
+        for ind in policy.sample_population():
+            self.assertIsInstance(ind, LSTMPolicy)
+
+    def test_pop_buffer_fills_on_sample(self):
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=6, seed=2)
+        policy.sample_population()
+        self.assertEqual(len(policy._pop), 6)
+
+    def test_sample_produces_distinct_individuals(self):
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=6, seed=3)
+        pop    = policy.sample_population()
+        flat_0 = pop[0].to_flat()
+        flat_1 = pop[1].to_flat()
+        self.assertFalse(np.allclose(flat_0, flat_1))
+
+
+class TestLSTMEvolutionPolicyUpdate(unittest.TestCase):
+
+    def _setup(self, pop=8, seed=0):
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=pop,
+                                      initial_sigma=0.1, seed=seed)
+        policy.sample_population()
+        return policy
+
+    def test_update_returns_true_first_time(self):
+        policy = self._setup()
+        improved = policy.update_distribution([float(i) for i in range(8)])
+        self.assertTrue(improved)
+
+    def test_update_sets_champion(self):
+        policy = self._setup()
+        policy.update_distribution([float(i) for i in range(8)])
+        self.assertIsNotNone(policy._champion)
+        self.assertIsInstance(policy._champion, LSTMPolicy)
+
+    def test_champion_reward_is_best_seen(self):
+        policy = self._setup()
+        policy.update_distribution([5.0, 99.0] + [1.0] * 6)
+        self.assertAlmostEqual(policy.champion_reward, 99.0)
+
+    def test_update_returns_false_when_no_improvement(self):
+        policy = self._setup()
+        policy.update_distribution([100.0] * 8)   # sets champion_reward = 100
+        policy.sample_population()
+        improved = policy.update_distribution([50.0] * 8)
+        self.assertFalse(improved)
+
+    def test_mean_shifts_after_update(self):
+        policy   = self._setup()
+        old_mean = policy._mean.copy()
+        policy.update_distribution([float(i) for i in range(8)])
+        self.assertFalse(np.allclose(policy._mean, old_mean))
+
+    def test_wrong_reward_count_raises(self):
+        policy = self._setup()
+        with self.assertRaises(ValueError):
+            policy.update_distribution([0.0] * 5)  # wrong count
+
+    def test_sigma_adapts(self):
+        policy   = self._setup()
+        old_sigma = policy.sigma
+        policy.update_distribution([float(i) for i in range(8)])
+        # sigma should have changed (up or down)
+        self.assertNotAlmostEqual(policy.sigma, old_sigma)
+
+
+class TestLSTMEvolutionPolicyCallable(unittest.TestCase):
+
+    def test_call_raises_before_any_update(self):
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=4, seed=0)
+        policy.sample_population()
+        with self.assertRaises(RuntimeError):
+            policy(_zero_obs())
+
+    def test_call_returns_valid_action_after_update(self):
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=4, seed=0)
+        policy.sample_population()
+        policy.update_distribution([float(i) for i in range(4)])
+        action = policy(_zero_obs())
+        self.assertEqual(action.shape, (3,))
+        self.assertGreaterEqual(float(action[0]), -1.0)
+        self.assertLessEqual(float(action[0]),     1.0)
+        self.assertIn(float(action[1]), (0.0, 1.0))
+        self.assertIn(float(action[2]), (0.0, 1.0))
+
+    def test_on_episode_end_resets_champion_hidden_state(self):
+        policy = LSTMEvolutionPolicy(hidden_size=8, population_size=4, seed=0)
+        policy.sample_population()
+        policy.update_distribution([float(i) for i in range(4)])
+        # Drive champion hidden state non-zero
+        for _ in range(3):
+            policy(_rand_obs())
+        policy.on_episode_end()
+        np.testing.assert_array_equal(policy._champion._h, np.zeros(8))
+        np.testing.assert_array_equal(policy._champion._c, np.zeros(8))
+
+
+class TestLSTMEvolutionPolicySerialisation(unittest.TestCase):
+
+    def test_to_cfg_keys(self):
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=6)
+        cfg    = policy.to_cfg()
+        for key in ("policy_type", "hidden_size", "population_size",
+                    "sigma", "n_lidar_rays", "champion_reward"):
+            self.assertIn(key, cfg)
+
+    def test_policy_type_string(self):
+        policy = LSTMEvolutionPolicy()
+        self.assertEqual(policy.to_cfg()["policy_type"], "lstm")
+
+    def test_save_writes_lstm_yaml(self):
+        import tempfile, os, yaml
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=4, seed=0)
+        policy.sample_population()
+        policy.update_distribution([float(i) for i in range(4)])
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            path = f.name
+        try:
+            policy.save(path)
+            with open(path) as f:
+                cfg = yaml.safe_load(f)
+            self.assertEqual(cfg["policy_type"], "lstm")
+            self.assertIn("W_f", cfg)
+        finally:
+            os.unlink(path)
+
+    def test_initialize_from_champion(self):
+        champion = LSTMPolicy(hidden_size=8, seed=5)
+        policy   = LSTMEvolutionPolicy(hidden_size=8, population_size=4)
+        policy.initialize_from_champion(champion)
+        np.testing.assert_array_almost_equal(
+            policy._mean, champion.to_flat().astype(np.float64), decimal=6)
+        self.assertIs(policy._champion, champion)
+
+
+class TestLSTMEvolutionConvergence(unittest.TestCase):
+
+    def test_mean_moves_toward_target(self):
+        """ES mean should move toward the minimizer of a quadratic after 20 generations."""
+        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=16,
+                                      initial_sigma=0.5, n_lidar_rays=0, seed=42)
+        target = np.ones(policy._flat_dim, dtype=np.float64)
+        initial_dist = float(np.linalg.norm(policy._mean - target))
+
+        for _ in range(20):
+            individuals = policy.sample_population()
+            rewards = [
+                -float(np.sum((ind.to_flat().astype(np.float64) - target) ** 2))
+                for ind in individuals
+            ]
+            policy.update_distribution(rewards)
+
+        final_dist = float(np.linalg.norm(policy._mean - target))
+        self.assertLess(final_dist, initial_dist,
+                        f"ES failed to converge: initial={initial_dist:.3f}, "
+                        f"final={final_dist:.3f}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_reinforce_policy.py
+++ b/tests/test_reinforce_policy.py
@@ -1,0 +1,239 @@
+"""Tests for REINFORCEPolicy in games/tmnf/policies.py."""
+import unittest
+
+import numpy as np
+
+from policies import REINFORCEPolicy
+from games.tmnf.actions import DISCRETE_ACTIONS
+from games.tmnf.obs_spec import BASE_OBS_DIM
+
+
+_OBS_DIM = BASE_OBS_DIM
+
+
+def _zero_obs(n_lidar_rays: int = 0) -> np.ndarray:
+    return np.zeros(_OBS_DIM + n_lidar_rays, dtype=np.float32)
+
+
+def _rand_obs(n_lidar_rays: int = 0, seed: int = 0) -> np.ndarray:
+    return np.random.default_rng(seed).standard_normal(
+        _OBS_DIM + n_lidar_rays).astype(np.float32)
+
+
+class TestREINFORCEPolicyStructure(unittest.TestCase):
+
+    def setUp(self):
+        self.policy = REINFORCEPolicy(hidden_sizes=[8, 8], n_lidar_rays=0, seed=0)
+
+    def test_action_shape(self):
+        action = self.policy(_zero_obs())
+        self.assertEqual(action.shape, (3,))
+
+    def test_steer_in_range(self):
+        for _ in range(20):
+            action = self.policy(_zero_obs())
+            self.assertGreaterEqual(float(action[0]), -1.0)
+            self.assertLessEqual(float(action[0]),     1.0)
+
+    def test_accel_binary(self):
+        for _ in range(20):
+            action = self.policy(_zero_obs())
+            self.assertIn(float(action[1]), (0.0, 1.0))
+
+    def test_brake_binary(self):
+        for _ in range(20):
+            action = self.policy(_zero_obs())
+            self.assertIn(float(action[2]), (0.0, 1.0))
+
+    def test_action_is_discrete(self):
+        """Returned actions must come from DISCRETE_ACTIONS."""
+        for _ in range(30):
+            action = self.policy(_zero_obs())
+            match = any(np.allclose(action, da) for da in DISCRETE_ACTIONS)
+            self.assertTrue(match, f"action {action} not in DISCRETE_ACTIONS")
+
+    def test_episode_buffers_fill_on_call(self):
+        obs = _zero_obs()
+        for _ in range(5):
+            self.policy(obs)
+            self.policy.update(obs, np.array([0, 1, 0]), 1.0, obs, False)
+        self.assertEqual(len(self.policy._ep_grads),   5)
+        self.assertEqual(len(self.policy._ep_rewards), 5)
+
+    def test_episode_buffers_clear_on_episode_end(self):
+        obs = _zero_obs()
+        self.policy(obs)
+        self.policy.update(obs, np.array([0, 1, 0]), 1.0, obs, False)
+        self.policy.on_episode_end()
+        self.assertEqual(len(self.policy._ep_grads),   0)
+        self.assertEqual(len(self.policy._ep_rewards), 0)
+
+    def test_on_episode_end_with_empty_buffer_is_noop(self):
+        # Should not raise
+        self.policy.on_episode_end()
+
+    def test_weights_match_hidden_sizes(self):
+        p = REINFORCEPolicy(hidden_sizes=[32, 16], n_lidar_rays=0)
+        dims = [_OBS_DIM, 32, 16, len(DISCRETE_ACTIONS)]
+        for i, (w, b) in enumerate(zip(p._weights, p._biases)):
+            self.assertEqual(w.shape, (dims[i + 1], dims[i]))
+            self.assertEqual(b.shape, (dims[i + 1],))
+
+
+class TestREINFORCEDiscountedReturns(unittest.TestCase):
+
+    def _run_synthetic(self, rewards):
+        """Run one synthetic episode and return gradient info."""
+        policy = REINFORCEPolicy(hidden_sizes=[8], learning_rate=0.1,
+                                 gamma=0.9, entropy_coeff=0.0, seed=42)
+        obs = _zero_obs()
+        for _ in range(len(rewards)):
+            policy(obs)
+        for r in rewards:
+            policy.update(obs, np.array([0, 1, 0]), r, obs, False)
+        return policy
+
+    def test_buffer_lengths_match(self):
+        rewards = [1.0, 2.0, 3.0]
+        policy  = self._run_synthetic(rewards)
+        self.assertEqual(len(policy._ep_grads),   len(rewards))
+        self.assertEqual(len(policy._ep_rewards), len(rewards))
+
+    def test_weights_change_after_update(self):
+        policy   = REINFORCEPolicy(hidden_sizes=[8], learning_rate=0.5,
+                                   gamma=0.99, entropy_coeff=0.0, seed=1)
+        w_before = [w.copy() for w in policy._weights]
+        obs      = _rand_obs(seed=42)
+        policy(obs)
+        policy.update(obs, np.array([0, 1, 0]), 10.0, obs, True)
+        policy.on_episode_end()
+        for i, (wb, wa) in enumerate(zip(w_before, policy._weights)):
+            self.assertFalse(np.allclose(wb, wa),
+                             f"weights[{i}] unchanged after gradient step")
+
+    def test_gradient_direction(self):
+        """
+        Acceptance criterion: after many episodes where action 7 (accel+straight)
+        always gets high reward and everything else gets zero, the log-probability
+        of action 7 should increase compared to baseline.
+
+        We verify that the logit for action 7 grows relative to action 0.
+        """
+        np.random.seed(123)
+        policy  = REINFORCEPolicy(hidden_sizes=[16], learning_rate=0.05,
+                                  gamma=1.0, entropy_coeff=0.0,
+                                  baseline="none", seed=0)
+        obs     = _rand_obs(seed=7)
+        target  = 7  # accel+straight
+
+        def _get_logit_diff():
+            # forward pass to read softmax probs
+            probs, _, _ = policy._forward(obs / policy._scales)
+            return float(probs[target]) - float(probs[0])
+
+        diff_before = _get_logit_diff()
+
+        for _ in range(200):
+            policy(obs)   # stochastic action
+            # Force override: pretend we always took action 7
+            l_in, pre_r, probs_ep, _ = policy._ep_grads[-1]
+            policy._ep_grads[-1]     = (l_in, pre_r, probs_ep, target)
+            policy.update(obs, DISCRETE_ACTIONS[target], 10.0, obs, True)
+            policy.on_episode_end()
+
+        diff_after = _get_logit_diff()
+        self.assertGreater(diff_after, diff_before,
+                           "REINFORCE did not increase probability of rewarded action")
+
+
+class TestREINFORCEEntropyCoeff(unittest.TestCase):
+
+    def test_zero_entropy_coeff_no_entropy_term(self):
+        policy = REINFORCEPolicy(hidden_sizes=[8], entropy_coeff=0.0, seed=0)
+        w_ref  = [w.copy() for w in policy._weights]
+        obs    = _rand_obs(seed=1)
+        policy(obs)
+        policy.update(obs, np.array([0, 1, 0]), 1.0, obs, True)
+        policy.on_episode_end()
+        # Just verify it ran without error and weights changed
+        changed = any(not np.allclose(w_ref[i], policy._weights[i])
+                      for i in range(len(policy._weights)))
+        self.assertTrue(changed)
+
+    def test_entropy_coeff_changes_gradient(self):
+        """Entropy term should produce different weight updates than without."""
+        obs   = _rand_obs(seed=5)
+
+        def _weights_after(entropy_coeff):
+            p = REINFORCEPolicy(hidden_sizes=[8], learning_rate=0.5,
+                                gamma=1.0, entropy_coeff=entropy_coeff, seed=77)
+            p(obs)
+            p.update(obs, np.array([0, 1, 0]), 1.0, obs, True)
+            p.on_episode_end()
+            return np.concatenate([w.ravel() for w in p._weights])
+
+        w_no_ent  = _weights_after(0.0)
+        w_with_ent = _weights_after(1.0)
+        self.assertFalse(np.allclose(w_no_ent, w_with_ent))
+
+
+class TestREINFORCECfgRoundtrip(unittest.TestCase):
+
+    def test_to_cfg_contains_required_keys(self):
+        policy = REINFORCEPolicy(hidden_sizes=[16, 8])
+        cfg    = policy.to_cfg()
+        for key in ("policy_type", "hidden_sizes", "learning_rate",
+                    "gamma", "entropy_coeff", "baseline",
+                    "n_lidar_rays", "weights", "biases"):
+            self.assertIn(key, cfg)
+
+    def test_policy_type_string(self):
+        policy = REINFORCEPolicy()
+        self.assertEqual(policy.to_cfg()["policy_type"], "reinforce")
+
+    def test_from_cfg_restores_weights(self):
+        policy = REINFORCEPolicy(hidden_sizes=[8, 4], seed=3)
+        cfg    = policy.to_cfg()
+        loaded = REINFORCEPolicy.from_cfg(cfg)
+        for w1, w2 in zip(policy._weights, loaded._weights):
+            np.testing.assert_array_equal(w1, w2)
+        for b1, b2 in zip(policy._biases, loaded._biases):
+            np.testing.assert_array_equal(b1, b2)
+
+    def test_from_cfg_restores_hyperparams(self):
+        policy = REINFORCEPolicy(hidden_sizes=[12], learning_rate=0.005,
+                                  gamma=0.95, entropy_coeff=0.02,
+                                  baseline="none")
+        cfg    = policy.to_cfg()
+        loaded = REINFORCEPolicy.from_cfg(cfg)
+        self.assertAlmostEqual(loaded._lr,           0.005)
+        self.assertAlmostEqual(loaded._gamma,        0.95)
+        self.assertAlmostEqual(loaded._entropy_coeff, 0.02)
+        self.assertEqual(loaded._baseline_type,      "none")
+
+    def test_save_and_reload(self):
+        import tempfile, os, yaml
+        policy = REINFORCEPolicy(hidden_sizes=[8], seed=9)
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            path = f.name
+        try:
+            policy.save(path)
+            with open(path) as f:
+                cfg = yaml.safe_load(f)
+            loaded = REINFORCEPolicy.from_cfg(cfg)
+            for w1, w2 in zip(policy._weights, loaded._weights):
+                np.testing.assert_array_almost_equal(w1, w2, decimal=5)
+        finally:
+            os.unlink(path)
+
+    def test_from_cfg_with_lidar(self):
+        policy = REINFORCEPolicy(hidden_sizes=[8], n_lidar_rays=4, seed=2)
+        cfg    = policy.to_cfg()
+        loaded = REINFORCEPolicy.from_cfg(cfg, n_lidar_rays=4)
+        self.assertEqual(loaded._obs_dim, BASE_OBS_DIM + 4)
+        action = loaded(_zero_obs(n_lidar_rays=4))
+        self.assertEqual(action.shape, (3,))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
REINFORCEPolicy — pure-numpy MLP with softmax over 9 discrete actions,
episode-level Monte Carlo policy gradient update, entropy regularisation,
and running-mean baseline for variance reduction.

LSTMPolicy — pure-numpy single-layer LSTM with persistent (h, c) state
across steps; on_episode_end() resets state to zeros. to_flat() /
with_flat() expose the full parameter vector for evolutionary training.

LSTMEvolutionPolicy — (μ/μ_w, λ)-ES outer optimiser wrapping LSTMPolicy;
uses isotropic Gaussian search with 1/5 success-rule σ adaptation (full
covariance is infeasible at ~7 K dims). Implements the sample_population() /
update_distribution() interface so it runs on the existing cmaes loop.

Both policies registered in main.py (reinforce→q_learning loop,
lstm→cmaes loop) and documented in config/training_params.yaml.
65 new unit tests across two test files, covering structure, gradient
direction, flat-param roundtrip, serialisation, and ES convergence.

Closes #21
Closes #22

https://claude.ai/code/session_01YZHZv67KbtHcTDb5GRo82g