### PR TITLE
Distributed grid search coordinator/worker architecture

### DIFF
--- a/config/grid_search_template.yaml
+++ b/config/grid_search_template.yaml
@@ -45,3 +45,10 @@ reward_params:
   airborne_penalty: -1.0
   crash_threshold_m: 25.0
   lidar_wall_weight: [0, -5.0, -20.0, -50.0]  # search axis: wall-proximity penalty strength
+
+# ---------------------------------------------------------------------------
+# Distributed coordinator settings (optional — only used with --distribute)
+# ---------------------------------------------------------------------------
+# distribute:
+#   port: 5555                # coordinator HTTP port (default: 5555)
+#   heartbeat_timeout: 60.0   # seconds before a silent worker is re-queued (default: 60)

--- a/distributed/__init__.py
+++ b/distributed/__init__.py
@@ -1,0 +1,1 @@
+# distributed — coordinator/worker architecture for grid search

--- a/distributed/coordinator.py
+++ b/distributed/coordinator.py
@@ -1,0 +1,248 @@
+"""
+Distributed grid-search coordinator.
+
+Hosts an HTTP server that workers poll for work and post results to.
+
+Endpoints:
+  GET  /work       → 200 + ComboSpec JSON, or 204 when queue is empty
+  POST /result     → 200 ack; stores ExperimentData from worker
+  GET  /status     → 200 + JSON summary (queue depth, done, active workers)
+  POST /heartbeat  → 200 ack; updates last-seen timestamp for a worker
+
+Usage (called automatically by grid_search.py --distribute):
+    from distributed.coordinator import Coordinator
+    from distributed.protocol import ComboSpec
+
+    combos = [ComboSpec(name=..., track=..., training_params=..., reward_params=...)]
+    coord = Coordinator(combos, port=5555, heartbeat_timeout=60.0)
+    coord.start()
+    print("Waiting for workers …")
+    all_runs = coord.wait_for_all()   # blocks until all results received
+    coord.stop()
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from collections import deque
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import ThreadingMixIn
+from typing import Any
+
+from distributed.protocol import (
+    ComboSpec,
+    combo_to_dict,
+    combo_from_dict,
+    result_from_dict,
+    experiment_from_dict,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    daemon_threads = True
+
+
+class Coordinator:
+    """Work-queue coordinator for distributed grid search.
+
+    Thread safety: all mutable state is protected by a single lock.
+    """
+
+    def __init__(
+        self,
+        combos: list[ComboSpec],
+        port: int = 5555,
+        heartbeat_timeout: float = 60.0,
+    ) -> None:
+        self._work_queue: deque[ComboSpec] = deque(combos)
+        self._in_progress: dict[str, dict[str, Any]] = {}   # name → info
+        self._results: dict[str, Any] = {}                   # name → ExperimentData
+        self._total = len(combos)
+        self._port = port
+        self._heartbeat_timeout = heartbeat_timeout
+
+        self._lock = threading.Lock()
+        self._done_event = threading.Event()
+        self._server: _ThreadingHTTPServer | None = None
+        self._server_thread: threading.Thread | None = None
+        self._monitor_thread: threading.Thread | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def start(self) -> None:
+        """Start the HTTP server and heartbeat monitor in background threads."""
+        coord = self  # captured by handler class below
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:  # type: ignore[override]
+                if self.path == "/work":
+                    coord._handle_get_work(self)
+                elif self.path == "/status":
+                    coord._handle_get_status(self)
+                else:
+                    self._send_json(404, {"error": "not found"})
+
+            def do_POST(self) -> None:  # type: ignore[override]
+                body = self._read_body()
+                if self.path == "/result":
+                    coord._handle_post_result(self, body)
+                elif self.path == "/heartbeat":
+                    coord._handle_post_heartbeat(self, body)
+                else:
+                    self._send_json(404, {"error": "not found"})
+
+            # ---- helpers ----
+
+            def _send_json(self, code: int, data: Any) -> None:
+                payload = json.dumps(data).encode()
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            def _read_body(self) -> bytes:
+                length = int(self.headers.get("Content-Length", 0))
+                return self.rfile.read(length)
+
+            def log_message(self, fmt: str, *args: Any) -> None:
+                pass  # suppress default access logging
+
+        self._server = _ThreadingHTTPServer(("", self._port), Handler)
+
+        self._server_thread = threading.Thread(
+            target=self._server.serve_forever, daemon=True, name="coord-http"
+        )
+        self._server_thread.start()
+
+        self._monitor_thread = threading.Thread(
+            target=self._heartbeat_monitor, daemon=True, name="coord-monitor"
+        )
+        self._monitor_thread.start()
+
+        logger.info("Coordinator listening on port %d (%d combo(s) queued)", self._port, self._total)
+
+    def wait_for_all(self) -> list[tuple[str, Any]]:
+        """Block until every combo has a result. Returns list of (name, ExperimentData)."""
+        if self._total == 0:
+            return []
+        self._done_event.wait()
+        with self._lock:
+            return list(self._results.items())
+
+    def stop(self) -> None:
+        """Shut down the HTTP server."""
+        if self._server:
+            self._server.shutdown()
+            self._server = None
+
+    # ------------------------------------------------------------------
+    # HTTP handlers (called on handler threads)
+    # ------------------------------------------------------------------
+
+    def _handle_get_work(self, handler: Any) -> None:
+        with self._lock:
+            if not self._work_queue:
+                handler.send_response(204)
+                handler.end_headers()
+                return
+            spec = self._work_queue.popleft()
+            worker_id = handler.headers.get("X-Worker-Id", "unknown")
+            self._in_progress[spec.name] = {
+                "spec": spec,
+                "worker_id": worker_id,
+                "last_hb": time.monotonic(),
+            }
+
+        logger.info("Dispatched %s → worker %s", spec.name, worker_id)
+        handler._send_json(200, combo_to_dict(spec))
+
+    def _handle_post_result(self, handler: Any, body: bytes) -> None:
+        try:
+            payload = result_from_dict(json.loads(body.decode()))
+            data = experiment_from_dict(json.loads(payload.data_json))
+        except Exception as exc:
+            logger.error("Failed to parse result payload: %s", exc)
+            handler._send_json(400, {"error": str(exc)})
+            return
+
+        done = False
+        with self._lock:
+            self._in_progress.pop(payload.name, None)
+            self._results[payload.name] = data
+            if len(self._results) == self._total:
+                done = True
+
+        logger.info(
+            "Received result for %s  best_reward=%+.1f  (%d/%d done)",
+            payload.name,
+            max((s.reward for s in data.greedy_sims), default=float("-inf")),
+            len(self._results),
+            self._total,
+        )
+        handler._send_json(200, {"status": "ok"})
+
+        if done:
+            self._done_event.set()
+
+    def _handle_post_heartbeat(self, handler: Any, body: bytes) -> None:
+        try:
+            d = json.loads(body.decode())
+            name = d["name"]
+            worker_id = d.get("worker_id", "unknown")
+        except Exception as exc:
+            handler._send_json(400, {"error": str(exc)})
+            return
+
+        with self._lock:
+            if name in self._in_progress:
+                self._in_progress[name]["last_hb"] = time.monotonic()
+                self._in_progress[name]["worker_id"] = worker_id
+
+        handler._send_json(200, {"status": "ok"})
+
+    def _handle_get_status(self, handler: Any) -> None:
+        with self._lock:
+            status = {
+                "queued": len(self._work_queue),
+                "in_progress": len(self._in_progress),
+                "done": len(self._results),
+                "total": self._total,
+                "workers": [
+                    {
+                        "name": name,
+                        "worker_id": info["worker_id"],
+                        "idle_s": round(time.monotonic() - info["last_hb"], 1),
+                    }
+                    for name, info in self._in_progress.items()
+                ],
+            }
+        handler._send_json(200, status)
+
+    # ------------------------------------------------------------------
+    # Heartbeat monitor
+    # ------------------------------------------------------------------
+
+    def _heartbeat_monitor(self) -> None:
+        check_interval = max(0.5, self._heartbeat_timeout / 2)
+        while not self._done_event.wait(timeout=check_interval):
+            now = time.monotonic()
+            with self._lock:
+                stale = [
+                    name
+                    for name, info in self._in_progress.items()
+                    if now - info["last_hb"] > self._heartbeat_timeout
+                ]
+                for name in stale:
+                    info = self._in_progress.pop(name)
+                    self._work_queue.appendleft(info["spec"])
+                    logger.warning(
+                        "Re-queued stale item %s (worker %s, idle %.0fs)",
+                        name, info["worker_id"], now - info["last_hb"],
+                    )

--- a/distributed/coordinator.py
+++ b/distributed/coordinator.py
@@ -34,7 +34,6 @@ from typing import Any
 from distributed.protocol import (
     ComboSpec,
     combo_to_dict,
-    combo_from_dict,
     result_from_dict,
     experiment_from_dict,
 )
@@ -59,6 +58,7 @@ class Coordinator:
         heartbeat_timeout: float = 60.0,
     ) -> None:
         self._work_queue: deque[ComboSpec] = deque(combos)
+        self._known_names: set[str] = {spec.name for spec in combos}
         self._in_progress: dict[str, dict[str, Any]] = {}   # name → info
         self._results: dict[str, Any] = {}                   # name → ExperimentData
         self._total = len(combos)
@@ -115,6 +115,7 @@ class Coordinator:
                 pass  # suppress default access logging
 
         self._server = _ThreadingHTTPServer(("", self._port), Handler)
+        actual_port = self._server.server_address[1]
 
         self._server_thread = threading.Thread(
             target=self._server.serve_forever, daemon=True, name="coord-http"
@@ -126,7 +127,14 @@ class Coordinator:
         )
         self._monitor_thread.start()
 
-        logger.info("Coordinator listening on port %d (%d combo(s) queued)", self._port, self._total)
+        logger.info("Coordinator listening on port %d (%d combo(s) queued)", actual_port, self._total)
+
+    @property
+    def port(self) -> int:
+        """The port the server is actually listening on (useful when port=0 was requested)."""
+        if self._server:
+            return self._server.server_address[1]
+        return self._port
 
     def wait_for_all(self) -> list[tuple[str, Any]]:
         """Block until every combo has a result. Returns list of (name, ExperimentData)."""
@@ -137,10 +145,16 @@ class Coordinator:
             return list(self._results.items())
 
     def stop(self) -> None:
-        """Shut down the HTTP server."""
+        """Shut down the HTTP server and background threads."""
+        self._done_event.set()  # signals monitor thread to exit
         if self._server:
             self._server.shutdown()
+            self._server.server_close()
             self._server = None
+        if self._server_thread and self._server_thread.is_alive():
+            self._server_thread.join(timeout=5)
+        if self._monitor_thread and self._monitor_thread.is_alive():
+            self._monitor_thread.join(timeout=5)
 
     # ------------------------------------------------------------------
     # HTTP handlers (called on handler threads)
@@ -164,6 +178,7 @@ class Coordinator:
         handler._send_json(200, combo_to_dict(spec))
 
     def _handle_post_result(self, handler: Any, body: bytes) -> None:
+        worker_id = handler.headers.get("X-Worker-Id", "unknown")
         try:
             payload = result_from_dict(json.loads(body.decode()))
             data = experiment_from_dict(json.loads(payload.data_json))
@@ -174,16 +189,27 @@ class Coordinator:
 
         done = False
         with self._lock:
+            if payload.name not in self._known_names:
+                logger.warning("Rejected result for unknown combo %s from worker %s", payload.name, worker_id)
+                handler._send_json(400, {"error": f"unknown combo: {payload.name}"})
+                return
+
+            if payload.name in self._results:
+                logger.info("Ignoring duplicate result for %s from worker %s", payload.name, worker_id)
+                handler._send_json(200, {"status": "ok", "ignored": "duplicate"})
+                return
+
             self._in_progress.pop(payload.name, None)
             self._results[payload.name] = data
-            if len(self._results) == self._total:
+            progress = len(self._results)
+            if progress == self._total:
                 done = True
 
         logger.info(
             "Received result for %s  best_reward=%+.1f  (%d/%d done)",
             payload.name,
             max((s.reward for s in data.greedy_sims), default=float("-inf")),
-            len(self._results),
+            progress,
             self._total,
         )
         handler._send_json(200, {"status": "ok"})

--- a/distributed/protocol.py
+++ b/distributed/protocol.py
@@ -1,0 +1,151 @@
+"""
+Shared dataclasses and JSON serialisation for distributed grid search.
+
+ComboSpec     — sent from coordinator to worker describing one work item
+ResultPayload — sent from worker back to coordinator with the result
+
+ExperimentData serialisation round-trips through dataclasses.asdict() + JSON.
+Numpy arrays are converted to lists on the way out; reconstruction is done
+via experiment_from_dict() which rebuilds the full dataclass tree.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any
+
+
+# ---------------------------------------------------------------------------
+# Wire types
+# ---------------------------------------------------------------------------
+
+@dataclasses.dataclass
+class ComboSpec:
+    """One grid-search combination, ready for a worker to execute."""
+    name: str
+    track: str
+    training_params: dict[str, Any]
+    reward_params: dict[str, Any]
+
+
+@dataclasses.dataclass
+class ResultPayload:
+    """Serialised experiment result posted by a worker to the coordinator."""
+    name: str
+    data_json: str   # ExperimentData serialised via experiment_to_json()
+
+
+# ---------------------------------------------------------------------------
+# JSON helpers
+# ---------------------------------------------------------------------------
+
+def _default(obj: Any) -> Any:
+    """Custom encoder: numpy arrays/scalars → plain Python, dataclasses → dict."""
+    try:
+        import numpy as np
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, np.integer):
+            return int(obj)
+        if isinstance(obj, np.floating):
+            return float(obj)
+    except ImportError:
+        pass
+    if dataclasses.is_dataclass(obj) and not isinstance(obj, type):
+        return dataclasses.asdict(obj)
+    raise TypeError(f"Object of type {type(obj).__name__} is not JSON serialisable")
+
+
+def experiment_to_json(data: Any) -> str:
+    """Serialise an ExperimentData instance to a JSON string."""
+    return json.dumps(dataclasses.asdict(data), default=_default)
+
+
+def experiment_from_dict(d: dict[str, Any]) -> Any:
+    """Reconstruct an ExperimentData instance from a plain dict (e.g. from JSON)."""
+    from framework.analytics import (
+        ExperimentData, RunTrace, ProbeResult,
+        ColdStartSimResult, ColdStartRestartResult, GreedySimResult,
+    )
+
+    def _trace(t: dict | None) -> RunTrace | None:
+        if t is None:
+            return None
+        return RunTrace(
+            pos_x=t.get("pos_x", []),
+            pos_z=t.get("pos_z", []),
+            throttle_state=t.get("throttle_state", []),
+            total_reward=t.get("total_reward", 0.0),
+        )
+
+    def _probe(p: dict) -> ProbeResult:
+        return ProbeResult(
+            action_idx=p["action_idx"],
+            action_name=p["action_name"],
+            reward=p["reward"],
+            trace=_trace(p.get("trace")),
+        )
+
+    def _cs_sim(s: dict) -> ColdStartSimResult:
+        return ColdStartSimResult(
+            sim=s["sim"],
+            reward=s["reward"],
+            throttle_counts=s["throttle_counts"],
+            total_steps=s["total_steps"],
+            trace=_trace(s.get("trace")),
+            termination_reason=s.get("termination_reason"),
+        )
+
+    def _cs_restart(r: dict) -> ColdStartRestartResult:
+        return ColdStartRestartResult(
+            restart=r["restart"],
+            sims=[_cs_sim(s) for s in r.get("sims", [])],
+            best_reward=r["best_reward"],
+            beat_probe_floor=r["beat_probe_floor"],
+        )
+
+    def _greedy_sim(s: dict) -> GreedySimResult:
+        return GreedySimResult(
+            sim=s["sim"],
+            reward=s["reward"],
+            improved=s["improved"],
+            throttle_counts=s["throttle_counts"],
+            total_steps=s["total_steps"],
+            trace=_trace(s.get("trace")),
+            weights=s.get("weights"),
+            final_track_progress=s.get("final_track_progress", 0.0),
+            laps_completed=s.get("laps_completed", 0),
+            mutation_scale=s.get("mutation_scale"),
+            termination_reason=s.get("termination_reason"),
+        )
+
+    return ExperimentData(
+        experiment_name=d["experiment_name"],
+        probe_results=[_probe(p) for p in d.get("probe_results", [])],
+        cold_start_restarts=[_cs_restart(r) for r in d.get("cold_start_restarts", [])],
+        greedy_sims=[_greedy_sim(s) for s in d.get("greedy_sims", [])],
+        probe_floor=d.get("probe_floor"),
+        weights_file=d.get("weights_file", ""),
+        reward_config_file=d.get("reward_config_file", ""),
+        training_params=d.get("training_params", {}),
+        timings=d.get("timings", {}),
+        track=d.get("track", ""),
+        early_stopped=d.get("early_stopped", False),
+        early_stop_sim=d.get("early_stop_sim"),
+    )
+
+
+def combo_to_dict(spec: ComboSpec) -> dict[str, Any]:
+    return dataclasses.asdict(spec)
+
+
+def combo_from_dict(d: dict[str, Any]) -> ComboSpec:
+    return ComboSpec(**d)
+
+
+def result_to_dict(payload: ResultPayload) -> dict[str, Any]:
+    return dataclasses.asdict(payload)
+
+
+def result_from_dict(d: dict[str, Any]) -> ResultPayload:
+    return ResultPayload(**d)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -27,8 +27,6 @@ import time
 import urllib.error
 import urllib.request
 
-import yaml
-
 from distributed.protocol import (
     ComboSpec,
     ResultPayload,
@@ -116,8 +114,7 @@ def run_worker(
     from games.tmnf.env import make_env
     from analytics import save_experiment_results
 
-    # Import the policy-param builder from grid_search
-    from grid_search import _build_policy_params
+    from grid_search import _build_policy_params, _setup_experiment_dir
 
     logger.info("Worker %s connecting to %s", worker_id, base)
 
@@ -131,6 +128,24 @@ def run_worker(
             continue
 
         if status == 204:
+            # Queue is empty, but items may still be in-progress (assigned to other workers
+            # that could crash). Poll /status until done == total before exiting so this
+            # worker remains available to pick up any re-queued stale items.
+            try:
+                s_status, s_body = _http_get(f"{base}/status")
+                if s_status == 200:
+                    s = json.loads(s_body.decode())
+                    if s.get("done", 0) >= s.get("total", 0):
+                        logger.info("Grid complete — worker %s exiting", worker_id)
+                        return
+                    logger.info(
+                        "Queue empty but grid not complete (%d/%d done) — waiting for re-queue",
+                        s.get("done", 0), s.get("total", 0),
+                    )
+                    time.sleep(5)
+                    continue
+            except Exception as exc:
+                logger.debug("GET /status failed: %s", exc)
             logger.info("Queue empty — worker %s exiting", worker_id)
             return
 
@@ -146,23 +161,7 @@ def run_worker(
         track = spec.track
         t = spec.training_params
         r = spec.reward_params
-        experiment_dir = f"experiments/{track}/{spec.name}"
-        weights_file = f"{experiment_dir}/policy_weights.yaml"
-        reward_cfg_file = f"{experiment_dir}/reward_config.yaml"
-        training_params_file = f"{experiment_dir}/training_params.yaml"
-        centerline_path = f"tracks/{track}.npy"
-
-        os.makedirs(experiment_dir, exist_ok=True)
-
-        with open("config/reward_config.yaml") as f:
-            reward_cfg = yaml.safe_load(f) or {}
-        reward_cfg.update(r)
-        reward_cfg["track_name"] = track
-        reward_cfg["centerline_path"] = centerline_path
-        with open(reward_cfg_file, "w") as f:
-            yaml.dump(reward_cfg, f, default_flow_style=False, sort_keys=False)
-        with open(training_params_file, "w") as f:
-            yaml.dump(t, f, default_flow_style=False, sort_keys=False)
+        experiment_dir, weights_file, reward_cfg_file = _setup_experiment_dir(spec.name, track, t, r)
 
         # --- start heartbeat ---
         hb = _HeartbeatThread(base, spec.name, worker_id, heartbeat_interval)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -1,0 +1,270 @@
+"""
+Distributed grid-search worker.
+
+Polls the coordinator for work items, runs train_rl() locally (requires a live
+TMInterface game session), and posts results back.
+
+Usage:
+    python -m distributed.worker --coordinator http://<host>:5555 [options]
+
+Options:
+    --coordinator URL    Coordinator base URL (required)
+    --worker-id ID       Identifier shown in coordinator logs (default: hostname)
+    --heartbeat-interval Seconds between heartbeat POSTs during a run (default: 15)
+    --no-interrupt       Pass --no-interrupt to each train_rl call
+    --re-initialize      Re-initialize weights for every experiment
+    --log-level LEVEL    DEBUG/INFO/WARNING/ERROR (default: INFO)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import socket
+import threading
+import time
+import urllib.error
+import urllib.request
+
+import yaml
+
+from distributed.protocol import (
+    ComboSpec,
+    ResultPayload,
+    combo_from_dict,
+    experiment_to_json,
+    result_to_dict,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers (stdlib only — no requests dependency)
+# ---------------------------------------------------------------------------
+
+def _http_get(url: str, headers: dict | None = None) -> tuple[int, bytes]:
+    req = urllib.request.Request(url, headers=headers or {})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+def _http_post(url: str, body: dict | str, headers: dict | None = None) -> tuple[int, bytes]:
+    if isinstance(body, dict):
+        data = json.dumps(body).encode()
+    else:
+        data = body.encode() if isinstance(body, str) else body
+    h = {"Content-Type": "application/json", "Content-Length": str(len(data))}
+    if headers:
+        h.update(headers)
+    req = urllib.request.Request(url, data=data, headers=h, method="POST")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return resp.status, resp.read()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read()
+
+
+# ---------------------------------------------------------------------------
+# Heartbeat thread
+# ---------------------------------------------------------------------------
+
+class _HeartbeatThread(threading.Thread):
+    """Sends POST /heartbeat to the coordinator at a fixed interval."""
+
+    def __init__(self, coordinator_url: str, combo_name: str, worker_id: str, interval: float) -> None:
+        super().__init__(daemon=True, name="worker-heartbeat")
+        self._url = f"{coordinator_url.rstrip('/')}/heartbeat"
+        self._name = combo_name
+        self._worker_id = worker_id
+        self._interval = interval
+        self._stop_event = threading.Event()
+
+    def run(self) -> None:
+        while not self._stop_event.wait(timeout=self._interval):
+            try:
+                _http_post(self._url, {"name": self._name, "worker_id": self._worker_id})
+            except Exception as exc:
+                logger.debug("Heartbeat failed: %s", exc)
+
+    def stop(self) -> None:
+        self._stop_event.set()
+
+
+# ---------------------------------------------------------------------------
+# Core worker loop
+# ---------------------------------------------------------------------------
+
+def run_worker(
+    coordinator_url: str,
+    worker_id: str,
+    heartbeat_interval: float,
+    no_interrupt: bool,
+    re_initialize: bool,
+) -> None:
+    """Poll for work, run experiments, post results. Returns when queue is empty."""
+    base = coordinator_url.rstrip("/")
+    extra_headers = {"X-Worker-Id": worker_id}
+
+    from framework.training import train_rl
+    from games.tmnf.obs_spec import TMNF_OBS_SPEC
+    from games.tmnf.actions import DISCRETE_ACTIONS, PROBE_ACTIONS, WARMUP_ACTION
+    from games.tmnf.env import make_env
+    from analytics import save_experiment_results
+
+    # Import the policy-param builder from grid_search
+    from grid_search import _build_policy_params
+
+    logger.info("Worker %s connecting to %s", worker_id, base)
+
+    while True:
+        # --- fetch work item ---
+        try:
+            status, body = _http_get(f"{base}/work", headers=extra_headers)
+        except Exception as exc:
+            logger.error("GET /work failed: %s — retrying in 5 s", exc)
+            time.sleep(5)
+            continue
+
+        if status == 204:
+            logger.info("Queue empty — worker %s exiting", worker_id)
+            return
+
+        if status != 200:
+            logger.error("GET /work returned %d — retrying in 5 s", status)
+            time.sleep(5)
+            continue
+
+        spec: ComboSpec = combo_from_dict(json.loads(body.decode()))
+        logger.info("Running experiment: %s", spec.name)
+
+        # --- prepare local experiment dir ---
+        track = spec.track
+        t = spec.training_params
+        r = spec.reward_params
+        experiment_dir = f"experiments/{track}/{spec.name}"
+        weights_file = f"{experiment_dir}/policy_weights.yaml"
+        reward_cfg_file = f"{experiment_dir}/reward_config.yaml"
+        training_params_file = f"{experiment_dir}/training_params.yaml"
+        centerline_path = f"tracks/{track}.npy"
+
+        os.makedirs(experiment_dir, exist_ok=True)
+
+        with open("config/reward_config.yaml") as f:
+            reward_cfg = yaml.safe_load(f) or {}
+        reward_cfg.update(r)
+        reward_cfg["track_name"] = track
+        reward_cfg["centerline_path"] = centerline_path
+        with open(reward_cfg_file, "w") as f:
+            yaml.dump(reward_cfg, f, default_flow_style=False, sort_keys=False)
+        with open(training_params_file, "w") as f:
+            yaml.dump(t, f, default_flow_style=False, sort_keys=False)
+
+        # --- start heartbeat ---
+        hb = _HeartbeatThread(base, spec.name, worker_id, heartbeat_interval)
+        hb.start()
+
+        # --- run training ---
+        n_lidar_rays = t.get("n_lidar_rays", 0)
+        obs_spec = TMNF_OBS_SPEC.with_lidar(n_lidar_rays)
+        try:
+            data = train_rl(
+                experiment_name=spec.name,
+                make_env_fn=lambda _dir=experiment_dir, _sp=t["speed"], _ep=t["in_game_episode_s"], _lr=n_lidar_rays: make_env(
+                    experiment_dir=_dir,
+                    speed=_sp,
+                    in_game_episode_s=_ep,
+                    n_lidar_rays=_lr,
+                ),
+                obs_spec=obs_spec,
+                head_names=["steer", "accel", "brake"],
+                discrete_actions=DISCRETE_ACTIONS,
+                speed=t["speed"],
+                n_sims=t["n_sims"],
+                in_game_episode_s=t["in_game_episode_s"],
+                weights_file=weights_file,
+                reward_config_file=reward_cfg_file,
+                mutation_scale=t["mutation_scale"],
+                mutation_share=t.get("mutation_share", 1.0),
+                probe_actions=PROBE_ACTIONS,
+                probe_in_game_s=t.get("probe_s", 0),
+                cold_start_restarts=t.get("cold_restarts", 0),
+                cold_start_sims=t.get("cold_sims", 0),
+                warmup_action=WARMUP_ACTION,
+                warmup_steps=100,
+                training_params=t,
+                no_interrupt=no_interrupt,
+                re_initialize=re_initialize,
+                policy_type=t.get("policy_type", "hill_climbing"),
+                policy_params=_build_policy_params(t),
+                track=track,
+                do_pretrain=t.get("do_pretrain", False),
+                patience=t.get("patience", 0),
+            )
+        except Exception as exc:
+            logger.error("train_rl failed for %s: %s", spec.name, exc, exc_info=True)
+            hb.stop()
+            hb.join(timeout=2)
+            continue
+        finally:
+            hb.stop()
+            hb.join(timeout=2)
+
+        # --- save local results ---
+        save_experiment_results(data, results_dir=f"{experiment_dir}/results")
+        best = max((s.reward for s in data.greedy_sims), default=float("-inf"))
+        logger.info("Finished %s  best_reward=%+.1f", spec.name, best)
+
+        # --- post result to coordinator ---
+        payload = ResultPayload(name=spec.name, data_json=experiment_to_json(data))
+        try:
+            status, _ = _http_post(f"{base}/result", json.dumps(result_to_dict(payload)))
+            if status != 200:
+                logger.error("POST /result returned %d for %s", status, spec.name)
+        except Exception as exc:
+            logger.error("POST /result failed for %s: %s", spec.name, exc)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Distributed grid-search worker — polls coordinator for work"
+    )
+    parser.add_argument("--coordinator", required=True, metavar="URL",
+                        help="Coordinator base URL, e.g. http://192.168.1.10:5555")
+    parser.add_argument("--worker-id", default=socket.gethostname(), metavar="ID",
+                        help="Identifier shown in coordinator status (default: hostname)")
+    parser.add_argument("--heartbeat-interval", type=float, default=15.0, metavar="S",
+                        help="Seconds between heartbeat POSTs (default: 15)")
+    parser.add_argument("--no-interrupt", action="store_true",
+                        help="Skip all 'Press Enter' prompts")
+    parser.add_argument("--re-initialize", action="store_true",
+                        help="Ignore existing weights files and restart from scratch")
+    parser.add_argument("--log-level", default="INFO",
+                        choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    run_worker(
+        coordinator_url=args.coordinator,
+        worker_id=args.worker_id,
+        heartbeat_interval=args.heartbeat_interval,
+        no_interrupt=args.no_interrupt,
+        re_initialize=args.re_initialize,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/grid_search.py
+++ b/grid_search.py
@@ -386,7 +386,7 @@ def main() -> None:
 
     names = []
     for c in combos:
-        name = _make_experiment_name(base_name, c["_flat"], varied_keys)
+        name = _make_experiment_name(base_name, c.get("_flat", {}), varied_keys)
         names.append(name)
         logger.info("  %s", name)
 

--- a/grid_search.py
+++ b/grid_search.py
@@ -31,11 +31,11 @@ import os
 from typing import Any
 
 import yaml
-from analytics import save_experiment_results, save_grid_summary
-from framework.training import train_rl
-from games.tmnf.obs_spec import TMNF_OBS_SPEC
-from games.tmnf.actions import DISCRETE_ACTIONS, PROBE_ACTIONS, WARMUP_ACTION
-from games.tmnf.env import make_env
+from distributed.protocol import ComboSpec
+
+# Game-specific and analytics imports are deferred to the functions that need them
+# so that importing grid_search for testing (utility functions only) doesn't require
+# a live game environment or Windows-only modules.
 
 logger = logging.getLogger(__name__)
 
@@ -132,15 +132,16 @@ def _make_experiment_name(base_name: str, combo: dict[str, Any], varied_keys: li
 # Config loading and grid expansion
 # ---------------------------------------------------------------------------
 
-def _load_grid_config(path: str) -> tuple[str, str, dict[str, Any], dict[str, Any]]:
-    """Load grid config YAML. Returns (base_name, track, training_spec, reward_spec)."""
+def _load_grid_config(path: str) -> tuple[str, str, dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Load grid config YAML. Returns (base_name, track, training_spec, reward_spec, distribute_cfg)."""
     with open(path) as f:
         cfg = yaml.safe_load(f)
     base_name = cfg.get("base_name", "gs")
     track = cfg.get("track", "a03_centerline")
     training_spec = cfg.get("training_params", {})
     reward_spec = cfg.get("reward_params", {})
-    return base_name, track, training_spec, reward_spec
+    distribute_cfg = cfg.get("distribute", {})
+    return base_name, track, training_spec, reward_spec, distribute_cfg
 
 
 def _expand_grid(training_spec: dict[str, Any], reward_spec: dict[str, Any]) -> tuple[list[dict[str, Any]], list[str]]:
@@ -209,6 +210,141 @@ def _build_policy_params(t: dict[str, Any]) -> dict[str, Any]:
 # Entry point
 # ---------------------------------------------------------------------------
 
+def _setup_experiment_dir(
+    name: str, track: str, t: dict[str, Any], r: dict[str, Any]
+) -> tuple[str, str, str]:
+    """Create experiment dir, write config files. Returns (experiment_dir, weights_file, reward_cfg_file)."""
+    centerline_path = f"tracks/{track}.npy"
+    experiment_dir = f"experiments/{track}/{name}"
+    weights_file = f"{experiment_dir}/policy_weights.yaml"
+    reward_cfg_file = f"{experiment_dir}/reward_config.yaml"
+    training_params_file = f"{experiment_dir}/training_params.yaml"
+
+    os.makedirs(experiment_dir, exist_ok=True)
+
+    with open("config/reward_config.yaml") as f:
+        reward_cfg = yaml.safe_load(f) or {}
+    reward_cfg.update(r)
+    reward_cfg["track_name"] = track
+    reward_cfg["centerline_path"] = centerline_path
+    with open(reward_cfg_file, "w") as f:
+        yaml.dump(reward_cfg, f, default_flow_style=False, sort_keys=False)
+    with open(training_params_file, "w") as f:
+        yaml.dump(t, f, default_flow_style=False, sort_keys=False)
+
+    return experiment_dir, weights_file, reward_cfg_file
+
+
+def _run_local(
+    combos: list[dict[str, Any]],
+    names: list[str],
+    track: str,
+    no_interrupt: bool,
+    re_initialize: bool,
+) -> list[tuple[str, Any]]:
+    """Run all combos sequentially on this machine. Returns list of (name, ExperimentData)."""
+    from analytics import save_experiment_results
+    from framework.training import train_rl
+    from games.tmnf.obs_spec import TMNF_OBS_SPEC
+    from games.tmnf.actions import DISCRETE_ACTIONS, PROBE_ACTIONS, WARMUP_ACTION
+    from games.tmnf.env import make_env
+
+    all_runs = []
+    n = len(combos)
+    for i, (combo, name) in enumerate(zip(combos, names), 1):
+        t = combo["training_params"]
+        r = combo["reward_params"]
+        logger.info("=== Run %d/%d: %s ===", i, n, name)
+
+        experiment_dir, weights_file, reward_cfg_file = _setup_experiment_dir(name, track, t, r)
+        n_lidar_rays = t.get("n_lidar_rays", 0)
+        obs_spec = TMNF_OBS_SPEC.with_lidar(n_lidar_rays)
+
+        data = train_rl(
+            experiment_name=name,
+            make_env_fn=lambda _dir=experiment_dir, _sp=t["speed"], _ep=t["in_game_episode_s"], _lr=n_lidar_rays: make_env(
+                experiment_dir=_dir,
+                speed=_sp,
+                in_game_episode_s=_ep,
+                n_lidar_rays=_lr,
+            ),
+            obs_spec=obs_spec,
+            head_names=["steer", "accel", "brake"],
+            discrete_actions=DISCRETE_ACTIONS,
+            speed=t["speed"],
+            n_sims=t["n_sims"],
+            in_game_episode_s=t["in_game_episode_s"],
+            weights_file=weights_file,
+            reward_config_file=reward_cfg_file,
+            mutation_scale=t["mutation_scale"],
+            mutation_share=t.get("mutation_share", 1.0),
+            probe_actions=PROBE_ACTIONS,
+            probe_in_game_s=t.get("probe_s", 0),
+            cold_start_restarts=t.get("cold_restarts", 0),
+            cold_start_sims=t.get("cold_sims", 0),
+            warmup_action=WARMUP_ACTION,
+            warmup_steps=100,
+            training_params=t,
+            no_interrupt=no_interrupt or i > 1,
+            re_initialize=re_initialize,
+            policy_type=t.get("policy_type", "hill_climbing"),
+            policy_params=_build_policy_params(t),
+            track=track,
+            do_pretrain=t.get("do_pretrain", False),
+            patience=t.get("patience", 0),
+        )
+
+        save_experiment_results(data, results_dir=f"{experiment_dir}/results")
+        all_runs.append((name, data))
+        best = max((s.reward for s in data.greedy_sims), default=float("-inf"))
+        logger.info("[%d/%d] %s  best_reward=%+.1f", i, n, name, best)
+
+    return all_runs
+
+
+def _run_distributed(
+    combos: list[dict[str, Any]],
+    names: list[str],
+    track: str,
+    port: int,
+    heartbeat_timeout: float,
+) -> list[tuple[str, Any]]:
+    """Start coordinator, write local config files, block until all results arrive."""
+    from distributed.coordinator import Coordinator
+    from analytics import save_experiment_results
+
+    # Build ComboSpec list and write local experiment dirs so reward_config_file
+    # resolves on this machine when save_grid_summary reads it.
+    combo_specs = []
+    for combo, name in zip(combos, names):
+        t = combo["training_params"]
+        r = combo["reward_params"]
+        _setup_experiment_dir(name, track, t, r)
+        combo_specs.append(ComboSpec(name=name, track=track, training_params=t, reward_params=r))
+
+    coord = Coordinator(combo_specs, port=port, heartbeat_timeout=heartbeat_timeout)
+    coord.start()
+    logger.info(
+        "Coordinator ready on port %d — start workers with:\n"
+        "  python -m distributed.worker --coordinator http://<this-host>:%d",
+        port, port,
+    )
+
+    raw_runs = coord.wait_for_all()
+    coord.stop()
+
+    # Override reward_config_file to the local path written above, then save results.
+    all_runs = []
+    for name, data in raw_runs:
+        experiment_dir = f"experiments/{track}/{name}"
+        data.reward_config_file = f"{experiment_dir}/reward_config.yaml"
+        data.weights_file = f"{experiment_dir}/policy_weights.yaml"
+        save_experiment_results(data, results_dir=f"{experiment_dir}/results")
+        all_runs.append((name, data))
+
+    return all_runs
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Grid search over TMNF training/reward params")
     parser.add_argument("config", help="Path to grid search YAML config")
@@ -217,6 +353,15 @@ def main() -> None:
     parser.add_argument("--re-initialize", action="store_true",
                         help="Start each run from fresh random small-positive weights, "
                              "ignoring any existing weights file. Skips probe and cold-start.")
+    parser.add_argument("--distribute", action="store_true",
+                        help="Act as coordinator: serve work items over HTTP and wait for "
+                             "workers to post results instead of running locally")
+    parser.add_argument("--port", type=int, default=None,
+                        help="Coordinator HTTP port when --distribute is set (default: 5555, "
+                             "or value from config distribute.port)")
+    parser.add_argument("--heartbeat-timeout", type=float, default=None,
+                        help="Seconds before a silent worker's item is re-queued "
+                             "(default: 60, or value from config distribute.heartbeat_timeout)")
     parser.add_argument("--log-level", default="INFO",
                         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
                         help="Logging verbosity (default: INFO)")
@@ -228,104 +373,31 @@ def main() -> None:
         datefmt="%H:%M:%S",
     )
 
-    logging.basicConfig(
-        level=getattr(logging, args.log_level),
-        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
-        datefmt="%H:%M:%S",
-    )
-
-    base_name, track, training_spec, reward_spec = _load_grid_config(args.config)
+    base_name, track, training_spec, reward_spec, distribute_cfg = _load_grid_config(args.config)
     combos, varied_keys = _expand_grid(training_spec, reward_spec)
-    centerline_path = f"tracks/{track}.npy"
 
     n = len(combos)
-    logger.info(f"  Grid search: {n} combination(s)")
-    logger.info(f"  Base name:   {base_name}")
-    logger.info(f"  Track:       {track}")
+    logger.info("  Grid search: %d combination(s)", n)
+    logger.info("  Base name:   %s", base_name)
+    logger.info("  Track:       %s", track)
     if varied_keys:
-        logger.info(f"  Varied:      {', '.join(varied_keys)}")
-    if varied_keys:
-        logger.info("  Varied:      %s", ', '.join(varied_keys))
-    logger.info("%s", "="*60)
+        logger.info("  Varied:      %s", ", ".join(varied_keys))
+    logger.info("%s", "=" * 60)
 
-    # Log all experiment names upfront so the user knows what's coming
     names = []
     for c in combos:
         name = _make_experiment_name(base_name, c["_flat"], varied_keys)
         names.append(name)
         logger.info("  %s", name)
 
-
-    all_runs = []   # list of (name, ExperimentData) for the summary
-
-    for i, (combo, name) in enumerate(zip(combos, names), 1):
-        t = combo["training_params"]
-        r = combo["reward_params"]
-
-        logger.info("=== Run %d/%d: %s ===", i, n, name)
-
-        experiment_dir = f"experiments/{track}/{name}"
-        weights_file   = f"{experiment_dir}/policy_weights.yaml"
-        reward_cfg_file = f"{experiment_dir}/reward_config.yaml"
-        training_params_file = f"{experiment_dir}/training_params.yaml"
-
-        os.makedirs(experiment_dir, exist_ok=True)
-
-        # Write reward config: master defaults merged with combo overrides.
-        # This ensures params not listed in the grid config (e.g. lidar_wall_weight)
-        # still get their master-config values rather than silently defaulting.
-        with open("config/reward_config.yaml") as f:
-            reward_cfg = yaml.safe_load(f) or {}
-        reward_cfg.update(r)
-        reward_cfg["track_name"] = track
-        reward_cfg["centerline_path"] = centerline_path
-        with open(reward_cfg_file, "w") as f:
-            yaml.dump(reward_cfg, f, default_flow_style=False, sort_keys=False)
-        with open(training_params_file, "w") as f:
-            yaml.dump(t, f, default_flow_style=False, sort_keys=False)
-
-        n_lidar_rays = t.get("n_lidar_rays", 0)
-        obs_spec     = TMNF_OBS_SPEC.with_lidar(n_lidar_rays)
-
-        data = train_rl(
-            experiment_name     = name,
-            make_env_fn         = lambda _dir=experiment_dir, _sp=t["speed"], _ep=t["in_game_episode_s"], _lr=n_lidar_rays: make_env(
-                experiment_dir    = _dir,
-                speed             = _sp,
-                in_game_episode_s = _ep,
-                n_lidar_rays      = _lr,
-            ),
-            obs_spec            = obs_spec,
-            head_names          = ["steer", "accel", "brake"],
-            discrete_actions    = DISCRETE_ACTIONS,
-            speed               = t["speed"],
-            n_sims              = t["n_sims"],
-            in_game_episode_s   = t["in_game_episode_s"],
-            weights_file        = weights_file,
-            reward_config_file  = reward_cfg_file,
-            mutation_scale      = t["mutation_scale"],
-            mutation_share      = t.get("mutation_share", 1.0),
-            probe_actions       = PROBE_ACTIONS,
-            probe_in_game_s     = t.get("probe_s", 0),
-            cold_start_restarts = t.get("cold_restarts", 0),
-            cold_start_sims     = t.get("cold_sims", 0),
-            warmup_action       = WARMUP_ACTION,
-            warmup_steps        = 100,
-            training_params     = t,
-            no_interrupt        = args.no_interrupt or i > 1,
-            re_initialize       = args.re_initialize,
-            policy_type         = t.get("policy_type", "hill_climbing"),
-            policy_params       = _build_policy_params(t),
-            track               = track,
-            do_pretrain         = t.get("do_pretrain", False),
-            patience            = t.get("patience", 0),
-        )
-
-        save_experiment_results(data, results_dir=f"{experiment_dir}/results")
-        all_runs.append((name, data))
-
-        best = max((s.reward for s in data.greedy_sims), default=float("-inf"))
-        logger.info("[%d/%d] %s  best_reward=%+.1f", i, n, name, best)
+    if args.distribute:
+        port = args.port or distribute_cfg.get("port", 5555)
+        hb_timeout = args.heartbeat_timeout or distribute_cfg.get("heartbeat_timeout", 60.0)
+        all_runs = _run_distributed(combos, names, track, port=port, heartbeat_timeout=hb_timeout)
+    else:
+        all_runs = _run_local(combos, names, track,
+                              no_interrupt=args.no_interrupt,
+                              re_initialize=args.re_initialize)
 
     # Final summary table
     logger.info("=== Grid search complete — %d run(s) ===", n)
@@ -337,6 +409,7 @@ def main() -> None:
         logger.info("  %-50s  %+12.1f", exp_name, best)
 
     # Cross-experiment summary report
+    from analytics import save_grid_summary
     summary_dir = f"experiments/{track}/{base_name}__summary"
     save_grid_summary(all_runs, varied_keys, summary_dir, base_name)
     logger.info("Summary report: %s/summary.md", summary_dir)

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -173,27 +173,31 @@ class TestExperimentDataSerialization:
 # ---------------------------------------------------------------------------
 
 class TestCoordinator:
-    def _start_coord(self, combos, port=15900, hb_timeout=2.0):
-        coord = Coordinator(combos, port=port, heartbeat_timeout=hb_timeout)
+    def _start_coord(self, combos, hb_timeout=30.0):
+        """Start a coordinator on an OS-assigned free port (port=0)."""
+        coord = Coordinator(combos, port=0, heartbeat_timeout=hb_timeout)
         coord.start()
+        time.sleep(0.05)  # give the server thread a moment to accept connections
         return coord
+
+    def _url(self, coord, path: str) -> str:
+        return f"http://localhost:{coord.port}{path}"
 
     def test_work_queue_serves_all_combos(self):
         import urllib.request
 
         combos = [_make_combo(f"c{i}") for i in range(3)]
-        coord = self._start_coord(combos, port=15901, hb_timeout=30.0)
-        time.sleep(0.1)
+        coord = self._start_coord(combos)
 
         names_received = []
         for _ in range(3):
-            with urllib.request.urlopen("http://localhost:15901/work", timeout=5) as r:
+            with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
                 assert r.status == 200
                 spec = combo_from_dict(json.loads(r.read()))
                 names_received.append(spec.name)
 
-        # Fourth request should be 204 (queue empty, no re-queue yet)
-        with urllib.request.urlopen("http://localhost:15901/work", timeout=5) as r:
+        # Fourth request should be 204 (queue empty, items in-progress, hb_timeout=30 s)
+        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
             assert r.status == 204
 
         coord.stop()
@@ -203,10 +207,9 @@ class TestCoordinator:
         import urllib.request
 
         combos = [_make_combo("s1"), _make_combo("s2")]
-        coord = self._start_coord(combos, port=15902)
-        time.sleep(0.1)
+        coord = self._start_coord(combos)
 
-        with urllib.request.urlopen("http://localhost:15902/status", timeout=5) as r:
+        with urllib.request.urlopen(self._url(coord, "/status"), timeout=5) as r:
             status = json.loads(r.read())
 
         assert status["total"] == 2
@@ -218,11 +221,10 @@ class TestCoordinator:
         import urllib.request
 
         combo = _make_combo("done_test")
-        coord = self._start_coord([combo], port=15903)
-        time.sleep(0.1)
+        coord = self._start_coord([combo])
 
         # Fetch work
-        with urllib.request.urlopen("http://localhost:15903/work", timeout=5) as r:
+        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
             assert r.status == 200
 
         # Post result
@@ -230,18 +232,70 @@ class TestCoordinator:
         payload = ResultPayload(name="done_test", data_json=experiment_to_json(data))
         body = json.dumps(result_to_dict(payload)).encode()
         req = urllib.request.Request(
-            "http://localhost:15903/result", data=body,
+            self._url(coord, "/result"), data=body,
             headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
             method="POST",
         )
         with urllib.request.urlopen(req, timeout=5) as r:
             assert r.status == 200
 
-        # wait_for_all should return immediately
         assert coord._done_event.is_set()
         runs = coord.wait_for_all()
         assert len(runs) == 1
         assert runs[0][0] == "done_test"
+        coord.stop()
+
+    def test_unknown_combo_name_rejected(self):
+        import urllib.request
+
+        coord = self._start_coord([_make_combo("known")])
+
+        data = _make_experiment_data_dict("unknown")
+        payload = ResultPayload(name="unknown", data_json=experiment_to_json(data))
+        body = json.dumps(result_to_dict(payload)).encode()
+        req = urllib.request.Request(
+            self._url(coord, "/result"), data=body,
+            headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
+            method="POST",
+        )
+        try:
+            urllib.request.urlopen(req, timeout=5)
+            assert False, "expected 400"
+        except urllib.error.HTTPError as e:
+            assert e.code == 400
+
+        assert not coord._done_event.is_set()
+        coord.stop()
+
+    def test_duplicate_result_ignored(self):
+        import urllib.request
+
+        combo = _make_combo("dup_test")
+        coord = self._start_coord([combo])
+
+        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
+            assert r.status == 200
+
+        def _post_result():
+            data = _make_experiment_data_dict("dup_test")
+            payload = ResultPayload(name="dup_test", data_json=experiment_to_json(data))
+            body = json.dumps(result_to_dict(payload)).encode()
+            req = urllib.request.Request(
+                self._url(coord, "/result"), data=body,
+                headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=5) as r:
+                return json.loads(r.read())
+
+        resp1 = _post_result()
+        assert resp1.get("status") == "ok"
+        assert coord._done_event.is_set()
+
+        resp2 = _post_result()
+        assert resp2.get("ignored") == "duplicate"
+        # Still only 1 result, total still 1
+        assert len(coord._results) == 1
         coord.stop()
 
     def test_stale_worker_item_requeued(self):
@@ -249,19 +303,18 @@ class TestCoordinator:
         import urllib.request
 
         combo = _make_combo("requeue_test")
-        # hb_timeout=0.5 → monitor fires every ~0.25s; item stale after 0.5s
-        coord = self._start_coord([combo], port=15904, hb_timeout=0.5)
-        time.sleep(0.1)
+        # hb_timeout=0.5 → monitor fires every 0.25 s; item stale after 0.5 s
+        coord = self._start_coord([combo], hb_timeout=0.5)
 
         # Fetch work (marks as in-progress) but send NO heartbeats
-        with urllib.request.urlopen("http://localhost:15904/work", timeout=5) as r:
+        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
             assert r.status == 200
 
         # Wait long enough for the monitor to re-queue the stale item
         time.sleep(1.5)
 
         # Item should now be back in the queue
-        with urllib.request.urlopen("http://localhost:15904/work", timeout=5) as r:
+        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
             assert r.status == 200
             spec = combo_from_dict(json.loads(r.read()))
             assert spec.name == "requeue_test"
@@ -273,10 +326,9 @@ class TestCoordinator:
         import urllib.request
 
         combo = _make_combo("hb_test")
-        coord = self._start_coord([combo], port=15905, hb_timeout=1.0)
-        time.sleep(0.1)
+        coord = self._start_coord([combo], hb_timeout=1.0)
 
-        with urllib.request.urlopen("http://localhost:15905/work", timeout=5) as r:
+        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
             assert r.status == 200
 
         # Send heartbeats every 0.3 s for 1.5 s — should keep item alive
@@ -284,7 +336,7 @@ class TestCoordinator:
             for _ in range(5):
                 body = json.dumps({"name": "hb_test", "worker_id": "tester"}).encode()
                 req = urllib.request.Request(
-                    "http://localhost:15905/heartbeat", data=body,
+                    self._url(coord, "/heartbeat"), data=body,
                     headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
                     method="POST",
                 )
@@ -299,15 +351,13 @@ class TestCoordinator:
         hb_thread.join()
 
         # Queue should still be empty (item is still in-progress, not re-queued)
-        with urllib.request.urlopen("http://localhost:15905/work", timeout=5) as r:
+        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
             assert r.status == 204
 
         coord.stop()
 
     def test_empty_queue_returns_immediately(self):
-        coord = Coordinator([], port=15906)
-        coord.start()
-        time.sleep(0.05)
+        coord = self._start_coord([])
         runs = coord.wait_for_all()
         assert runs == []
         coord.stop()

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -1,0 +1,313 @@
+"""
+Tests for distributed grid search — coordinator re-queue logic and JSON round-trip.
+
+These tests do NOT require a live TMInterface session; they use synthetic data.
+"""
+from __future__ import annotations
+
+import json
+import threading
+import time
+
+import pytest
+
+from distributed.protocol import (
+    ComboSpec,
+    ResultPayload,
+    combo_to_dict,
+    combo_from_dict,
+    result_to_dict,
+    result_from_dict,
+    experiment_to_json,
+    experiment_from_dict,
+)
+from distributed.coordinator import Coordinator
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_combo(name: str = "test_combo") -> ComboSpec:
+    return ComboSpec(
+        name=name,
+        track="a03_centerline",
+        training_params={"speed": 10.0, "n_sims": 5, "mutation_scale": 0.05,
+                         "in_game_episode_s": 30.0},
+        reward_params={"progress_weight": 10000.0},
+    )
+
+
+def _make_experiment_data_dict(name: str = "test_combo") -> dict:
+    """Return a minimal ExperimentData-compatible dict for round-trip tests."""
+    from framework.analytics import (
+        ExperimentData, GreedySimResult, RunTrace,
+    )
+    data = ExperimentData(
+        experiment_name=name,
+        probe_results=[],
+        cold_start_restarts=[],
+        greedy_sims=[
+            GreedySimResult(
+                sim=1, reward=123.4, improved=True,
+                throttle_counts=[5, 10, 85], total_steps=100,
+                trace=RunTrace(pos_x=[0.0, 1.0], pos_z=[0.0, 2.0],
+                               throttle_state=[(0, 1)], total_reward=123.4),
+            ),
+            GreedySimResult(
+                sim=2, reward=100.0, improved=False,
+                throttle_counts=[10, 10, 80], total_steps=100,
+            ),
+        ],
+        probe_floor=None,
+        weights_file="experiments/a03_centerline/test_combo/policy_weights.yaml",
+        reward_config_file="experiments/a03_centerline/test_combo/reward_config.yaml",
+        training_params={"speed": 10.0, "n_sims": 5},
+        timings={"greedy_s": 42.0},
+        track="a03_centerline",
+    )
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Protocol serialisation
+# ---------------------------------------------------------------------------
+
+class TestComboSpecSerialization:
+    def test_round_trip(self):
+        spec = _make_combo()
+        d = combo_to_dict(spec)
+        recovered = combo_from_dict(d)
+        assert recovered.name == spec.name
+        assert recovered.track == spec.track
+        assert recovered.training_params == spec.training_params
+        assert recovered.reward_params == spec.reward_params
+
+    def test_dict_is_json_serialisable(self):
+        spec = _make_combo()
+        json.dumps(combo_to_dict(spec))  # must not raise
+
+
+class TestResultPayloadSerialization:
+    def test_round_trip(self):
+        payload = ResultPayload(name="x", data_json='{"experiment_name": "x"}')
+        d = result_to_dict(payload)
+        recovered = result_from_dict(d)
+        assert recovered.name == payload.name
+        assert recovered.data_json == payload.data_json
+
+
+class TestExperimentDataSerialization:
+    def test_to_json_produces_valid_json(self):
+        data = _make_experiment_data_dict()
+        json_str = experiment_to_json(data)
+        parsed = json.loads(json_str)
+        assert parsed["experiment_name"] == "test_combo"
+
+    def test_round_trip_greedy_sims(self):
+        original = _make_experiment_data_dict()
+        json_str = experiment_to_json(original)
+        recovered = experiment_from_dict(json.loads(json_str))
+
+        assert len(recovered.greedy_sims) == 2
+        assert recovered.greedy_sims[0].reward == pytest.approx(123.4)
+        assert recovered.greedy_sims[0].improved is True
+        assert recovered.greedy_sims[1].improved is False
+
+    def test_round_trip_preserves_throttle_counts(self):
+        original = _make_experiment_data_dict()
+        recovered = experiment_from_dict(json.loads(experiment_to_json(original)))
+        assert recovered.greedy_sims[0].throttle_counts == [5, 10, 85]
+
+    def test_round_trip_preserves_trace(self):
+        original = _make_experiment_data_dict()
+        recovered = experiment_from_dict(json.loads(experiment_to_json(original)))
+        trace = recovered.greedy_sims[0].trace
+        assert trace is not None
+        assert trace.pos_x == [0.0, 1.0]
+        assert trace.total_reward == pytest.approx(123.4)
+
+    def test_round_trip_none_trace(self):
+        original = _make_experiment_data_dict()
+        recovered = experiment_from_dict(json.loads(experiment_to_json(original)))
+        assert recovered.greedy_sims[1].trace is None
+
+    def test_round_trip_metadata(self):
+        original = _make_experiment_data_dict()
+        recovered = experiment_from_dict(json.loads(experiment_to_json(original)))
+        assert recovered.training_params == {"speed": 10.0, "n_sims": 5}
+        assert recovered.timings["greedy_s"] == pytest.approx(42.0)
+        assert recovered.track == "a03_centerline"
+
+    def test_numpy_arrays_serialised(self):
+        """Numpy arrays in RunTrace should be serialised to lists without error."""
+        try:
+            import numpy as np
+        except ImportError:
+            pytest.skip("numpy not available")
+
+        from framework.analytics import ExperimentData, GreedySimResult, RunTrace
+        data = ExperimentData(
+            experiment_name="np_test",
+            probe_results=[], cold_start_restarts=[],
+            greedy_sims=[GreedySimResult(
+                sim=1, reward=1.0, improved=True,
+                throttle_counts=[0, 0, 100], total_steps=100,
+                trace=RunTrace(
+                    pos_x=np.array([1.0, 2.0, 3.0]),
+                    pos_z=np.array([4.0, 5.0, 6.0]),
+                    throttle_state=[],
+                    total_reward=1.0,
+                ),
+            )],
+            probe_floor=None, weights_file="", reward_config_file="",
+            training_params={}, timings={},
+        )
+        json_str = experiment_to_json(data)
+        recovered = experiment_from_dict(json.loads(json_str))
+        assert recovered.greedy_sims[0].trace.pos_x == [1.0, 2.0, 3.0]
+
+
+# ---------------------------------------------------------------------------
+# Coordinator — work queue and re-queue logic
+# ---------------------------------------------------------------------------
+
+class TestCoordinator:
+    def _start_coord(self, combos, port=15900, hb_timeout=2.0):
+        coord = Coordinator(combos, port=port, heartbeat_timeout=hb_timeout)
+        coord.start()
+        return coord
+
+    def test_work_queue_serves_all_combos(self):
+        import urllib.request
+
+        combos = [_make_combo(f"c{i}") for i in range(3)]
+        coord = self._start_coord(combos, port=15901, hb_timeout=30.0)
+        time.sleep(0.1)
+
+        names_received = []
+        for _ in range(3):
+            with urllib.request.urlopen("http://localhost:15901/work", timeout=5) as r:
+                assert r.status == 200
+                spec = combo_from_dict(json.loads(r.read()))
+                names_received.append(spec.name)
+
+        # Fourth request should be 204 (queue empty, no re-queue yet)
+        with urllib.request.urlopen("http://localhost:15901/work", timeout=5) as r:
+            assert r.status == 204
+
+        coord.stop()
+        assert set(names_received) == {"c0", "c1", "c2"}
+
+    def test_status_endpoint(self):
+        import urllib.request
+
+        combos = [_make_combo("s1"), _make_combo("s2")]
+        coord = self._start_coord(combos, port=15902)
+        time.sleep(0.1)
+
+        with urllib.request.urlopen("http://localhost:15902/status", timeout=5) as r:
+            status = json.loads(r.read())
+
+        assert status["total"] == 2
+        assert status["queued"] == 2
+        assert status["done"] == 0
+        coord.stop()
+
+    def test_result_accepted_and_done_event_fires(self):
+        import urllib.request
+
+        combo = _make_combo("done_test")
+        coord = self._start_coord([combo], port=15903)
+        time.sleep(0.1)
+
+        # Fetch work
+        with urllib.request.urlopen("http://localhost:15903/work", timeout=5) as r:
+            assert r.status == 200
+
+        # Post result
+        data = _make_experiment_data_dict("done_test")
+        payload = ResultPayload(name="done_test", data_json=experiment_to_json(data))
+        body = json.dumps(result_to_dict(payload)).encode()
+        req = urllib.request.Request(
+            "http://localhost:15903/result", data=body,
+            headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as r:
+            assert r.status == 200
+
+        # wait_for_all should return immediately
+        assert coord._done_event.is_set()
+        runs = coord.wait_for_all()
+        assert len(runs) == 1
+        assert runs[0][0] == "done_test"
+        coord.stop()
+
+    def test_stale_worker_item_requeued(self):
+        """An item not heartbeated within heartbeat_timeout should be re-queued."""
+        import urllib.request
+
+        combo = _make_combo("requeue_test")
+        # hb_timeout=0.5 → monitor fires every ~0.25s; item stale after 0.5s
+        coord = self._start_coord([combo], port=15904, hb_timeout=0.5)
+        time.sleep(0.1)
+
+        # Fetch work (marks as in-progress) but send NO heartbeats
+        with urllib.request.urlopen("http://localhost:15904/work", timeout=5) as r:
+            assert r.status == 200
+
+        # Wait long enough for the monitor to re-queue the stale item
+        time.sleep(1.5)
+
+        # Item should now be back in the queue
+        with urllib.request.urlopen("http://localhost:15904/work", timeout=5) as r:
+            assert r.status == 200
+            spec = combo_from_dict(json.loads(r.read()))
+            assert spec.name == "requeue_test"
+
+        coord.stop()
+
+    def test_heartbeat_prevents_requeue(self):
+        """A worker sending heartbeats should NOT have its item re-queued."""
+        import urllib.request
+
+        combo = _make_combo("hb_test")
+        coord = self._start_coord([combo], port=15905, hb_timeout=1.0)
+        time.sleep(0.1)
+
+        with urllib.request.urlopen("http://localhost:15905/work", timeout=5) as r:
+            assert r.status == 200
+
+        # Send heartbeats every 0.3 s for 1.5 s — should keep item alive
+        def send_hbs():
+            for _ in range(5):
+                body = json.dumps({"name": "hb_test", "worker_id": "tester"}).encode()
+                req = urllib.request.Request(
+                    "http://localhost:15905/heartbeat", data=body,
+                    headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
+                    method="POST",
+                )
+                try:
+                    urllib.request.urlopen(req, timeout=5)
+                except Exception:
+                    pass
+                time.sleep(0.3)
+
+        hb_thread = threading.Thread(target=send_hbs, daemon=True)
+        hb_thread.start()
+        hb_thread.join()
+
+        # Queue should still be empty (item is still in-progress, not re-queued)
+        with urllib.request.urlopen("http://localhost:15905/work", timeout=5) as r:
+            assert r.status == 204
+
+        coord.stop()
+
+    def test_empty_queue_returns_immediately(self):
+        coord = Coordinator([], port=15906)
+        coord.start()
+        time.sleep(0.05)
+        runs = coord.wait_for_all()
+        assert runs == []
+        coord.stop()

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -1,8 +1,6 @@
 """Tests for grid_search.py — grid expansion and name generation."""
 from __future__ import annotations
 
-import pytest
-
 from grid_search import _expand_grid, _make_experiment_name, _fmt_value
 
 

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -1,0 +1,99 @@
+"""Tests for grid_search.py — grid expansion and name generation."""
+from __future__ import annotations
+
+import pytest
+
+from grid_search import _expand_grid, _make_experiment_name, _fmt_value
+
+
+class TestExpandGrid:
+    def test_no_variation_returns_single_combo(self):
+        t = {"speed": 10.0, "n_sims": 50, "mutation_scale": 0.05}
+        r = {"progress_weight": 10000.0}
+        combos, varied_keys = _expand_grid(t, r)
+        assert len(combos) == 1
+        assert varied_keys == []
+        assert combos[0]["training_params"]["speed"] == 10.0
+
+    def test_single_training_axis(self):
+        t = {"mutation_scale": [0.05, 0.1, 0.2], "n_sims": 50}
+        r = {"progress_weight": 10000.0}
+        combos, varied_keys = _expand_grid(t, r)
+        assert len(combos) == 3
+        assert varied_keys == ["mutation_scale"]
+        scales = [c["training_params"]["mutation_scale"] for c in combos]
+        assert scales == [0.05, 0.1, 0.2]
+
+    def test_single_reward_axis(self):
+        t = {"n_sims": 50}
+        r = {"centerline_weight": [-0.1, -0.5]}
+        combos, varied_keys = _expand_grid(t, r)
+        assert len(combos) == 2
+        assert varied_keys == ["centerline_weight"]
+
+    def test_cartesian_product(self):
+        t = {"mutation_scale": [0.05, 0.1]}
+        r = {"centerline_weight": [-0.1, -0.5, -1.0]}
+        combos, varied_keys = _expand_grid(t, r)
+        assert len(combos) == 6   # 2 × 3
+        assert set(varied_keys) == {"mutation_scale", "centerline_weight"}
+
+    def test_fixed_params_preserved_across_combos(self):
+        t = {"speed": 10.0, "mutation_scale": [0.05, 0.1]}
+        r = {"progress_weight": 9999.0}
+        combos, _ = _expand_grid(t, r)
+        for c in combos:
+            assert c["training_params"]["speed"] == 10.0
+            assert c["reward_params"]["progress_weight"] == 9999.0
+
+    def test_flat_dict_contains_varied_values(self):
+        t = {"mutation_scale": [0.05, 0.2]}
+        r = {}
+        combos, _ = _expand_grid(t, r)
+        assert combos[0]["_flat"]["mutation_scale"] == 0.05
+        assert combos[1]["_flat"]["mutation_scale"] == 0.2
+
+    def test_no_variation_has_no_flat_key(self):
+        t = {"n_sims": 50}
+        r = {}
+        combos, _ = _expand_grid(t, r)
+        # Single-combo result has no _flat since it's not added
+        assert "_flat" not in combos[0]
+
+
+class TestMakeExperimentName:
+    def test_no_varied_keys(self):
+        name = _make_experiment_name("gs_v1", {}, [])
+        assert name == "gs_v1"
+
+    def test_single_varied_key(self):
+        name = _make_experiment_name("gs_v1", {"mutation_scale": 0.05}, ["mutation_scale"])
+        assert name == "gs_v1__ms0.05"
+
+    def test_negative_float_uses_n_prefix(self):
+        name = _make_experiment_name("gs", {"centerline_weight": -0.1}, ["centerline_weight"])
+        assert "n0.1" in name
+
+    def test_multiple_varied_keys(self):
+        flat = {"mutation_scale": 0.1, "centerline_weight": -0.5}
+        name = _make_experiment_name("gs", flat, ["mutation_scale", "centerline_weight"])
+        assert name == "gs__ms0.1__cwn0.5"
+
+    def test_unknown_key_uses_key_itself(self):
+        name = _make_experiment_name("gs", {"my_custom_param": 42}, ["my_custom_param"])
+        assert "my_custom_param42" in name
+
+
+class TestFmtValue:
+    def test_integer(self):
+        assert _fmt_value(50) == "50"
+
+    def test_float_strips_trailing_zeros(self):
+        assert _fmt_value(10.0) == "10"
+        assert _fmt_value(0.050) == "0.05"
+
+    def test_negative_float(self):
+        assert _fmt_value(-0.1) == "n0.1"
+
+    def test_string(self):
+        assert _fmt_value("hill_climbing") == "hill_climbing"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a `distributed/` package with coordinator HTTP server, worker CLI, and shared protocol dataclasses so grid-search combinations can be run across multiple machines in parallel
- `grid_search.py` gains `--distribute`, `--port`, and `--heartbeat-timeout` flags; single-machine behaviour is completely unchanged
- Full `ExperimentData` JSON round-trip (numpy-safe) so results can be transmitted over the network and aggregated on the coordinator

## New files

| File | Purpose |
|---|---|
| `distributed/protocol.py` | `ComboSpec` / `ResultPayload` dataclasses + `experiment_to_json` / `experiment_from_dict` serialisation |
| `distributed/coordinator.py` | Threading HTTP server; work queue, heartbeat monitor, automatic re-queue of silent workers |
| `distributed/worker.py` | CLI (`python -m distributed.worker --coordinator http://host:5555`); polls `/work`, runs `train_rl()`, POSTs result; background heartbeat thread |
| `tests/test_grid_search.py` | Grid expansion, name generation, fmt_value unit tests |
| `tests/test_distributed.py` | JSON round-trip, coordinator HTTP integration, re-queue logic, heartbeat prevention |

## Usage

**Coordinator (machine that owns the grid config):**
```bash
python grid_search.py config/my_grid.yaml --distribute --port 5555
```
Prints worker connection instructions and blocks until all results arrive, then runs `save_grid_summary` as normal.

**Each worker (Windows VM with TMInterface running):**
```bash
python -m distributed.worker --coordinator http://<coordinator-ip>:5555
```

## Test plan

- [x] `poetry run pytest tests/test_grid_search.py tests/test_distributed.py` — 32 tests pass
- [ ] Single-machine `python grid_search.py config/gs_v1.yaml` — no regression (lazy imports verified by test collection)
- [ ] `--distribute` end-to-end with a second machine

closes #29

https://claude.ai/code/session_01NFPGwmXCNrnEasjArA1C1g
EOF
)