### PR TITLE
fix: force Agg backend to prevent TkAgg GC crash between grid search experiments

### DIFF
--- a/framework/analytics.py
+++ b/framework/analytics.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 logger = logging.getLogger(__name__)
 
 try:
+    import matplotlib
+    matplotlib.use('Agg')  # prevent TkAgg GC-from-daemon-thread crashes between experiments
     import matplotlib.pyplot as plt
     import matplotlib.patches as mpatches
     import matplotlib.cm as cm

--- a/framework/analytics.py
+++ b/framework/analytics.py
@@ -20,8 +20,10 @@ from dataclasses import dataclass, field
 logger = logging.getLogger(__name__)
 
 try:
+    import sys
     import matplotlib
-    matplotlib.use('Agg')  # prevent TkAgg GC-from-daemon-thread crashes between experiments
+    if 'matplotlib.pyplot' not in sys.modules:
+        matplotlib.use('Agg')  # prevent TkAgg GC-from-daemon-thread crashes between experiments
     import matplotlib.pyplot as plt
     import matplotlib.patches as mpatches
     import matplotlib.cm as cm

--- a/games/tmnf/analytics.py
+++ b/games/tmnf/analytics.py
@@ -13,8 +13,10 @@ import os
 import numpy as np
 import yaml
 
+import sys
 import matplotlib
-matplotlib.use('Agg')  # prevent TkAgg GC-from-daemon-thread crashes between experiments
+if 'matplotlib.pyplot' not in sys.modules:
+    matplotlib.use('Agg')  # prevent TkAgg GC-from-daemon-thread crashes between experiments
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
 from matplotlib.axes import Axes

--- a/games/tmnf/analytics.py
+++ b/games/tmnf/analytics.py
@@ -13,6 +13,8 @@ import os
 import numpy as np
 import yaml
 
+import matplotlib
+matplotlib.use('Agg')  # prevent TkAgg GC-from-daemon-thread crashes between experiments
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
 from matplotlib.axes import Axes


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- On Windows, matplotlib defaults to `TkAgg`, which binds a Tcl/Tk interpreter to the main thread and creates `tkinter.Image`/`tkinter.Variable` objects during figure rendering
- `plt.close(fig)` closes the figure logically but those Tk objects linger until Python's GC collects them
- When the next grid search experiment starts and TMInterface daemon threads spin up, the cyclic GC can fire from a non-main thread, finalising the stale Tk objects and calling back into the Tcl interpreter → `RuntimeError: main thread is not in main loop` / `Tcl_AsyncDelete: async handler deleted by the wrong thread`
- Fix: `matplotlib.use('Agg')` before pyplot import in both analytics modules — Agg is a pure raster renderer with zero Tk dependency

Closes #70

## Test plan

- [ ] Run a grid search with ≥2 combinations and confirm no tkinter/Tcl errors appear between experiments
- [ ] Confirm all PNG plots are still generated correctly in `experiments/<track>/<name>/results/`
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N25HY88XY8idVEoRu1C9zc)_