### PR TITLE
feat: parameterized action windowing (issue #65)

### DIFF
--- a/games/tmnf/clients/rl_client.py
+++ b/games/tmnf/clients/rl_client.py
@@ -101,15 +101,47 @@ class RLClient(PhaseAwareClient):
         centerline_file: str,
         speed: float = 10.0,
         auto_respawn_on_finish: bool = False,
+        action_window_ticks: int = 1,
+        decision_offset_pct: float = 0.75,
     ) -> None:
         super().__init__()
         self.speed = speed
         self.centerline = Centerline(centerline_file)
         self._auto_respawn_on_finish = auto_respawn_on_finish
 
-        # Shared state — written by RL thread, read by game thread
+        # --- Action windowing (issue #65) ---------------------------------
+        # The window has two phases:
+        #   * Observation phase (tick 0 .. _decision_idx-1): game thread emits
+        #     a StepState every tick; RL thread iteratively refines the pending
+        #     action.
+        #   * Transit phase (tick _decision_idx .. window-1): no StepStates,
+        #     pending action is locked.
+        # At every window boundary the pending action is committed to the game
+        # via iface.set_input_state(...).
+        # When action_window_ticks == 1, _decision_idx == 0 and every tick
+        # commits and emits — preserving legacy behavior bit-for-bit.
+        assert action_window_ticks >= 1, "action_window_ticks must be >= 1"
+        assert 0.0 < decision_offset_pct <= 1.0, "decision_offset_pct must be in (0, 1]"
+        self._action_window_ticks: int = action_window_ticks
+        if action_window_ticks > 1:
+            # Clamp to [1, window-1] so there's at least one observation tick
+            # and at least one transit tick.
+            self._decision_idx: int = max(
+                1,
+                min(action_window_ticks - 1,
+                    int(action_window_ticks * decision_offset_pct)),
+            )
+        else:
+            self._decision_idx = 0
+        self._window_tick: int = 0
+        self._force_commit_next_tick: bool = True
+
+        # Shared state — written by RL thread, read by game thread.
+        # _pending_action is what the RL thread is iteratively refining;
+        # _committed_action is what the game is currently being driven with.
         # shape (3,): [steer ∈ [-1,1], accel ∈ {0,1}, brake ∈ {0,1}]
-        self._action: np.ndarray = _DEFAULT_ACTION.copy()
+        self._pending_action: np.ndarray = _DEFAULT_ACTION.copy()
+        self._committed_action: np.ndarray = _DEFAULT_ACTION.copy()
         self._action_lock = threading.Lock()
 
         # Shared state — written by game thread, read by RL thread
@@ -153,13 +185,17 @@ class RLClient(PhaseAwareClient):
         self._episode_ready.set()  # unblock wait_episode_ready
 
     def set_action(self, action: np.ndarray) -> None:
-        """Set the next action. Thread-safe.
+        """Set the next pending action. Thread-safe.
+
+        Stored in _pending_action; copied to _committed_action and applied to
+        the game at the next window boundary (or immediately when
+        action_window_ticks == 1).
 
         action: shape (3,) float32 — [steer ∈ [-1,1], accel ∈ {0,1}, brake ∈ {0,1}]
         accel and brake are thresholded at 0.5 when applied to the game.
         """
         with self._action_lock:
-            self._action = action
+            self._pending_action = action
 
     def get_step_state(self) -> StepState:
         """Block until the game thread delivers the next state."""
@@ -353,6 +389,8 @@ class RLClient(PhaseAwareClient):
             self._last_centerline_idx = None  # full scan on next tick after respawn
             self._simulation_finish_delivered = False
             self._running = False
+            self._window_tick = 0
+            self._force_commit_next_tick = True
             return
 
         state = iface.get_simulation_state()
@@ -380,6 +418,8 @@ class RLClient(PhaseAwareClient):
             if speed_ms < VELOCITY_ZERO_THRESHOLD:
                 logger.debug("[RLClient] on_run_step t=%d: BRAKING_START → RUNNING (episode ready)", _time)
                 self._running = True
+                self._window_tick = 0
+                self._force_commit_next_tick = True
                 step_state = StepState(
                     state_data=data,
                     yaw_error=self._compute_yaw_error(data),
@@ -401,18 +441,9 @@ class RLClient(PhaseAwareClient):
                 iface.give_up()  # restart race from position zero
                 self._simulation_finish_delivered = False
                 self._running = False
+                self._window_tick = 0
+                self._force_commit_next_tick = True
                 return
-
-            with self._action_lock:
-                action = self._action
-            steer_norm = float(np.clip(action[0], -1.0, 1.0))
-            accel = bool(float(action[1]) >= 0.5)
-            brake = bool(float(action[2]) >= 0.5)
-            iface.set_input_state(
-                accelerate=accel,
-                brake=brake,
-                steer=int(steer_norm * STEER_SCALE),
-            )
 
             finished  = data.track_progress is not None and data.track_progress >= _FINISH_THRESHOLD
             hard_crash = (
@@ -429,6 +460,23 @@ class RLClient(PhaseAwareClient):
                     self._simulation_finish_delivered, self._state_queue.qsize(),
                 )
 
+            # --- Commit boundary: copy pending → committed and apply to game.
+            # Fires at the start of every window, on the very first running
+            # tick, and whenever termination forces an immediate commit.
+            is_window_start = (self._window_tick == 0) or self._force_commit_next_tick
+            if is_window_start or finished or hard_crash:
+                with self._action_lock:
+                    self._committed_action = self._pending_action.copy()
+                steer_norm = float(np.clip(self._committed_action[0], -1.0, 1.0))
+                accel = bool(float(self._committed_action[1]) >= 0.5)
+                brake = bool(float(self._committed_action[2]) >= 0.5)
+                iface.set_input_state(
+                    accelerate=accel,
+                    brake=brake,
+                    steer=int(steer_norm * STEER_SCALE),
+                )
+                self._force_commit_next_tick = False
+
             if finished and self._auto_respawn_on_finish:
                 # Deliver the finish step with done=False; respawn next tick.
                 self._finish_respawn_pending = True
@@ -437,13 +485,22 @@ class RLClient(PhaseAwareClient):
             else:
                 done = finished or hard_crash
 
-            step_state = StepState(
-                state_data=data,
-                yaw_error=self._compute_yaw_error(data),
-                done=done,
-                finished=finished,
-            )
-            self._drain_and_put(step_state)
+            # --- StepState gating: emit during the observation phase only.
+            # Always emit on termination so the env sees the final state.
+            in_observation_phase = self._window_tick < self._decision_idx or self._action_window_ticks == 1
+            if in_observation_phase or finished or hard_crash:
+                step_state = StepState(
+                    state_data=data,
+                    yaw_error=self._compute_yaw_error(data),
+                    done=done,
+                    finished=finished,
+                )
+                self._drain_and_put(step_state)
+
+            # --- Advance window pointer.
+            self._window_tick += 1
+            if self._window_tick >= self._action_window_ticks:
+                self._window_tick = 0
 
     def on_simulation_end(self, iface: TMInterface, result: int) -> None:
         """Fires once when replay validation finishes."""

--- a/games/tmnf/clients/rl_client.py
+++ b/games/tmnf/clients/rl_client.py
@@ -135,6 +135,9 @@ class RLClient(PhaseAwareClient):
             self._decision_idx = 0
         self._window_tick: int = 0
         self._force_commit_next_tick: bool = True
+        # Game ticks suppressed during the transit phase, pending attribution
+        # to the next emitted StepState so cumulative tick totals are preserved.
+        self._pending_transit_ticks: int = 0
 
         # Shared state — written by RL thread, read by game thread.
         # _pending_action is what the RL thread is iteratively refining;
@@ -391,6 +394,7 @@ class RLClient(PhaseAwareClient):
             self._running = False
             self._window_tick = 0
             self._force_commit_next_tick = True
+            self._pending_transit_ticks = 0
             return
 
         state = iface.get_simulation_state()
@@ -420,6 +424,7 @@ class RLClient(PhaseAwareClient):
                 self._running = True
                 self._window_tick = 0
                 self._force_commit_next_tick = True
+                self._pending_transit_ticks = 0
                 step_state = StepState(
                     state_data=data,
                     yaw_error=self._compute_yaw_error(data),
@@ -443,6 +448,7 @@ class RLClient(PhaseAwareClient):
                 self._running = False
                 self._window_tick = 0
                 self._force_commit_next_tick = True
+                self._pending_transit_ticks = 0
                 return
 
             finished  = data.track_progress is not None and data.track_progress >= _FINISH_THRESHOLD
@@ -495,7 +501,15 @@ class RLClient(PhaseAwareClient):
                     done=done,
                     finished=finished,
                 )
+                # Carry forward any ticks that were suppressed during the
+                # transit phase so cumulative totals are never undercounted.
+                step_state.ticks_this_step += self._pending_transit_ticks
+                self._pending_transit_ticks = 0
                 self._drain_and_put(step_state)
+            else:
+                # Transit phase: StepState suppressed — count the tick so it
+                # can be attributed to the next emitted StepState.
+                self._pending_transit_ticks += 1
 
             # --- Advance window pointer.
             self._window_tick += 1

--- a/games/tmnf/config/training_params.yaml
+++ b/games/tmnf/config/training_params.yaml
@@ -11,6 +11,28 @@ cold_sims: 5            # hill-climb sims per cold-start restart (hill_climbing 
 n_lidar_rays: 8          # LIDAR wall-distance rays appended to observation (0 = disabled)
 patience: 0              # stop greedy loop if no improvement for this many sims (0 = run all)
 
+# Action windowing (issue #65) — act only every X game ticks instead of every tick.
+# Counted in game ticks, independent of `speed`.
+#
+# action_window_ticks: 1 = legacy (commit and emit StepState every tick).
+# When > 1, the window has two phases:
+#   * Observation phase (tick 0 .. floor(window * decision_offset_pct) - 1):
+#     game thread emits a StepState every tick; RL thread iteratively refines
+#     the pending action with each new observation.
+#   * Transit phase (remaining ticks): pending action is locked, no StepStates.
+#     Provides deterministic compute slack so the RL thread is not racing the
+#     next commit boundary. Mimics human reaction delay.
+# At each window boundary the pending action is committed via set_input_state.
+#
+# Notes:
+#   - Per-tick reward terms (centerline, speed_weight, accel_bonus, step_penalty,
+#     airborne_penalty) scale with ticks_this_step. Per-RL-step magnitudes shift
+#     across the window but cumulative episode totals are unchanged.
+#   - Larger windows shrink RL-steps-per-episode by ~decision_idx×, affecting
+#     replay-buffer fill, batch sizes, and step-tuned epsilon schedules.
+action_window_ticks: 1
+decision_offset_pct: 0.75
+
 
 # Policy algorithm for the greedy training phase.
 # Options: hill_climbing | neural_net | epsilon_greedy | mcts | genetic | neural_dqn | cmaes | reinforce | lstm

--- a/games/tmnf/config/training_params.yaml
+++ b/games/tmnf/config/training_params.yaml
@@ -15,13 +15,16 @@ patience: 0              # stop greedy loop if no improvement for this many sims
 # Counted in game ticks, independent of `speed`.
 #
 # action_window_ticks: 1 = legacy (commit and emit StepState every tick).
-# When > 1, the window has two phases:
-#   * Observation phase (tick 0 .. floor(window * decision_offset_pct) - 1):
+# When > 1, the window has two phases. The split point is computed as
+# floor(window * decision_offset_pct) and then clamped to [1, window - 1],
+# so there is always at least one observation tick and one transit tick.
+#   * Observation phase (tick 0 .. decision_idx - 1):
 #     game thread emits a StepState every tick; RL thread iteratively refines
 #     the pending action with each new observation.
 #   * Transit phase (remaining ticks): pending action is locked, no StepStates.
 #     Provides deterministic compute slack so the RL thread is not racing the
-#     next commit boundary. Mimics human reaction delay.
+#     next commit boundary. Even decision_offset_pct: 1.0 still leaves one
+#     transit tick because of the clamp. Mimics human reaction delay.
 # At each window boundary the pending action is committed via set_input_state.
 #
 # Notes:

--- a/games/tmnf/env.py
+++ b/games/tmnf/env.py
@@ -97,6 +97,8 @@ class TMNFEnv(BaseGameEnv):
         max_episode_time_s: float = 120.0,
         n_lidar_rays: int = 0,
         auto_respawn_on_finish: bool = True,
+        action_window_ticks: int = 1,
+        decision_offset_pct: float = 0.75,
     ) -> None:
         super().__init__()
 
@@ -104,6 +106,7 @@ class TMNFEnv(BaseGameEnv):
         self._reward_calc = RewardCalculator(self._reward_config)
         self._max_episode_time_s = max_episode_time_s
         self._auto_respawn_on_finish = auto_respawn_on_finish
+        self._action_window_ticks = action_window_ticks
 
         # Optional LIDAR sensor (screenshot-based wall distances)
         if n_lidar_rays > 0:
@@ -131,7 +134,9 @@ class TMNFEnv(BaseGameEnv):
 
         # Set up TMInterface
         self._client = RLClient(centerline_file, speed=speed,
-                                auto_respawn_on_finish=auto_respawn_on_finish)
+                                auto_respawn_on_finish=auto_respawn_on_finish,
+                                action_window_ticks=action_window_ticks,
+                                decision_offset_pct=decision_offset_pct)
         self._iface = TMInterface()
 
         # The keepalive thread owns register() so the message-pump is already
@@ -155,10 +160,11 @@ class TMNFEnv(BaseGameEnv):
         self._laps_completed: int = 0
 
         # Skip-event telemetry — reset each episode, printed at episode end.
-        self._ep_rl_steps: int = 0         # env.step() calls this episode
-        self._ep_total_ticks: int = 0      # game ticks covered (≥ rl_steps)
-        self._ep_max_skip: int = 0         # worst single-step skip
-        self._total_rl_steps: int = 0      # lifetime step counter (for periodic log)
+        self._ep_rl_steps: int = 0              # env.step() calls this episode
+        self._ep_total_ticks: int = 0           # game ticks covered (≥ rl_steps)
+        self._ep_max_window_ticks: int = 0      # worst single-step ticks_this_step
+        self._ep_max_overrun_ticks: int = 0     # worst overrun beyond action_window_ticks
+        self._total_rl_steps: int = 0           # lifetime step counter (for periodic log)
 
     # ------------------------------------------------------------------
     # Gymnasium interface
@@ -181,7 +187,8 @@ class TMNFEnv(BaseGameEnv):
         self._laps_completed = 0
         self._ep_rl_steps = 0
         self._ep_total_ticks = 0
-        self._ep_max_skip = 0
+        self._ep_max_window_ticks = 0
+        self._ep_max_overrun_ticks = 0
 
         obs = self._build_obs(init_step)
         return obs, {}
@@ -201,8 +208,11 @@ class TMNFEnv(BaseGameEnv):
         self._ep_rl_steps += 1
         self._ep_total_ticks += n
         self._total_rl_steps += 1
-        if n > self._ep_max_skip:
-            self._ep_max_skip = n
+        if n > self._ep_max_window_ticks:
+            self._ep_max_window_ticks = n
+        overrun = max(0, n - self._action_window_ticks)
+        if overrun > self._ep_max_overrun_ticks:
+            self._ep_max_overrun_ticks = overrun
 
         accelerating = bool(float(action[1]) >= 0.5)
         lidar_rays   = self._lidar.get_distances() if self._lidar is not None else None
@@ -283,7 +293,9 @@ class TMNFEnv(BaseGameEnv):
             "ep_rl_steps": self._ep_rl_steps,
             "ep_total_ticks": self._ep_total_ticks,
             "ep_skipped_ticks": self._ep_total_ticks - self._ep_rl_steps,
-            "ep_max_skip": self._ep_max_skip,
+            "ep_max_window_ticks": self._ep_max_window_ticks,
+            "ep_max_overrun_ticks": self._ep_max_overrun_ticks,
+            "ep_max_skip": self._ep_max_window_ticks,  # back-compat alias
             "termination_reason": termination_reason,
         }
 
@@ -312,9 +324,11 @@ class TMNFEnv(BaseGameEnv):
         skipped = self._ep_total_ticks - self._ep_rl_steps
         avg = self._ep_total_ticks / self._ep_rl_steps if self._ep_rl_steps else 0.0
         logger.debug(
-            "[skip] ep_step %d | rl_steps=%d  game_ticks=%d  skipped=%d  avg=%.2f  max=%d",
+            "[skip] ep_step %d | rl_steps=%d  game_ticks=%d  skipped=%d  avg=%.2f  "
+            "max_window=%d  max_overrun=%d  window_size=%d",
             self._total_rl_steps, self._ep_rl_steps, self._ep_total_ticks,
-            skipped, avg, self._ep_max_skip
+            skipped, avg, self._ep_max_window_ticks, self._ep_max_overrun_ticks,
+            self._action_window_ticks,
         )
 
     def _build_obs(self, step: StepState) -> np.ndarray:  # type: ignore[override]
@@ -359,6 +373,8 @@ def make_env(
     speed: float = 10.0,
     in_game_episode_s: float = 20.0,
     n_lidar_rays: int = 0,
+    action_window_ticks: int = 1,
+    decision_offset_pct: float = 0.75,
 ) -> TMNFEnv:
     """
     Factory that wires up a TMNFEnv from an experiment directory.
@@ -376,4 +392,6 @@ def make_env(
         reward_config=reward_config,
         max_episode_time_s=in_game_episode_s / speed,
         n_lidar_rays=n_lidar_rays,
+        action_window_ticks=action_window_ticks,
+        decision_offset_pct=decision_offset_pct,
     )

--- a/grid_search.py
+++ b/grid_search.py
@@ -75,6 +75,8 @@ _ABBREV = {
     "policy_type": "pt",
     "do_pretrain": "dpt",
     "patience": "pat",
+    "action_window_ticks": "win",
+    "decision_offset_pct": "dec",
     # neural_net policy params
     "hidden_sizes": "hs",
     # genetic policy params

--- a/main.py
+++ b/main.py
@@ -80,6 +80,8 @@ def main() -> None:
     obs_spec     = TMNF_OBS_SPEC.with_lidar(n_lidar_rays)
     policy_type  = p.get("policy_type", "hill_climbing")
     policy_params = p.get("policy_params") or {}
+    action_window_ticks = p.get("action_window_ticks", 1)
+    decision_offset_pct = p.get("decision_offset_pct", 0.75)
     re_initialize = args.re_initialize
 
     # Factory callables for TMNF-specific policy types (injected into framework).
@@ -182,10 +184,12 @@ def main() -> None:
     data = train_rl(
         experiment_name     = args.experiment,
         make_env_fn         = lambda: make_env(
-            experiment_dir    = experiment_dir,
-            speed             = p["speed"],
-            in_game_episode_s = p["in_game_episode_s"],
-            n_lidar_rays      = n_lidar_rays,
+            experiment_dir      = experiment_dir,
+            speed               = p["speed"],
+            in_game_episode_s   = p["in_game_episode_s"],
+            n_lidar_rays        = n_lidar_rays,
+            action_window_ticks = action_window_ticks,
+            decision_offset_pct = decision_offset_pct,
         ),
         obs_spec            = obs_spec,
         head_names          = ["steer", "accel", "brake"],

--- a/tests/test_env_termination.py
+++ b/tests/test_env_termination.py
@@ -67,7 +67,9 @@ def _make_env(
     env._laps_completed = 0
     env._ep_rl_steps = 0
     env._ep_total_ticks = 0
-    env._ep_max_skip = 0
+    env._ep_max_window_ticks = 0
+    env._ep_max_overrun_ticks = 0
+    env._action_window_ticks = 1
     env._total_rl_steps = 0
     env._client = MagicMock()
     env._log_skip_stats = MagicMock()

--- a/tests/test_rl_client.py
+++ b/tests/test_rl_client.py
@@ -145,5 +145,196 @@ class TestDefaultAction(unittest.TestCase):
         np.testing.assert_array_equal(_DEFAULT_ACTION, [0.0, 0.0, 0.0])
 
 
+def _make_windowed_client(action_window_ticks, decision_offset_pct=0.75):
+    """Instantiate RLClient with windowing parameters and a mocked Centerline."""
+    with patch("games.tmnf.clients.rl_client.Centerline", return_value=MagicMock()):
+        return RLClient(
+            centerline_file="fake.npy",
+            speed=1.0,
+            action_window_ticks=action_window_ticks,
+            decision_offset_pct=decision_offset_pct,
+        )
+
+
+class TestActionWindow(unittest.TestCase):
+    """Verify action-windowing behavior for action_window_ticks > 1."""
+
+    def setUp(self):
+        # window=4, decision_offset=0.75 → decision_idx=3.
+        # Observation phase: ticks 0, 1, 2.
+        # Transit phase: tick 3.
+        self.client = _make_windowed_client(action_window_ticks=4, decision_offset_pct=0.75)
+        self.client._running = True
+        self.client._finish_respawn_pending = False
+        self.client._simulation_finish_delivered = False
+        # Start mid-window so we don't auto-commit on tick 0.
+        self.client._force_commit_next_tick = False
+        self.state_data = _make_state_data()
+
+    def _iface(self):
+        iface = MagicMock()
+        iface.get_simulation_state.return_value = MagicMock()
+        return iface
+
+    def _run_step(self, iface, action=None, time_ms=1000, state_data=None):
+        if action is not None:
+            self.client.set_action(action)
+        sd = state_data if state_data is not None else self.state_data
+        with patch("games.tmnf.clients.rl_client.StateData", return_value=sd), \
+             patch.object(self.client, "_compute_yaw_error", return_value=0.0):
+            self.client.on_run_step(iface, time_ms)
+
+    def test_decision_idx_computed(self):
+        """decision_offset_pct=0.75 with window=4 → decision_idx=3."""
+        self.assertEqual(self.client._decision_idx, 3)
+
+    def test_first_tick_commits_pending_action(self):
+        """Tick 0 of a window calls set_input_state once with the pending action."""
+        iface = self._iface()
+        # window_tick=0 at start of test → tick 0 of a window.
+        self._run_step(iface, action=np.array([0.5, 1.0, 0.0], dtype=np.float32))
+        iface.set_input_state.assert_called_once_with(
+            accelerate=True, brake=False, steer=32768
+        )
+
+    def test_later_window_ticks_do_not_commit(self):
+        """Ticks 1, 2, 3 of a window do NOT call set_input_state.
+
+        Mid-window changes to the pending action are not applied to the game
+        until the next window-start.
+        """
+        iface = self._iface()
+        # Tick 0: commit with first action.
+        self._run_step(iface, action=np.array([0.5, 1.0, 0.0], dtype=np.float32))
+        iface.set_input_state.reset_mock()
+        # Ticks 1, 2, 3: change pending action but no commit should fire.
+        for _ in range(3):
+            self._run_step(iface, action=np.array([-1.0, 0.0, 1.0], dtype=np.float32))
+        iface.set_input_state.assert_not_called()
+
+    def test_observation_phase_emits_states_transit_does_not(self):
+        """Ticks 0, 1, 2 emit StepStates; tick 3 (transit) does not."""
+        iface = self._iface()
+        # Drain queue first.
+        while not self.client._state_queue.empty():
+            self.client._state_queue.get_nowait()
+        # Ticks 0, 1, 2 — should each enqueue a StepState.
+        for _ in range(3):
+            self._run_step(iface)
+            self.assertEqual(self.client._state_queue.qsize(), 1)
+            self.client._state_queue.get_nowait()  # drain
+        # Tick 3 — transit phase, no enqueue.
+        self._run_step(iface)
+        self.assertTrue(self.client._state_queue.empty())
+
+    def test_transit_phase_ticks_accumulate_via_drain_and_put(self):
+        """The next window's tick 0 StepState absorbs suppressed transit ticks."""
+        iface = self._iface()
+        # Run a full window: ticks 0, 1, 2 emit; tick 3 (transit) suppresses.
+        for _ in range(4):
+            self._run_step(iface)
+        # Drain queue (whatever's left from observation phase).
+        while not self.client._state_queue.empty():
+            self.client._state_queue.get_nowait()
+        # Next tick is tick 0 of a new window — should emit and absorb the
+        # transit tick from the previous window. Exact count depends on
+        # _drain_and_put state; this just verifies emission.
+        self._run_step(iface)
+        self.assertEqual(self.client._state_queue.qsize(), 1)
+
+    def test_pending_action_locked_after_decision_tick(self):
+        """Action set during transit phase does NOT reach the game until next window-start."""
+        iface = self._iface()
+        # Tick 0: commit action A.
+        self._run_step(iface, action=np.array([0.5, 1.0, 0.0], dtype=np.float32))
+        # Ticks 1, 2, 3: set new action B every tick. None should commit.
+        for _ in range(3):
+            self._run_step(iface, action=np.array([-1.0, 0.0, 1.0], dtype=np.float32))
+        # Only the first tick's commit happened.
+        self.assertEqual(iface.set_input_state.call_count, 1)
+        # Tick 4 (next window's tick 0): commits action B.
+        iface.set_input_state.reset_mock()
+        self._run_step(iface)
+        iface.set_input_state.assert_called_once_with(
+            accelerate=False, brake=True, steer=-65536
+        )
+
+    def test_finish_forces_immediate_commit_and_emit(self):
+        """A finish detected during transit phase triggers commit + StepState."""
+        iface = self._iface()
+        # Run through ticks 0, 1, 2 (observation) — drain.
+        for _ in range(3):
+            self._run_step(iface)
+        while not self.client._state_queue.empty():
+            self.client._state_queue.get_nowait()
+        iface.set_input_state.reset_mock()
+        # Tick 3: transit, but inject finish.
+        finished_state = _make_state_data(track_progress=0.97)
+        self._run_step(iface, action=np.array([1.0, 1.0, 0.0], dtype=np.float32),
+                       state_data=finished_state)
+        iface.set_input_state.assert_called_once()
+        self.assertEqual(self.client._state_queue.qsize(), 1)
+        emitted = self.client._state_queue.get_nowait()
+        self.assertTrue(emitted.finished)
+
+    def test_hard_crash_forces_commit(self):
+        """A hard-crash detected during transit phase triggers commit + StepState."""
+        from games.tmnf.clients.rl_client import _HARD_CRASH_THRESHOLD_M
+        iface = self._iface()
+        for _ in range(3):
+            self._run_step(iface)
+        while not self.client._state_queue.empty():
+            self.client._state_queue.get_nowait()
+        iface.set_input_state.reset_mock()
+        crash_state = _make_state_data(lateral_offset=_HARD_CRASH_THRESHOLD_M + 1.0)
+        self._run_step(iface, state_data=crash_state)
+        iface.set_input_state.assert_called_once()
+        self.assertEqual(self.client._state_queue.qsize(), 1)
+        emitted = self.client._state_queue.get_nowait()
+        self.assertTrue(emitted.done)
+
+    def test_decision_idx_clamped_to_at_least_one(self):
+        """decision_offset_pct very small still yields decision_idx >= 1."""
+        client = _make_windowed_client(action_window_ticks=2, decision_offset_pct=0.01)
+        self.assertEqual(client._decision_idx, 1)
+
+    def test_decision_idx_clamped_to_at_most_window_minus_one(self):
+        """decision_offset_pct=1.0 leaves at least one transit tick."""
+        client = _make_windowed_client(action_window_ticks=4, decision_offset_pct=1.0)
+        self.assertEqual(client._decision_idx, 3)
+
+    def test_legacy_window_one_commits_every_tick(self):
+        """action_window_ticks=1 (default): every tick commits and emits."""
+        client = _make_windowed_client(action_window_ticks=1)
+        client._running = True
+        client._finish_respawn_pending = False
+        client._simulation_finish_delivered = False
+        self.assertEqual(client._decision_idx, 0)
+        iface = MagicMock()
+        iface.get_simulation_state.return_value = MagicMock()
+        for i in range(5):
+            with patch("games.tmnf.clients.rl_client.StateData", return_value=_make_state_data()), \
+                 patch.object(client, "_compute_yaw_error", return_value=0.0):
+                client.set_action(np.array([0.0, 1.0, 0.0], dtype=np.float32))
+                client.on_run_step(iface, i)
+        self.assertEqual(iface.set_input_state.call_count, 5)
+
+
+class TestRLClientConstructorValidation(unittest.TestCase):
+    def test_action_window_ticks_must_be_positive(self):
+        with patch("games.tmnf.clients.rl_client.Centerline", return_value=MagicMock()):
+            with self.assertRaises(AssertionError):
+                RLClient(centerline_file="fake.npy", speed=1.0, action_window_ticks=0)
+
+    def test_decision_offset_pct_bounds(self):
+        with patch("games.tmnf.clients.rl_client.Centerline", return_value=MagicMock()):
+            with self.assertRaises(AssertionError):
+                RLClient(centerline_file="fake.npy", speed=1.0,
+                         action_window_ticks=4, decision_offset_pct=0.0)
+            with self.assertRaises(AssertionError):
+                RLClient(centerline_file="fake.npy", speed=1.0,
+                         action_window_ticks=4, decision_offset_pct=1.5)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_rl_client.py
+++ b/tests/test_rl_client.py
@@ -167,7 +167,7 @@ class TestActionWindow(unittest.TestCase):
         self.client._running = True
         self.client._finish_respawn_pending = False
         self.client._simulation_finish_delivered = False
-        # Start mid-window so we don't auto-commit on tick 0.
+        # Start at window_tick=0 (window start); only disable any forced extra commit.
         self.client._force_commit_next_tick = False
         self.state_data = _make_state_data()
 

--- a/tests/test_rl_client.py
+++ b/tests/test_rl_client.py
@@ -228,7 +228,13 @@ class TestActionWindow(unittest.TestCase):
         self.assertTrue(self.client._state_queue.empty())
 
     def test_transit_phase_ticks_accumulate_via_drain_and_put(self):
-        """The next window's tick 0 StepState absorbs suppressed transit ticks."""
+        """Transit ticks are carried into the next window's first StepState.
+
+        Window=4: ticks 0-2 (observation) each emit a StepState; tick 3
+        (transit) is suppressed and increments _pending_transit_ticks.  The
+        next window's tick 0 must add that pending count to its own
+        ticks_this_step so no game tick is lost.
+        """
         iface = self._iface()
         # Run a full window: ticks 0, 1, 2 emit; tick 3 (transit) suppresses.
         for _ in range(4):
@@ -236,11 +242,16 @@ class TestActionWindow(unittest.TestCase):
         # Drain queue (whatever's left from observation phase).
         while not self.client._state_queue.empty():
             self.client._state_queue.get_nowait()
-        # Next tick is tick 0 of a new window — should emit and absorb the
-        # transit tick from the previous window. Exact count depends on
-        # _drain_and_put state; this just verifies emission.
+        # Verify the counter was incremented for the suppressed transit tick.
+        self.assertEqual(self.client._pending_transit_ticks, 1)
+        # Next tick is tick 0 of a new window — emits with ticks_this_step=2:
+        # 1 for the current tick + 1 for the suppressed transit tick.
         self._run_step(iface)
         self.assertEqual(self.client._state_queue.qsize(), 1)
+        emitted = self.client._state_queue.get_nowait()
+        self.assertEqual(emitted.ticks_this_step, 2)
+        # Counter must be reset after emission.
+        self.assertEqual(self.client._pending_transit_ticks, 0)
 
     def test_pending_action_locked_after_decision_tick(self):
         """Action set during transit phase does NOT reach the game until next window-start."""


### PR DESCRIPTION
Act on the game only every X game ticks instead of every tick. The window
has an observation phase where the RL thread iteratively refines a pending
action, then a transit phase that locks the decision and provides
deterministic compute slack before the next commit boundary. Mimics human
reaction delay and makes runs reproducible at coarse-grained input cadence.

Two new training_params.yaml keys (default to legacy behavior):
- action_window_ticks: 1   (>1 enables windowing; counted in game ticks,
                            independent of `speed`)
- decision_offset_pct: 0.75 (fraction of window for observation phase)

Game thread (RLClient.on_run_step) holds _pending_action vs _committed_action,
emits StepStates only during the observation phase, and commits + fires
set_input_state once per window. Termination (finish / hard crash) forces
an immediate mid-window commit so latency is never delayed.

Telemetry: split ep_max_skip into ep_max_window_ticks (normal cadence) and
ep_max_overrun_ticks (true RL-thread lag signal); ep_max_skip retained as
back-compat alias.

13 new unit tests cover commit timing, StepState gating, decision-tick
clamping, mid-window termination, and legacy window=1 behavior.