### PR TITLE
Add distributed grid search with Bearer token authentication

### DIFF
--- a/distributed/coordinator.py
+++ b/distributed/coordinator.py
@@ -136,10 +136,7 @@ class Coordinator:
         )
         self._monitor_thread.start()
 
-        logger.info(
-            "Coordinator listening on port %d (%d combo(s) queued)  token: %s…",
-            actual_port, self._total, self._token[:8],
-        )
+        logger.info("Coordinator listening on port %d (%d combo(s) queued)", actual_port, self._total)
 
     @property
     def port(self) -> int:
@@ -174,9 +171,15 @@ class Coordinator:
 
     def _check_auth(self, handler: Any) -> bool:
         """Check Bearer token. Sends 401 and returns False if invalid."""
+        import hmac
         auth = handler.headers.get("Authorization", "")
         parts = auth.split(" ", 1)
-        if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1] == self._token:
+        token_ok = (
+            len(parts) == 2
+            and parts[0].lower() == "bearer"
+            and hmac.compare_digest(parts[1].strip(), self._token.strip())
+        )
+        if token_ok:
             return True
         handler.send_response(401)
         handler.send_header("WWW-Authenticate", 'Bearer realm="tmnf-grid"')

--- a/distributed/coordinator.py
+++ b/distributed/coordinator.py
@@ -3,6 +3,9 @@ Distributed grid-search coordinator.
 
 Hosts an HTTP server that workers poll for work and post results to.
 
+Authentication: every request must carry  Authorization: Bearer <token>.
+Missing or wrong token → 401 Unauthorized.
+
 Endpoints:
   GET  /work       → 200 + ComboSpec JSON, or 204 when queue is empty
   POST /result     → 200 ack; stores ExperimentData from worker
@@ -14,7 +17,7 @@ Usage (called automatically by grid_search.py --distribute):
     from distributed.protocol import ComboSpec
 
     combos = [ComboSpec(name=..., track=..., training_params=..., reward_params=...)]
-    coord = Coordinator(combos, port=5555, heartbeat_timeout=60.0)
+    coord = Coordinator(combos, token="mysecret", port=5555, heartbeat_timeout=60.0)
     coord.start()
     print("Waiting for workers …")
     all_runs = coord.wait_for_all()   # blocks until all results received
@@ -54,9 +57,11 @@ class Coordinator:
     def __init__(
         self,
         combos: list[ComboSpec],
+        token: str,
         port: int = 5555,
         heartbeat_timeout: float = 60.0,
     ) -> None:
+        self._token = token
         self._work_queue: deque[ComboSpec] = deque(combos)
         self._known_names: set[str] = {spec.name for spec in combos}
         self._in_progress: dict[str, dict[str, Any]] = {}   # name → info
@@ -81,6 +86,8 @@ class Coordinator:
 
         class Handler(BaseHTTPRequestHandler):
             def do_GET(self) -> None:  # type: ignore[override]
+                if not coord._check_auth(self):
+                    return
                 if self.path == "/work":
                     coord._handle_get_work(self)
                 elif self.path == "/status":
@@ -89,6 +96,8 @@ class Coordinator:
                     self._send_json(404, {"error": "not found"})
 
             def do_POST(self) -> None:  # type: ignore[override]
+                if not coord._check_auth(self):
+                    return
                 body = self._read_body()
                 if self.path == "/result":
                     coord._handle_post_result(self, body)
@@ -127,7 +136,10 @@ class Coordinator:
         )
         self._monitor_thread.start()
 
-        logger.info("Coordinator listening on port %d (%d combo(s) queued)", actual_port, self._total)
+        logger.info(
+            "Coordinator listening on port %d (%d combo(s) queued)  token: %s…",
+            actual_port, self._total, self._token[:8],
+        )
 
     @property
     def port(self) -> int:
@@ -155,6 +167,22 @@ class Coordinator:
             self._server_thread.join(timeout=5)
         if self._monitor_thread and self._monitor_thread.is_alive():
             self._monitor_thread.join(timeout=5)
+
+    # ------------------------------------------------------------------
+    # Auth
+    # ------------------------------------------------------------------
+
+    def _check_auth(self, handler: Any) -> bool:
+        """Check Bearer token. Sends 401 and returns False if invalid."""
+        auth = handler.headers.get("Authorization", "")
+        parts = auth.split(" ", 1)
+        if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1] == self._token:
+            return True
+        handler.send_response(401)
+        handler.send_header("WWW-Authenticate", 'Bearer realm="tmnf-grid"')
+        handler.send_header("Content-Length", "0")
+        handler.end_headers()
+        return False
 
     # ------------------------------------------------------------------
     # HTTP handlers (called on handler threads)

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -4,11 +4,15 @@ Distributed grid-search worker.
 Polls the coordinator for work items, runs train_rl() locally (requires a live
 TMInterface game session), and posts results back.
 
+Authentication: every request carries  Authorization: Bearer <token>.
+Supply the token via --token or the TMNF_GRID_TOKEN environment variable.
+
 Usage:
-    python -m distributed.worker --coordinator http://<host>:5555 [options]
+    python -m distributed.worker --coordinator http://<host>:5555 --token <secret>
 
 Options:
     --coordinator URL    Coordinator base URL (required)
+    --token SECRET       Shared secret; falls back to TMNF_GRID_TOKEN env var
     --worker-id ID       Identifier shown in coordinator logs (default: hostname)
     --heartbeat-interval Seconds between heartbeat POSTs during a run (default: 15)
     --no-interrupt       Pass --no-interrupt to each train_rl call
@@ -48,6 +52,8 @@ def _http_get(url: str, headers: dict | None = None) -> tuple[int, bytes]:
         with urllib.request.urlopen(req, timeout=30) as resp:
             return resp.status, resp.read()
     except urllib.error.HTTPError as exc:
+        if exc.code == 401:
+            raise PermissionError("401 Unauthorized — check your --token") from exc
         return exc.code, exc.read()
 
 
@@ -64,6 +70,8 @@ def _http_post(url: str, body: dict | str, headers: dict | None = None) -> tuple
         with urllib.request.urlopen(req, timeout=30) as resp:
             return resp.status, resp.read()
     except urllib.error.HTTPError as exc:
+        if exc.code == 401:
+            raise PermissionError("401 Unauthorized — check your --token") from exc
         return exc.code, exc.read()
 
 
@@ -74,18 +82,21 @@ def _http_post(url: str, body: dict | str, headers: dict | None = None) -> tuple
 class _HeartbeatThread(threading.Thread):
     """Sends POST /heartbeat to the coordinator at a fixed interval."""
 
-    def __init__(self, coordinator_url: str, combo_name: str, worker_id: str, interval: float) -> None:
+    def __init__(self, coordinator_url: str, combo_name: str, worker_id: str,
+                 interval: float, auth_headers: dict) -> None:
         super().__init__(daemon=True, name="worker-heartbeat")
         self._url = f"{coordinator_url.rstrip('/')}/heartbeat"
         self._name = combo_name
         self._worker_id = worker_id
         self._interval = interval
+        self._auth_headers = auth_headers
         self._stop_event = threading.Event()
 
     def run(self) -> None:
         while not self._stop_event.wait(timeout=self._interval):
             try:
-                _http_post(self._url, {"name": self._name, "worker_id": self._worker_id})
+                _http_post(self._url, {"name": self._name, "worker_id": self._worker_id},
+                           headers=self._auth_headers)
             except Exception as exc:
                 logger.debug("Heartbeat failed: %s", exc)
 
@@ -99,6 +110,7 @@ class _HeartbeatThread(threading.Thread):
 
 def run_worker(
     coordinator_url: str,
+    token: str,
     worker_id: str,
     heartbeat_interval: float,
     no_interrupt: bool,
@@ -106,7 +118,10 @@ def run_worker(
 ) -> None:
     """Poll for work, run experiments, post results. Returns when queue is empty."""
     base = coordinator_url.rstrip("/")
-    extra_headers = {"X-Worker-Id": worker_id}
+    auth_headers = {
+        "Authorization": f"Bearer {token}",
+        "X-Worker-Id": worker_id,
+    }
 
     from framework.training import train_rl
     from games.tmnf.obs_spec import TMNF_OBS_SPEC
@@ -121,7 +136,7 @@ def run_worker(
     while True:
         # --- fetch work item ---
         try:
-            status, body = _http_get(f"{base}/work", headers=extra_headers)
+            status, body = _http_get(f"{base}/work", headers=auth_headers)
         except Exception as exc:
             logger.error("GET /work failed: %s — retrying in 5 s", exc)
             time.sleep(5)
@@ -132,7 +147,7 @@ def run_worker(
             # that could crash). Poll /status until done == total before exiting so this
             # worker remains available to pick up any re-queued stale items.
             try:
-                s_status, s_body = _http_get(f"{base}/status")
+                s_status, s_body = _http_get(f"{base}/status", headers=auth_headers)
                 if s_status == 200:
                     s = json.loads(s_body.decode())
                     if s.get("done", 0) >= s.get("total", 0):
@@ -164,7 +179,7 @@ def run_worker(
         experiment_dir, weights_file, reward_cfg_file = _setup_experiment_dir(spec.name, track, t, r)
 
         # --- start heartbeat ---
-        hb = _HeartbeatThread(base, spec.name, worker_id, heartbeat_interval)
+        hb = _HeartbeatThread(base, spec.name, worker_id, heartbeat_interval, auth_headers)
         hb.start()
 
         # --- run training ---
@@ -221,7 +236,8 @@ def run_worker(
         # --- post result to coordinator ---
         payload = ResultPayload(name=spec.name, data_json=experiment_to_json(data))
         try:
-            status, _ = _http_post(f"{base}/result", json.dumps(result_to_dict(payload)))
+            status, _ = _http_post(f"{base}/result", json.dumps(result_to_dict(payload)),
+                                   headers=auth_headers)
             if status != 200:
                 logger.error("POST /result returned %d for %s", status, spec.name)
         except Exception as exc:
@@ -238,6 +254,8 @@ def main() -> None:
     )
     parser.add_argument("--coordinator", required=True, metavar="URL",
                         help="Coordinator base URL, e.g. http://192.168.1.10:5555")
+    parser.add_argument("--token", default=None, metavar="SECRET",
+                        help="Shared secret; falls back to TMNF_GRID_TOKEN env var")
     parser.add_argument("--worker-id", default=socket.gethostname(), metavar="ID",
                         help="Identifier shown in coordinator status (default: hostname)")
     parser.add_argument("--heartbeat-interval", type=float, default=15.0, metavar="S",
@@ -256,8 +274,13 @@ def main() -> None:
         datefmt="%H:%M:%S",
     )
 
+    token = args.token or os.environ.get("TMNF_GRID_TOKEN")
+    if not token:
+        parser.error("No token provided. Use --token <secret> or set TMNF_GRID_TOKEN env var.")
+
     run_worker(
         coordinator_url=args.coordinator,
+        token=token,
         worker_id=args.worker_id,
         heartbeat_interval=args.heartbeat_interval,
         no_interrupt=args.no_interrupt,

--- a/grid_search.py
+++ b/grid_search.py
@@ -306,6 +306,7 @@ def _run_distributed(
     combos: list[dict[str, Any]],
     names: list[str],
     track: str,
+    token: str,
     port: int,
     heartbeat_timeout: float,
 ) -> list[tuple[str, Any]]:
@@ -322,11 +323,11 @@ def _run_distributed(
         _setup_experiment_dir(name, track, t, r)
         combo_specs.append(ComboSpec(name=name, track=track, training_params=t, reward_params=r))
 
-    coord = Coordinator(combo_specs, port=port, heartbeat_timeout=heartbeat_timeout)
+    coord = Coordinator(combo_specs, token=token, port=port, heartbeat_timeout=heartbeat_timeout)
     coord.start()
     logger.info(
         "Coordinator ready on port %d — start workers with:\n"
-        "  python -m distributed.worker --coordinator http://<this-host>:%d",
+        "  python -m distributed.worker --coordinator http://<this-host>:%d --token <token>",
         port, port,
     )
 
@@ -359,6 +360,9 @@ def main() -> None:
     parser.add_argument("--port", type=int, default=None,
                         help="Coordinator HTTP port when --distribute is set (default: 5555, "
                              "or value from config distribute.port)")
+    parser.add_argument("--token", default=None, metavar="SECRET",
+                        help="Shared secret for worker authentication; falls back to "
+                             "TMNF_GRID_TOKEN env var (auto-generated UUID if neither provided)")
     parser.add_argument("--heartbeat-timeout", type=float, default=None,
                         help="Seconds before a silent worker's item is re-queued "
                              "(default: 60, or value from config distribute.heartbeat_timeout)")
@@ -391,9 +395,14 @@ def main() -> None:
         logger.info("  %s", name)
 
     if args.distribute:
+        import uuid as _uuid
         port = args.port or distribute_cfg.get("port", 5555)
         hb_timeout = args.heartbeat_timeout or distribute_cfg.get("heartbeat_timeout", 60.0)
-        all_runs = _run_distributed(combos, names, track, port=port, heartbeat_timeout=hb_timeout)
+        token = args.token or os.environ.get("TMNF_GRID_TOKEN") or str(_uuid.uuid4())
+        if not (args.token or os.environ.get("TMNF_GRID_TOKEN")):
+            logger.info("Auto-generated token: %s  (pass to workers via --token or TMNF_GRID_TOKEN)", token)
+        all_runs = _run_distributed(combos, names, track, token=token,
+                                    port=port, heartbeat_timeout=hb_timeout)
     else:
         all_runs = _run_local(combos, names, track,
                               no_interrupt=args.no_interrupt,

--- a/grid_search.py
+++ b/grid_search.py
@@ -400,7 +400,11 @@ def main() -> None:
         hb_timeout = args.heartbeat_timeout or distribute_cfg.get("heartbeat_timeout", 60.0)
         token = args.token or os.environ.get("TMNF_GRID_TOKEN") or str(_uuid.uuid4())
         if not (args.token or os.environ.get("TMNF_GRID_TOKEN")):
-            logger.info("Auto-generated token: %s  (pass to workers via --token or TMNF_GRID_TOKEN)", token)
+            token_preview = f"{token[:8]}..." if len(token) > 8 else "[redacted]"
+            logger.info(
+                "Auto-generated token for distributed run (%s). Pass it to workers via --token or TMNF_GRID_TOKEN.",
+                token_preview,
+            )
         all_runs = _run_distributed(combos, names, track, token=token,
                                     port=port, heartbeat_timeout=hb_timeout)
     else:

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -172,10 +172,13 @@ class TestExperimentDataSerialization:
 # Coordinator — work queue and re-queue logic
 # ---------------------------------------------------------------------------
 
+_TEST_TOKEN = "test-secret"
+
+
 class TestCoordinator:
     def _start_coord(self, combos, hb_timeout=30.0):
         """Start a coordinator on an OS-assigned free port (port=0)."""
-        coord = Coordinator(combos, port=0, heartbeat_timeout=hb_timeout)
+        coord = Coordinator(combos, token=_TEST_TOKEN, port=0, heartbeat_timeout=hb_timeout)
         coord.start()
         time.sleep(0.05)  # give the server thread a moment to accept connections
         return coord
@@ -183,33 +186,51 @@ class TestCoordinator:
     def _url(self, coord, path: str) -> str:
         return f"http://localhost:{coord.port}{path}"
 
-    def test_work_queue_serves_all_combos(self):
-        import urllib.request
+    def _auth_headers(self, extra: dict | None = None) -> dict:
+        h = {"Authorization": f"Bearer {_TEST_TOKEN}"}
+        if extra:
+            h.update(extra)
+        return h
 
+    def _get(self, coord, path: str):
+        import urllib.request
+        req = urllib.request.Request(self._url(coord, path), headers=self._auth_headers())
+        return urllib.request.urlopen(req, timeout=5)
+
+    def _post(self, coord, path: str, body: bytes):
+        import urllib.request
+        req = urllib.request.Request(
+            self._url(coord, path), data=body, method="POST",
+            headers=self._auth_headers({
+                "Content-Type": "application/json",
+                "Content-Length": str(len(body)),
+            }),
+        )
+        return urllib.request.urlopen(req, timeout=5)
+
+    def test_work_queue_serves_all_combos(self):
         combos = [_make_combo(f"c{i}") for i in range(3)]
         coord = self._start_coord(combos)
 
         names_received = []
         for _ in range(3):
-            with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
+            with self._get(coord, "/work") as r:
                 assert r.status == 200
                 spec = combo_from_dict(json.loads(r.read()))
                 names_received.append(spec.name)
 
         # Fourth request should be 204 (queue empty, items in-progress, hb_timeout=30 s)
-        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
+        with self._get(coord, "/work") as r:
             assert r.status == 204
 
         coord.stop()
         assert set(names_received) == {"c0", "c1", "c2"}
 
     def test_status_endpoint(self):
-        import urllib.request
-
         combos = [_make_combo("s1"), _make_combo("s2")]
         coord = self._start_coord(combos)
 
-        with urllib.request.urlopen(self._url(coord, "/status"), timeout=5) as r:
+        with self._get(coord, "/status") as r:
             status = json.loads(r.read())
 
         assert status["total"] == 2
@@ -218,25 +239,18 @@ class TestCoordinator:
         coord.stop()
 
     def test_result_accepted_and_done_event_fires(self):
-        import urllib.request
-
         combo = _make_combo("done_test")
         coord = self._start_coord([combo])
 
         # Fetch work
-        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
+        with self._get(coord, "/work") as r:
             assert r.status == 200
 
         # Post result
         data = _make_experiment_data_dict("done_test")
         payload = ResultPayload(name="done_test", data_json=experiment_to_json(data))
         body = json.dumps(result_to_dict(payload)).encode()
-        req = urllib.request.Request(
-            self._url(coord, "/result"), data=body,
-            headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
-            method="POST",
-        )
-        with urllib.request.urlopen(req, timeout=5) as r:
+        with self._post(coord, "/result", body) as r:
             assert r.status == 200
 
         assert coord._done_event.is_set()
@@ -246,20 +260,15 @@ class TestCoordinator:
         coord.stop()
 
     def test_unknown_combo_name_rejected(self):
-        import urllib.request
+        import urllib.error
 
         coord = self._start_coord([_make_combo("known")])
 
         data = _make_experiment_data_dict("unknown")
         payload = ResultPayload(name="unknown", data_json=experiment_to_json(data))
         body = json.dumps(result_to_dict(payload)).encode()
-        req = urllib.request.Request(
-            self._url(coord, "/result"), data=body,
-            headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
-            method="POST",
-        )
         try:
-            urllib.request.urlopen(req, timeout=5)
+            self._post(coord, "/result", body)
             assert False, "expected 400"
         except urllib.error.HTTPError as e:
             assert e.code == 400
@@ -268,24 +277,17 @@ class TestCoordinator:
         coord.stop()
 
     def test_duplicate_result_ignored(self):
-        import urllib.request
-
         combo = _make_combo("dup_test")
         coord = self._start_coord([combo])
 
-        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
+        with self._get(coord, "/work") as r:
             assert r.status == 200
 
         def _post_result():
             data = _make_experiment_data_dict("dup_test")
             payload = ResultPayload(name="dup_test", data_json=experiment_to_json(data))
             body = json.dumps(result_to_dict(payload)).encode()
-            req = urllib.request.Request(
-                self._url(coord, "/result"), data=body,
-                headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
-                method="POST",
-            )
-            with urllib.request.urlopen(req, timeout=5) as r:
+            with self._post(coord, "/result", body) as r:
                 return json.loads(r.read())
 
         resp1 = _post_result()
@@ -294,27 +296,24 @@ class TestCoordinator:
 
         resp2 = _post_result()
         assert resp2.get("ignored") == "duplicate"
-        # Still only 1 result, total still 1
         assert len(coord._results) == 1
         coord.stop()
 
     def test_stale_worker_item_requeued(self):
         """An item not heartbeated within heartbeat_timeout should be re-queued."""
-        import urllib.request
-
         combo = _make_combo("requeue_test")
         # hb_timeout=0.5 → monitor fires every 0.25 s; item stale after 0.5 s
         coord = self._start_coord([combo], hb_timeout=0.5)
 
         # Fetch work (marks as in-progress) but send NO heartbeats
-        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
+        with self._get(coord, "/work") as r:
             assert r.status == 200
 
         # Wait long enough for the monitor to re-queue the stale item
         time.sleep(1.5)
 
         # Item should now be back in the queue
-        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
+        with self._get(coord, "/work") as r:
             assert r.status == 200
             spec = combo_from_dict(json.loads(r.read()))
             assert spec.name == "requeue_test"
@@ -323,25 +322,18 @@ class TestCoordinator:
 
     def test_heartbeat_prevents_requeue(self):
         """A worker sending heartbeats should NOT have its item re-queued."""
-        import urllib.request
-
         combo = _make_combo("hb_test")
         coord = self._start_coord([combo], hb_timeout=1.0)
 
-        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
+        with self._get(coord, "/work") as r:
             assert r.status == 200
 
         # Send heartbeats every 0.3 s for 1.5 s — should keep item alive
         def send_hbs():
             for _ in range(5):
                 body = json.dumps({"name": "hb_test", "worker_id": "tester"}).encode()
-                req = urllib.request.Request(
-                    self._url(coord, "/heartbeat"), data=body,
-                    headers={"Content-Type": "application/json", "Content-Length": str(len(body))},
-                    method="POST",
-                )
                 try:
-                    urllib.request.urlopen(req, timeout=5)
+                    self._post(coord, "/heartbeat", body)
                 except Exception:
                     pass
                 time.sleep(0.3)
@@ -351,7 +343,7 @@ class TestCoordinator:
         hb_thread.join()
 
         # Queue should still be empty (item is still in-progress, not re-queued)
-        with urllib.request.urlopen(self._url(coord, "/work"), timeout=5) as r:
+        with self._get(coord, "/work") as r:
             assert r.status == 204
 
         coord.stop()
@@ -360,4 +352,31 @@ class TestCoordinator:
         coord = self._start_coord([])
         runs = coord.wait_for_all()
         assert runs == []
+        coord.stop()
+
+    def test_unauthorized_request_rejected(self):
+        """Requests with wrong or missing token must receive 401."""
+        import urllib.request
+        import urllib.error
+
+        coord = self._start_coord([_make_combo("auth_test")])
+
+        # No token
+        try:
+            with urllib.request.urlopen(self._url(coord, "/work"), timeout=5):
+                assert False, "expected 401"
+        except urllib.error.HTTPError as e:
+            assert e.code == 401
+
+        # Wrong token
+        req = urllib.request.Request(
+            self._url(coord, "/work"),
+            headers={"Authorization": "Bearer wrong-token"},
+        )
+        try:
+            urllib.request.urlopen(req, timeout=5)
+            assert False, "expected 401"
+        except urllib.error.HTTPError as e:
+            assert e.code == 401
+
         coord.stop()


### PR DESCRIPTION
Introduces a coordinator/worker HTTP architecture so a grid search can
be split across any number of machines that have TMInterface running.

- distributed/protocol.py: ComboSpec + ResultPayload wire types,
  full ExperimentData JSON serialisation (handles numpy arrays).
- distributed/coordinator.py: HTTPServer-based coordinator — work
  queue, result store, heartbeat monitor with re-queue on timeout,
  Bearer token auth (401 on wrong/missing token).
- distributed/worker.py: polls /work, runs train_rl identically to
  single-machine mode, sends /heartbeat every 15 s, posts result to
  /result.  Token via --token or TMNF_GRID_TOKEN env var.
- grid_search.py: adds --distribute / --port / --token flags; when
  --distribute is set the process becomes the coordinator and returns
  after save_grid_summary; single-machine path is unchanged.

GitHub issue: espenhk/tmnf-ai#29

https://claude.ai/code/session_015TGa4zSU1e6S43Bqfa2pwX