### PR TITLE
tests: update imports after root-level shim removal

### DIFF
--- a/tests/test_cmaes_policy.py
+++ b/tests/test_cmaes_policy.py
@@ -156,7 +156,7 @@ class TestCMAESPolicyCallable(unittest.TestCase):
         policy.sample_population()
         policy.update_distribution([float(i) for i in range(6)])
 
-        from obs_spec import BASE_OBS_DIM
+        from games.tmnf.obs_spec import BASE_OBS_DIM
         obs    = np.zeros(BASE_OBS_DIM, dtype=np.float32)
         action = policy(obs)
         self.assertEqual(action.shape, (3,))
@@ -205,7 +205,7 @@ class TestCMAESConvergence(unittest.TestCase):
 
     def test_converges_toward_quadratic_maximum(self):
         """CMA-ES mean should move toward the maximizer of a quadratic in <=50 generations."""
-        from obs_spec import BASE_OBS_DIM
+        from games.tmnf.obs_spec import BASE_OBS_DIM
 
         policy  = CMAESPolicy(population_size=20, initial_sigma=1.0, n_lidar_rays=0, seed=42)
         policy.initialize_random()

--- a/tests/test_discretize_obs.py
+++ b/tests/test_discretize_obs.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-from obs_spec import BASE_OBS_DIM
+from games.tmnf.obs_spec import BASE_OBS_DIM
 from policies import WeightedLinearPolicy, _discretize_obs
 
 _N = BASE_OBS_DIM

--- a/tests/test_early_stopping.py
+++ b/tests/test_early_stopping.py
@@ -18,8 +18,7 @@ from framework.training import _greedy_loop, _greedy_loop_q_learning
 # in policies.py bakes in TMNF's obs_spec and a different from_cfg signature;
 # these tests exercise framework internals with a custom 3-dim obs_spec.
 from framework.policies import WeightedLinearPolicy
-# obs_spec shim re-exports ObsSpec/ObsDim unchanged — use it for consistency.
-from obs_spec import ObsSpec, ObsDim
+from framework.obs_spec import ObsSpec, ObsDim
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_epsilon_greedy_policy.py
+++ b/tests/test_epsilon_greedy_policy.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-from obs_spec import BASE_OBS_DIM
+from games.tmnf.obs_spec import BASE_OBS_DIM
 from policies import EpsilonGreedyPolicy, WeightedLinearPolicy, _action_to_idx, _discretize_obs
 
 

--- a/tests/test_mcts_policy.py
+++ b/tests/test_mcts_policy.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-from obs_spec import BASE_OBS_DIM
+from games.tmnf.obs_spec import BASE_OBS_DIM
 from policies import MCTSPolicy, WeightedLinearPolicy, _action_to_idx, _discretize_obs
 
 

--- a/tests/test_neural_dqn_policy.py
+++ b/tests/test_neural_dqn_policy.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-from obs_spec import BASE_OBS_DIM
+from games.tmnf.obs_spec import BASE_OBS_DIM
 from policies import (
     NeuralDQNPolicy,
     ReplayBuffer,

--- a/tests/test_neural_net_policy.py
+++ b/tests/test_neural_net_policy.py
@@ -3,7 +3,7 @@ import unittest
 
 import numpy as np
 
-from obs_spec import BASE_OBS_DIM
+from games.tmnf.obs_spec import BASE_OBS_DIM
 from policies import NeuralNetPolicy
 
 _N = BASE_OBS_DIM

--- a/tests/test_track.py
+++ b/tests/test_track.py
@@ -5,8 +5,8 @@ import unittest
 
 import numpy as np
 
-from track import Centerline
-from utils import Vec3
+from games.tmnf.track import Centerline
+from games.tmnf.state import Vec3
 
 
 class TestCenterline(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,8 +7,8 @@ import unittest
 import numpy as np
 
 from helpers import make_game_state
-from track import Centerline
-from utils import Vec3, Quat, StateData
+from games.tmnf.track import Centerline
+from games.tmnf.state import Vec3, Quat, StateData
 
 
 class TestVec3(unittest.TestCase):

--- a/tests/test_weighted_linear_policy.py
+++ b/tests/test_weighted_linear_policy.py
@@ -4,7 +4,7 @@ import unittest
 import numpy as np
 
 from helpers import make_wlp
-from obs_spec import BASE_OBS_DIM
+from games.tmnf.obs_spec import BASE_OBS_DIM
 from policies import WeightedLinearPolicy
 
 _N = BASE_OBS_DIM


### PR DESCRIPTION
The shim modules obs_spec.py, track.py, and utils.py at the repo root
were removed in c049d40, but tests still imported from those paths and
failed to collect on CI.

Point every affected test at the new module locations:
  obs_spec  → games.tmnf.obs_spec  (BASE_OBS_DIM)
            → framework.obs_spec   (ObsSpec, ObsDim)
  track     → games.tmnf.track     (Centerline)
  utils     → games.tmnf.state     (Vec3, Quat, StateData)

All 261 non-Windows tests now pass.