### PR TITLE
fix: call give_up() from on_simulation_step to unblock finish reset

### DIFF
--- a/games/tmnf/clients/rl_client.py
+++ b/games/tmnf/clients/rl_client.py
@@ -172,6 +172,12 @@ class RLClient(PhaseAwareClient):
 
     def request_respawn(self) -> None:
         """Signal the game thread to respawn the car. Call before wait_episode_ready()."""
+        logger.info(
+            "[RLClient] request_respawn: setting _respawn_event "
+            "(running=%s finish_pending=%s finish_delivered=%s queue_size=%d)",
+            self._running, self._finish_respawn_pending,
+            self._simulation_finish_delivered, self._state_queue.qsize(),
+        )
         self._episode_ready.clear()
         self._simulation_finish_delivered = False
         self._respawn_event.set()
@@ -181,11 +187,27 @@ class RLClient(PhaseAwareClient):
         Block until the car has stopped after respawn (BRAKING_START → RUNNING).
         Returns the first state of the new episode.
         """
+        logger.info(
+            "[RLClient] wait_episode_ready: blocking "
+            "(running=%s finish_pending=%s finish_delivered=%s queue_size=%d)",
+            self._running, self._finish_respawn_pending,
+            self._simulation_finish_delivered, self._state_queue.qsize(),
+        )
+        wait_count = 0
         while not self._stop_event.is_set():
             if self._episode_ready.wait(timeout=1.0):
                 break
+            wait_count += 1
+            logger.warning(
+                "[RLClient] wait_episode_ready: still waiting after %ds "
+                "(running=%s finish_pending=%s finish_delivered=%s respawn_set=%s queue_size=%d)",
+                wait_count, self._running, self._finish_respawn_pending,
+                self._simulation_finish_delivered, self._respawn_event.is_set(),
+                self._state_queue.qsize(),
+            )
         if self._stop_event.is_set():
             raise RuntimeError("RLClient stopped while waiting for episode ready")
+        logger.info("[RLClient] wait_episode_ready: _episode_ready fired — reading first state")
         self._episode_ready.clear()
         return self._state_queue.get(timeout=30.0)
 
@@ -199,21 +221,24 @@ class RLClient(PhaseAwareClient):
         self._registered_event.set()
 
     def on_simulation_begin(self, iface: TMInterface) -> None:
-        """Fires every tick during replay validation (after race finish).
-        Unlike on_simulation_begin (one-shot), this fires repeatedly so a
-        drain+overwrite race between on_run_step and the RL thread cannot
-        cause the finish step to be lost."""
-        logger.debug("[RLClient] on_simulation_begin running=%s delivered=%s last_state=%s",
-                    self._running, self._simulation_finish_delivered,
-                    'yes' if self._last_step_state else 'no')
+        """Fires ONCE when replay validation begins (car crossed finish line)."""
+        logger.info(
+            "[RLClient] on_simulation_begin: replay validation started "
+            "(running=%s finish_delivered=%s finish_pending=%s respawn_set=%s last_state=%s queue_size=%d)",
+            self._running, self._simulation_finish_delivered,
+            self._finish_respawn_pending, self._respawn_event.is_set(),
+            "yes" if self._last_step_state else "NO",
+            self._state_queue.qsize(),
+        )
 
         if not self._running:
-            logger.debug("[RLClient] on_simulation_begin: not RUNNING — ignoring")
+            logger.info("[RLClient] on_simulation_begin: not RUNNING — ignoring")
             return
         if self._simulation_finish_delivered:
-            return  # already delivered; wait for respawn
+            logger.info("[RLClient] on_simulation_begin: finish already delivered — skipping synthetic")
+            return
         if self._last_step_state is None:
-            logger.debug("[RLClient] on_simulation_begin: no last_step_state — cannot synthesize")
+            logger.warning("[RLClient] on_simulation_begin: no last_step_state — cannot synthesize finish step!")
             return
 
         synthetic = StepState(
@@ -225,29 +250,76 @@ class RLClient(PhaseAwareClient):
         )
         self._drain_and_put(synthetic)
         self._simulation_finish_delivered = True
-        logger.debug("[RLClient] on_simulation_begin: delivered synthetic finish step")
+        logger.info("[RLClient] on_simulation_begin: delivered synthetic finish step (done=False finished=True)")
 
         if self._auto_respawn_on_finish:
             self._finish_respawn_pending = True
-            logger.debug("[RLClient] on_simulation_begin: auto-respawn pending set")
+            logger.info("[RLClient] on_simulation_begin: auto-respawn pending set")
 
 
     def on_simulation_step(self, iface: TMInterface, _time: int) -> None:
         """Fires every tick during replay validation (after race finish).
-        Unlike on_simulation_begin (one-shot), this fires repeatedly so a
-        drain+overwrite race between on_run_step and the RL thread cannot
-        cause the finish step to be lost."""
-        logger.debug("[RLClient] on_simulation_step t=%d running=%s delivered=%s last_state=%s",
-                    _time, self._running, self._simulation_finish_delivered,
-                    'yes' if self._last_step_state else 'no')
+        on_simulation_begin is the one-shot entry; this fires repeatedly for each tick."""
+        if _time == 0:
+            # First tick of replay validation — log full state.
+            logger.info(
+                "[RLClient] on_simulation_step t=0 (first replay tick): "
+                "running=%s finish_delivered=%s finish_pending=%s respawn_set=%s last_state=%s queue_size=%d",
+                self._running, self._simulation_finish_delivered,
+                self._finish_respawn_pending, self._respawn_event.is_set(),
+                "yes" if self._last_step_state else "NO",
+                self._state_queue.qsize(),
+            )
+        elif _time % 10_000 == 0:
+            # Log every 10 s of replay time so we can see it's still running.
+            logger.info(
+                "[RLClient] on_simulation_step t=%d still in replay validation "
+                "(running=%s finish_pending=%s respawn_set=%s queue_size=%d)",
+                _time, self._running, self._finish_respawn_pending,
+                self._respawn_event.is_set(), self._state_queue.qsize(),
+            )
+
+        # on_run_step does not fire during replay validation, so any pending
+        # respawn must be handled here instead.
+
+        if self._respawn_event.is_set():
+            # RL thread called request_respawn() (non-auto-respawn path).
+            # Finish step was already delivered before on_run_step stopped, or by
+            # on_simulation_begin above.  Safe to exit replay validation now.
+            logger.info(
+                "[RLClient] on_simulation_step t=%d: _respawn_event set in replay validation "
+                "→ give_up() here (finish_delivered=%s queue_size=%d)",
+                _time, self._simulation_finish_delivered, self._state_queue.qsize(),
+            )
+            self._respawn_event.clear()
+            self._simulation_finish_delivered = False
+            self._last_centerline_idx = None
+            self._running = False
+            iface.give_up()
+            return
+
+        if self._finish_respawn_pending:
+            # Auto-respawn path: finish step delivered, now exit replay validation.
+            # on_run_step will resume after give_up() and handle BRAKING_START → RUNNING.
+            logger.info(
+                "[RLClient] on_simulation_step t=%d: _finish_respawn_pending in replay validation "
+                "→ give_up() here (finish_delivered=%s queue_size=%d)",
+                _time, self._simulation_finish_delivered, self._state_queue.qsize(),
+            )
+            self._finish_respawn_pending = False
+            self._episode_ready.clear()
+            self._simulation_finish_delivered = False
+            self._last_centerline_idx = None
+            self._running = False
+            iface.give_up()
+            return
 
         if not self._running:
-            logger.debug("[RLClient] on_simulation_step: not RUNNING — ignoring")
             return
         if self._simulation_finish_delivered:
             return  # already delivered; wait for respawn
         if self._last_step_state is None:
-            logger.debug("[RLClient] on_simulation_step: no last_step_state — cannot synthesize")
+            logger.warning("[RLClient] on_simulation_step t=%d: no last_step_state — cannot synthesize!", _time)
             return
 
         synthetic = StepState(
@@ -259,11 +331,11 @@ class RLClient(PhaseAwareClient):
         )
         self._drain_and_put(synthetic)
         self._simulation_finish_delivered = True
-        logger.debug("[RLClient] on_simulation_step: delivered synthetic finish step")
+        logger.info("[RLClient] on_simulation_step t=%d: delivered synthetic finish step", _time)
 
         if self._auto_respawn_on_finish:
             self._finish_respawn_pending = True
-            logger.debug("[RLClient] on_simulation_step: auto-respawn pending set")
+            logger.info("[RLClient] on_simulation_step t=%d: auto-respawn pending set", _time)
 
     def on_run_step(self, iface: TMInterface, _time: int) -> None:
         self._tick += 1
@@ -271,7 +343,12 @@ class RLClient(PhaseAwareClient):
         # Handle a pending respawn request from the RL thread.
         if self._respawn_event.is_set():
             self._respawn_event.clear()
-            logger.debug("[RLClient] on_run_step t=%d: respawn triggered → give_up()", _time)
+            logger.info(
+                "[RLClient] on_run_step t=%d: _respawn_event set → give_up() "
+                "(running=%s finish_pending=%s finish_delivered=%s)",
+                _time, self._running, self._finish_respawn_pending,
+                self._simulation_finish_delivered,
+            )
             iface.give_up()
             self._last_centerline_idx = None  # full scan on next tick after respawn
             self._simulation_finish_delivered = False
@@ -289,10 +366,19 @@ class RLClient(PhaseAwareClient):
             logger.debug("[RLClient] tick=%d t=%d running=%s speed=%.2fm/s progress=%s",
                         self._tick, _time, self._running, speed_ms, data.track_progress)
 
+        # Extra logging as car approaches finish.
+        if data.track_progress is not None and data.track_progress >= 0.85:
+            logger.debug(
+                "[RLClient] on_run_step t=%d: approaching finish progress=%.4f "
+                "(threshold=%.2f running=%s finish_pending=%s)",
+                _time, data.track_progress, _FINISH_THRESHOLD,
+                self._running, self._finish_respawn_pending,
+            )
+
         if not self._running:
             iface.set_input_state(brake=True)
             if speed_ms < VELOCITY_ZERO_THRESHOLD:
-                logger.debug("[RLClient] on_run_step t=%d: BRAKING_START → RUNNING (episode ready)", _time)
+                logger.info("[RLClient] on_run_step t=%d: BRAKING_START → RUNNING (episode ready)", _time)
                 self._running = True
                 step_state = StepState(
                     state_data=data,
@@ -305,6 +391,11 @@ class RLClient(PhaseAwareClient):
             # Pending auto-respawn from the previous tick's lap completion:
             # act on it here so the finish step was already delivered first.
             if self._finish_respawn_pending:
+                logger.info(
+                    "[RLClient] on_run_step t=%d: _finish_respawn_pending → give_up() "
+                    "(finish_delivered=%s queue_size=%d)",
+                    _time, self._simulation_finish_delivered, self._state_queue.qsize(),
+                )
                 self._finish_respawn_pending = False
                 self._episode_ready.clear()
                 iface.give_up()  # restart race from position zero
@@ -330,14 +421,19 @@ class RLClient(PhaseAwareClient):
             )
 
             if finished:
-                logger.info("[RLClient] on_run_step t=%d: finish detected (progress=%.4f >= %.2f) auto_respawn=%s",
-                           _time, data.track_progress, _FINISH_THRESHOLD, self._auto_respawn_on_finish)
+                logger.info(
+                    "[RLClient] on_run_step t=%d: FINISH DETECTED progress=%.4f >= %.2f "
+                    "(auto_respawn=%s finish_pending=%s finish_delivered=%s queue_size=%d)",
+                    _time, data.track_progress, _FINISH_THRESHOLD,
+                    self._auto_respawn_on_finish, self._finish_respawn_pending,
+                    self._simulation_finish_delivered, self._state_queue.qsize(),
+                )
 
             if finished and self._auto_respawn_on_finish:
                 # Deliver the finish step with done=False; respawn next tick.
                 self._finish_respawn_pending = True
                 done = False
-                logger.debug("[RLClient] on_run_step t=%d: auto-respawn pending set", _time)
+                logger.info("[RLClient] on_run_step t=%d: auto-respawn pending set", _time)
             else:
                 done = finished or hard_crash
 
@@ -348,6 +444,31 @@ class RLClient(PhaseAwareClient):
                 finished=finished,
             )
             self._drain_and_put(step_state)
+
+    def on_simulation_end(self, iface: TMInterface, result: int) -> None:
+        """Fires once when replay validation finishes."""
+        logger.info(
+            "[RLClient] on_simulation_end result=%d "
+            "(running=%s finish_pending=%s finish_delivered=%s respawn_set=%s queue_size=%d)",
+            result, self._running, self._finish_respawn_pending,
+            self._simulation_finish_delivered, self._respawn_event.is_set(),
+            self._state_queue.qsize(),
+        )
+
+    def on_checkpoint_count_changed(self, iface: TMInterface, current: int, target: int) -> None:
+        logger.info(
+            "[RLClient] on_checkpoint_count_changed %d/%d "
+            "(running=%s finish_pending=%s)",
+            current, target, self._running, self._finish_respawn_pending,
+        )
+
+    def on_laps_count_changed(self, iface: TMInterface, current: int) -> None:
+        logger.info(
+            "[RLClient] on_laps_count_changed laps=%d "
+            "(running=%s finish_pending=%s finish_delivered=%s respawn_set=%s)",
+            current, self._running, self._finish_respawn_pending,
+            self._simulation_finish_delivered, self._respawn_event.is_set(),
+        )
 
     # ------------------------------------------------------------------
     # Internal helpers

--- a/games/tmnf/env.py
+++ b/games/tmnf/env.py
@@ -219,6 +219,11 @@ class TMNFEnv(BaseGameEnv):
         # wait for the car to stop at the new spawn, then continue the episode.
         if finished and self._auto_respawn_on_finish and not time_over:
             self._laps_completed += 1
+            logger.info(
+                "[TMNFEnv] finish detected (step.finished=%s progress=%.4f) "
+                "— calling wait_episode_ready for lap %d",
+                step.finished, data.track_progress or 0.0, self._laps_completed,
+            )
             init_step = self._client.wait_episode_ready()
             self._prev_state = init_step.state_data
             obs = self._build_obs(init_step)
@@ -237,6 +242,14 @@ class TMNFEnv(BaseGameEnv):
         terminated = finished or crashed
         # step.done signals a hard crash (>50 m off, handled by client safety net)
         truncated = (step.done and not terminated) or time_over
+
+        if finished or terminated or truncated:
+            logger.info(
+                "[TMNFEnv] episode end: finished=%s crashed=%s time_over=%s "
+                "terminated=%s truncated=%s progress=%.4f elapsed=%.1fs",
+                finished, crashed, time_over, terminated, truncated,
+                data.track_progress or 0.0, self._elapsed_s,
+            )
 
         if finished:
             termination_reason: str | None = "finish"


### PR DESCRIPTION
on_run_step stops firing once the game enters replay validation after a finish. Any respawn triggered there (_respawn_event or _finish_respawn_pending) was never acted on, so wait_episode_ready() blocked indefinitely.

Fix: on_simulation_step now handles both paths:
- _respawn_event set (non-auto-respawn): clear + give_up() + running=False
- _finish_respawn_pending set (auto-respawn): same

on_simulation_begin delivers the synthetic finish step before on_simulation_step t=0 fires, so give_up() is only called after the finish step is guaranteed to be in the queue.

Also adds extensive logging throughout the finish/reset flow to make future regressions diagnosable: request_respawn, wait_episode_ready (with per-second stall warnings), on_simulation_begin/end, all give_up() calls, checkpoint/laps callbacks, and approaching-finish progress logs in on_run_step.