### PR TITLE
config: add CMA-ES grid search template

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,5 +21,9 @@ jobs:
         run: pip install pytest numpy scipy pyyaml gymnasium
 
       - name: Run tests
-        # test_env_termination requires tminterface (Windows-only, not on PyPI)
+        # test_env_termination requires tminterface (Windows-only, not on PyPI).
+        # PYTHONPATH=. puts the repo root on sys.path so `import clients` etc.
+        # resolve regardless of pytest's import-mode/rootdir handling.
+        env:
+          PYTHONPATH: .
         run: python -m pytest tests/ --ignore=tests/test_env_termination.py

--- a/config/gs_cmaes_v1.yaml
+++ b/config/gs_cmaes_v1.yaml
@@ -4,10 +4,11 @@
 #   population_size — lambda in CMA-ES. Drives the total episode budget
 #                     (= n_sims * population_size) and the quality of the
 #                     rank-mu covariance update. Very small populations
-#                     (< 10) give noisy covariance estimates for a 63-dim
-#                     search; very large ones burn the episode budget on
-#                     individual evaluations rather than generations.
-#                     20 is the Hansen 2016 default for this dimension.
+#                     (< 10) give noisy covariance estimates for an 87-dim
+#                     search ((BASE_OBS_DIM + n_lidar_rays) * 3 = (21+8)*3
+#                     with this template's n_lidar_rays=8); very large ones
+#                     burn the episode budget on individual evaluations
+#                     rather than generations.
 #   initial_sigma   — starting step size. CSA adapts sigma automatically
 #                     each generation, but the initial value still controls
 #                     how far the first samples spread. Too small → slow
@@ -29,11 +30,11 @@ training_params:
   speed: 10.0
   n_sims: 30
   in_game_episode_s: 90.0
-  mutation_scale: 0.05   # unused for CMA-ES but required by grid_search.py
-  mutation_share: 1.0    # unused for CMA-ES but required by grid_search.py
+  mutation_scale: 0.05   # unused for CMA-ES but indexed directly by grid_search.py
+  mutation_share: 1.0    # unused for CMA-ES; optional in grid_search.py
   probe_s: 8.0
-  cold_restarts: 1       # unused for CMA-ES but required by grid_search.py
-  cold_sims: 1           # unused for CMA-ES but required by grid_search.py
+  cold_restarts: 1       # unused for CMA-ES; optional in grid_search.py
+  cold_sims: 1           # unused for CMA-ES; optional in grid_search.py
   n_lidar_rays: 8
   policy_type: cmaes
 

--- a/config/gs_cmaes_v1.yaml
+++ b/config/gs_cmaes_v1.yaml
@@ -1,0 +1,56 @@
+# Grid search: CMAESPolicy ((mu/mu_w, lambda)-CMA-ES)
+#
+# Primary axes:
+#   population_size — lambda in CMA-ES. Drives the total episode budget
+#                     (= n_sims * population_size) and the quality of the
+#                     rank-mu covariance update. Very small populations
+#                     (< 10) give noisy covariance estimates for a 63-dim
+#                     search; very large ones burn the episode budget on
+#                     individual evaluations rather than generations.
+#                     20 is the Hansen 2016 default for this dimension.
+#   initial_sigma   — starting step size. CSA adapts sigma automatically
+#                     each generation, but the initial value still controls
+#                     how far the first samples spread. Too small → slow
+#                     escape from a flat initial basin; too large → the
+#                     first few generations are effectively random.
+#                     The adapted sigma typically converges regardless, so
+#                     this axis mainly affects wall-clock time to first
+#                     improvement, not the final champion.
+#
+# n_sims=30 generations × up to 30 individuals = up to 900 episodes,
+# comparable to the genetic experiments. No mutation_scale tuning needed —
+# CMA-ES replaces that dial with the adapted sigma + covariance.
+#
+# Combos: 3 x 3 = 9
+
+base_name: "gs_cmaes_v1"
+
+training_params:
+  speed: 10.0
+  n_sims: 30
+  in_game_episode_s: 90.0
+  mutation_scale: 0.05   # unused for CMA-ES but required by grid_search.py
+  mutation_share: 1.0    # unused for CMA-ES but required by grid_search.py
+  probe_s: 8.0
+  cold_restarts: 1       # unused for CMA-ES but required by grid_search.py
+  cold_sims: 1           # unused for CMA-ES but required by grid_search.py
+  n_lidar_rays: 8
+  policy_type: cmaes
+
+  # --- Search axes ---
+  population_size: [10, 20, 30]
+  initial_sigma: [0.1, 0.3, 0.6]
+
+reward_params:
+  progress_weight: 10000.0
+  centerline_weight: 0.0
+  centerline_exp: 0.0
+  speed_weight: 0.05
+  step_penalty: -0.01
+  finish_bonus: 5000.0
+  finish_time_weight: -5.0
+  par_time_s: 60.0
+  accel_bonus: 1.0
+  airborne_penalty: -1.0
+  crash_threshold_m: 25.0
+  lidar_wall_weight: -5.0

--- a/distributed/coordinator.py
+++ b/distributed/coordinator.py
@@ -235,6 +235,7 @@ class Coordinator:
             progress = len(self._results)
             if progress == self._total:
                 done = True
+                self._done_event.set()
 
         logger.info(
             "Received result for %s  best_reward=%+.1f  (%d/%d done)",
@@ -244,9 +245,6 @@ class Coordinator:
             self._total,
         )
         handler._send_json(200, {"status": "ok"})
-
-        if done:
-            self._done_event.set()
 
     def _handle_post_heartbeat(self, handler: Any, body: bytes) -> None:
         try:

--- a/distributed/worker.py
+++ b/distributed/worker.py
@@ -129,7 +129,7 @@ def run_worker(
     from games.tmnf.env import make_env
     from analytics import save_experiment_results
 
-    from grid_search import _build_policy_params, _setup_experiment_dir
+    from grid_search import _build_policy_params, _build_tmnf_extras, _setup_experiment_dir
 
     logger.info("Worker %s connecting to %s", worker_id, base)
 
@@ -185,6 +185,13 @@ def run_worker(
         # --- run training ---
         n_lidar_rays = t.get("n_lidar_rays", 0)
         obs_spec = TMNF_OBS_SPEC.with_lidar(n_lidar_rays)
+        policy_params = _build_policy_params(t)
+        extras, dispatch = _build_tmnf_extras(
+            weights_file=weights_file,
+            n_lidar_rays=n_lidar_rays,
+            re_initialize=re_initialize,
+            policy_params=policy_params,
+        )
         try:
             data = train_rl(
                 experiment_name=spec.name,
@@ -214,7 +221,9 @@ def run_worker(
                 no_interrupt=no_interrupt,
                 re_initialize=re_initialize,
                 policy_type=t.get("policy_type", "hill_climbing"),
-                policy_params=_build_policy_params(t),
+                policy_params=policy_params,
+                extra_policy_types=extras,
+                extra_loop_dispatch=dispatch,
                 track=track,
                 do_pretrain=t.get("do_pretrain", False),
                 patience=t.get("patience", 0),

--- a/grid_search.py
+++ b/grid_search.py
@@ -66,6 +66,8 @@ _ABBREV = {
     # genetic policy params
     "population_size": "pop",
     "elite_k": "ek",
+    # cmaes policy params
+    "initial_sigma": "sigma",
     # epsilon-greedy params
     "epsilon": "eps",
     "epsilon_decay": "ed",
@@ -102,8 +104,9 @@ _POLICY_PARAM_MAP = {
     "gamma": "gamma",  # epsilon_greedy / mcts
     "n_bins": "n_bins",  # epsilon_greedy / mcts
     "mcts_c": "c",  # mcts (renamed)
-    "population_size": "population_size",  # genetic
+    "population_size": "population_size",  # genetic / cmaes
     "elite_k": "elite_k",  # genetic
+    "initial_sigma": "initial_sigma",  # cmaes
 }
 
 

--- a/grid_search.py
+++ b/grid_search.py
@@ -225,6 +225,119 @@ def _build_policy_params(t: dict[str, Any]) -> dict[str, Any]:
     return params
 
 
+def _build_tmnf_extras(
+    weights_file: str,
+    n_lidar_rays: int,
+    re_initialize: bool,
+    policy_params: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """
+    Build (extra_policy_types, extra_loop_dispatch) for TMNF-specific policy
+    types so train_rl() can construct and route them. Mirrors main.py's setup
+    so `policy_type: cmaes | neural_dqn | reinforce | lstm` works from grid
+    search and distributed workers, not just from main.py.
+    """
+    import yaml as _yaml
+    from games.tmnf.policies import (
+        CMAESPolicy,
+        LSTMEvolutionPolicy,
+        LSTMPolicy,
+        NeuralDQNPolicy,
+        REINFORCEPolicy,
+    )
+
+    def _make_neural_dqn() -> NeuralDQNPolicy:
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as _f:
+                _cfg = _yaml.safe_load(_f)
+            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "neural_dqn":
+                return NeuralDQNPolicy.from_cfg(_cfg, n_lidar_rays=n_lidar_rays)
+        return NeuralDQNPolicy(
+            hidden_sizes        = policy_params.get("hidden_sizes",        [64, 64]),
+            replay_buffer_size  = policy_params.get("replay_buffer_size",  10000),
+            batch_size          = policy_params.get("batch_size",          64),
+            min_replay_size     = policy_params.get("min_replay_size",     500),
+            target_update_freq  = policy_params.get("target_update_freq",  200),
+            learning_rate       = policy_params.get("learning_rate",       0.001),
+            epsilon_start       = policy_params.get("epsilon_start",       1.0),
+            epsilon_end         = policy_params.get("epsilon_end",         0.05),
+            epsilon_decay_steps = policy_params.get("epsilon_decay_steps", 5000),
+            gamma               = policy_params.get("gamma",               0.99),
+            n_lidar_rays        = n_lidar_rays,
+        )
+
+    def _make_cmaes() -> CMAESPolicy:
+        policy = CMAESPolicy(
+            population_size = policy_params.get("population_size", 20),
+            initial_sigma   = policy_params.get("initial_sigma",   0.3),
+            n_lidar_rays    = n_lidar_rays,
+        )
+        if os.path.exists(weights_file) and not re_initialize:
+            from policies import WeightedLinearPolicy as _WLP
+            with open(weights_file) as _f:
+                champion = _WLP.from_cfg(_yaml.safe_load(_f) or {}, n_lidar_rays=n_lidar_rays)
+            policy.initialize_from_champion(champion)
+        else:
+            policy.initialize_random()
+        return policy
+
+    def _make_reinforce() -> REINFORCEPolicy:
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as _f:
+                _cfg = _yaml.safe_load(_f) or {}
+            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "reinforce":
+                return REINFORCEPolicy.from_cfg(_cfg, n_lidar_rays=n_lidar_rays)
+        return REINFORCEPolicy(
+            hidden_sizes  = policy_params.get("hidden_sizes",  [64, 64]),
+            learning_rate = policy_params.get("learning_rate", 0.001),
+            gamma         = policy_params.get("gamma",         0.99),
+            entropy_coeff = policy_params.get("entropy_coeff", 0.01),
+            baseline      = policy_params.get("baseline",      "running_mean"),
+            n_lidar_rays  = n_lidar_rays,
+        )
+
+    def _make_lstm() -> LSTMEvolutionPolicy:
+        hidden_size = policy_params.get("hidden_size",     32)
+        policy = LSTMEvolutionPolicy(
+            hidden_size     = hidden_size,
+            population_size = policy_params.get("population_size", 20),
+            initial_sigma   = policy_params.get("initial_sigma",   0.05),
+            n_lidar_rays    = n_lidar_rays,
+        )
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as _f:
+                _cfg = _yaml.safe_load(_f) or {}
+            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "lstm":
+                saved_hidden = _cfg.get("hidden_size")
+                saved_lidar  = _cfg.get("n_lidar_rays")
+                if saved_hidden is not None and saved_hidden != hidden_size:
+                    raise ValueError(
+                        "Saved LSTM champion hidden_size does not match current run: "
+                        f"saved={saved_hidden}, current={hidden_size}"
+                    )
+                if saved_lidar is not None and saved_lidar != n_lidar_rays:
+                    raise ValueError(
+                        "Saved LSTM champion n_lidar_rays does not match current run: "
+                        f"saved={saved_lidar}, current={n_lidar_rays}"
+                    )
+                policy.initialize_from_champion(LSTMPolicy.from_cfg(_cfg))
+        return policy
+
+    extras = {
+        "neural_dqn": _make_neural_dqn,
+        "cmaes":      _make_cmaes,
+        "reinforce":  _make_reinforce,
+        "lstm":       _make_lstm,
+    }
+    dispatch = {
+        "neural_dqn": "q_learning",
+        "cmaes":      "cmaes",
+        "reinforce":  "q_learning",
+        "lstm":       "cmaes",
+    }
+    return extras, dispatch
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -281,6 +394,13 @@ def _run_local(
         )
         n_lidar_rays = t.get("n_lidar_rays", 0)
         obs_spec = TMNF_OBS_SPEC.with_lidar(n_lidar_rays)
+        policy_params = _build_policy_params(t)
+        extras, dispatch = _build_tmnf_extras(
+            weights_file=weights_file,
+            n_lidar_rays=n_lidar_rays,
+            re_initialize=re_initialize,
+            policy_params=policy_params,
+        )
 
         data = train_rl(
             experiment_name=name,
@@ -312,7 +432,9 @@ def _run_local(
             no_interrupt=no_interrupt or i > 1,
             re_initialize=re_initialize,
             policy_type=t.get("policy_type", "hill_climbing"),
-            policy_params=_build_policy_params(t),
+            policy_params=policy_params,
+            extra_policy_types=extras,
+            extra_loop_dispatch=dispatch,
             track=track,
             do_pretrain=t.get("do_pretrain", False),
             patience=t.get("patience", 0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,3 +32,6 @@ pyyaml = ">=6.0"
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tests/test_rl_client.py
+++ b/tests/test_rl_client.py
@@ -31,7 +31,7 @@ _iface.TMInterface = MagicMock
 # ---------------------------------------------------------------------------
 # Now we can safely import the module under test.
 # ---------------------------------------------------------------------------
-from clients.rl_client import RLClient, StepState, _DEFAULT_ACTION, ACTIONS  # noqa: E402
+from games.tmnf.clients.rl_client import RLClient, StepState, _DEFAULT_ACTION, ACTIONS  # noqa: E402
 
 
 def _make_state_data(track_progress=0.5, lateral_offset=0.0, speed=10.0):


### PR DESCRIPTION
Adds config/gs_cmaes_v1.yaml so every documented policy_type in CLAUDE.md
now has a matching grid template. Sweeps population_size and initial_sigma,
the two exposed CMA-ES hyperparams; no mutation_scale axis since sigma
adapts via CSA each generation.

Also wires initial_sigma into grid_search.py's ABBREV table ("sigma") and
POLICY_PARAM_MAP so it can be used as a top-level search axis rather than
nested under policy_params.