### PR TITLE
Add neural_dqn, reinforce, and lstm policies with grid search configs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,9 @@ All policies live in `policies.py`, inherit `BasePolicy`. Active policy set via 
 | `mcts` | `MCTSPolicy` | UCT-style online Q-learner (UCB1). No env cloning — builds value table over real episodes. |
 | `genetic` | `GeneticPolicy` | Population of `WeightedLinearPolicy` instances. Evolutionary selection + crossover + mutation. |
 | `cmaes` | `CMAESPolicy` | `(μ/μ_w, λ)-CMA-ES` (Hansen 2016) over flat `WeightedLinearPolicy` weights. Automatic step-size + covariance adaptation. |
+| `neural_dqn` | `NeuralDQNPolicy` | Deep Q-learning with replay buffer + target network. |
+| `reinforce` | `REINFORCEPolicy` | Monte Carlo policy gradient (optional running-mean baseline). |
+| `lstm` | `LSTMEvolutionPolicy` | Recurrent (LSTM) policy, trained by evolutionary search over network weights. |
 
 `SimplePolicy` = non-trainable hand-coded PD baseline (see `steering.py`).
 
@@ -94,6 +97,53 @@ Implements `(μ/μ_w, λ)-CMA-ES` (Hansen 2016) over concatenated `[steer | acce
 `n_sims` controls generations; total episodes = `n_sims × population_size`. No `mutation_scale` tuning needed — σ adapts automatically.
 
 `save()` writes champion in `WeightedLinearPolicy` YAML format so analytics, weight heatmaps, inference work unchanged.
+
+### NeuralDQNPolicy
+
+MLP Q-network (pure numpy) with experience replay and a periodically-synced target network. Action space is the 9-element discrete set (`DISCRETE_ACTIONS`). ε-greedy exploration decays linearly from `epsilon_start` to `epsilon_end` over `epsilon_decay_steps` environment steps.
+
+**Hyperparams** (in `policy_params`):
+
+| Param | Default | Description |
+|---|---|---|
+| `hidden_sizes` | `[64, 64]` | Hidden layer widths of the Q-network MLP |
+| `replay_buffer_size` | `10000` | Max transitions stored in the replay buffer |
+| `batch_size` | `64` | Transitions sampled per gradient update |
+| `min_replay_size` | `500` | Buffer must reach this size before training starts |
+| `target_update_freq` | `200` | Steps between copying online weights → target network |
+| `learning_rate` | `0.001` | Adam-style gradient step size |
+| `epsilon_start` | `1.0` | Initial exploration rate |
+| `epsilon_end` | `0.05` | Final exploration rate |
+| `epsilon_decay_steps` | `5000` | Steps over which ε decays linearly |
+| `gamma` | `0.99` | Discount factor |
+
+### REINFORCEPolicy
+
+Monte Carlo policy-gradient over the 9-element discrete action set. Collects full episodes, computes discounted returns, optionally subtracts a running-mean baseline, then updates the softmax policy network via gradient ascent.
+
+**Hyperparams** (in `policy_params`):
+
+| Param | Default | Description |
+|---|---|---|
+| `hidden_sizes` | `[64, 64]` | Hidden layer widths of the policy MLP |
+| `learning_rate` | `0.001` | Gradient step size |
+| `gamma` | `0.99` | Discount factor for return computation |
+| `entropy_coeff` | `0.01` | Entropy regularisation weight (encourages exploration) |
+| `baseline` | `"running_mean"` | Return baseline: `"running_mean"` or `"none"` |
+
+### LSTMEvolutionPolicy
+
+LSTM recurrent policy trained by CMA-ES-style evolutionary search over flattened network weights. The hidden state is reset each episode; at each step the LSTM receives the current observation and emits logits over the 9-element discrete action set.
+
+**Hyperparams** (in `policy_params`):
+
+| Param | Default | Description |
+|---|---|---|
+| `hidden_size` | `32` | LSTM hidden/cell state dimensionality |
+| `population_size` | `20` | λ — offspring evaluated per generation |
+| `initial_sigma` | `0.05` | Starting perturbation scale (smaller than CMAESPolicy because the LSTM weight space is larger) |
+
+`n_sims` controls generations; total episodes = `n_sims × population_size`. Saved champion weights are incompatible across different `hidden_size` or `n_lidar_rays` values — changing either requires `--re-initialize`.
 
 ---
 

--- a/games/tmnf/config/gs_lstm_v1.yaml
+++ b/games/tmnf/config/gs_lstm_v1.yaml
@@ -18,9 +18,9 @@
 # Combos: 2 x 2 x 2 = 8
 
 base_name: "gs_lstm_v1"
+track: a03_centerline
 
 training_params:
-  track: a03_centerline
   speed: 10.0
   n_sims: 30
   in_game_episode_s: 90.0

--- a/games/tmnf/config/gs_lstm_v1.yaml
+++ b/games/tmnf/config/gs_lstm_v1.yaml
@@ -1,0 +1,45 @@
+# Grid search: LSTMEvolutionPolicy (recurrent policy trained by evolutionary search)
+#
+# Primary axes:
+#   hidden_size     — LSTM hidden/cell dimensionality. Larger = more expressive
+#                     recurrent memory but a bigger weight vector to search over.
+#                     NOTE: changing hidden_size between runs requires
+#                     --re-initialize (saved checkpoints are incompatible).
+#   population_size — λ offspring evaluated per generation, identical semantics
+#                     to CMAESPolicy. More offspring → better covariance estimate
+#                     but more episodes per generation.
+#   initial_sigma   — starting perturbation scale. Smaller than CMAESPolicy's
+#                     default (0.3) because the LSTM weight vector is large and
+#                     large perturbations produce effectively random policies.
+#
+# n_sims = generations; total episodes = n_sims × population_size.
+# 30 gens × 20 individuals = 600 episodes, comparable to gs_cmaes.yaml.
+#
+# Combos: 2 x 2 x 2 = 8
+
+base_name: "gs_lstm_v1"
+
+training_params:
+  track: a03_centerline
+  speed: 10.0
+  n_sims: 30
+  in_game_episode_s: 90.0
+  n_lidar_rays: 8
+  policy_type: lstm
+
+  # --- Search axes ---
+  hidden_size: [16, 32]
+  population_size: [10, 20]
+  initial_sigma: [0.02, 0.05]
+
+reward_params:
+  progress_weight: 10000.0
+  centerline_weight: 0.0
+  centerline_exp: 0.0
+  finish_bonus: 5000.0
+  finish_time_weight: -5.0
+  par_time_s: 60.0
+  accel_bonus: 1.0
+  airborne_penalty: -1.0
+  crash_threshold_m: 25.0
+  lidar_wall_weight: -5.0

--- a/games/tmnf/config/gs_neural_dqn_v1.yaml
+++ b/games/tmnf/config/gs_neural_dqn_v1.yaml
@@ -1,0 +1,58 @@
+# Grid search: NeuralDQNPolicy (Deep Q-Network with replay buffer + target network)
+#
+# Primary axes:
+#   learning_rate       — controls how aggressively the Q-network updates on
+#                         each sampled batch. Too high → unstable value estimates;
+#                         too low → slow convergence within the episode budget.
+#   batch_size          — transitions sampled per gradient step. Larger batches
+#                         give more stable gradient estimates but are slower per
+#                         step; smaller batches explore the buffer more frequently.
+#   target_update_freq  — steps between syncing the online network to the target
+#                         network. More frequent updates can destabilise training
+#                         (moving target); less frequent means the target lags.
+#   epsilon_decay_steps — steps over which ε decays from 1.0 → 0.05. Faster
+#                         decay commits to exploitation sooner; slower keeps
+#                         exploration active longer relative to episode count.
+#
+# n_sims controls total training steps (not episode count directly — DQN trains
+# step-by-step inside each episode). 100 sims with 90 s episodes at 10x speed
+# gives a large step budget for replay learning to kick in.
+#
+# Combos: 2 x 2 x 2 x 2 = 16
+
+base_name: "gs_neural_dqn_v1"
+
+training_params:
+  track: a03_centerline
+  speed: 10.0
+  n_sims: 100
+  in_game_episode_s: 90.0
+  n_lidar_rays: 8
+  policy_type: neural_dqn
+
+  # --- Search axes ---
+  learning_rate: [0.0005, 0.001]
+  batch_size: [32, 64]
+  target_update_freq: [100, 200]
+  epsilon_decay_steps: [2000, 5000]
+
+  # Fixed policy params (nested to avoid being treated as sweep axes)
+  gamma: 0.99
+  policy_params:
+    hidden_sizes: [64, 64]
+    replay_buffer_size: 10000
+    min_replay_size: 500
+    epsilon_start: 1.0
+    epsilon_end: 0.05
+
+reward_params:
+  progress_weight: 10000.0
+  centerline_weight: 0.0
+  centerline_exp: 0.0
+  finish_bonus: 5000.0
+  finish_time_weight: -5.0
+  par_time_s: 60.0
+  accel_bonus: 1.0
+  airborne_penalty: -1.0
+  crash_threshold_m: 25.0
+  lidar_wall_weight: -5.0

--- a/games/tmnf/config/gs_neural_dqn_v1.yaml
+++ b/games/tmnf/config/gs_neural_dqn_v1.yaml
@@ -21,9 +21,9 @@
 # Combos: 2 x 2 x 2 x 2 = 16
 
 base_name: "gs_neural_dqn_v1"
+track: a03_centerline
 
 training_params:
-  track: a03_centerline
   speed: 10.0
   n_sims: 100
   in_game_episode_s: 90.0

--- a/games/tmnf/config/gs_reinforce_v1.yaml
+++ b/games/tmnf/config/gs_reinforce_v1.yaml
@@ -1,0 +1,50 @@
+# Grid search: REINFORCEPolicy (Monte Carlo policy gradient)
+#
+# Primary axes:
+#   learning_rate  — gradient step size applied after each full episode return.
+#                    REINFORCE has high variance, so a smaller lr is often safer
+#                    than in supervised settings; too large → divergence.
+#   entropy_coeff  — weight on the entropy bonus added to the policy gradient
+#                    loss. Higher values force more exploration; 0.0 disables it.
+#   baseline       — return baseline to reduce gradient variance.
+#                    "running_mean" subtracts an exponential moving average of
+#                    past returns; "none" uses raw discounted returns.
+#   hidden_sizes   — MLP architecture. Wider/deeper networks can represent more
+#                    complex policies but are harder to train with pure MC gradients.
+#
+# n_sims = number of full episodes (each episode = one MC rollout + one gradient
+# update). REINFORCE can be slow to converge; 200 episodes is a reasonable budget
+# for verifying that the signal is positive.
+#
+# Combos: 2 x 2 x 2 x 2 = 16
+
+base_name: "gs_reinforce_v1"
+
+training_params:
+  track: a03_centerline
+  speed: 10.0
+  n_sims: 200
+  in_game_episode_s: 90.0
+  n_lidar_rays: 8
+  policy_type: reinforce
+
+  # --- Search axes ---
+  learning_rate: [0.0005, 0.001]
+  entropy_coeff: [0.0, 0.01]
+  baseline: ["running_mean", "none"]
+  hidden_sizes: [[64, 64], [128, 64]]
+
+  # Fixed policy params
+  gamma: 0.99
+
+reward_params:
+  progress_weight: 10000.0
+  centerline_weight: 0.0
+  centerline_exp: 0.0
+  finish_bonus: 5000.0
+  finish_time_weight: -5.0
+  par_time_s: 60.0
+  accel_bonus: 1.0
+  airborne_penalty: -1.0
+  crash_threshold_m: 25.0
+  lidar_wall_weight: -5.0

--- a/games/tmnf/config/gs_reinforce_v1.yaml
+++ b/games/tmnf/config/gs_reinforce_v1.yaml
@@ -19,9 +19,9 @@
 # Combos: 2 x 2 x 2 x 2 = 16
 
 base_name: "gs_reinforce_v1"
+track: a03_centerline
 
 training_params:
-  track: a03_centerline
   speed: 10.0
   n_sims: 200
   in_game_episode_s: 90.0

--- a/grid_search.py
+++ b/grid_search.py
@@ -152,7 +152,51 @@ _POLICY_PARAM_MAP = {
     "eval_episodes": "eval_episodes",  # genetic / cmaes
 }
 
+# Guard against silent regressions when adding or editing promoted top-level
+# training_params keys. If one of these entries is removed or renamed
+# incorrectly, grid configs can silently fall back to policy defaults.
+_EXPECTED_POLICY_PARAM_MAP = {
+    "hidden_sizes": "hidden_sizes",
+    "hidden_size": "hidden_size",
+    "learning_rate": "learning_rate",
+    "entropy_coeff": "entropy_coeff",
+    "baseline": "baseline",
+    "batch_size": "batch_size",
+    "target_update_freq": "target_update_freq",
+    "epsilon_decay_steps": "epsilon_decay_steps",
+    "epsilon": "epsilon",
+    "epsilon_decay": "epsilon_decay",
+    "epsilon_min": "epsilon_min",
+    "alpha": "alpha",
+    "gamma": "gamma",
+    "n_bins": "n_bins",
+    "mcts_c": "c",
+    "population_size": "population_size",
+    "elite_k": "elite_k",
+    "initial_sigma": "initial_sigma",
+}
 
+
+def _validate_policy_param_map() -> None:
+    """Fail fast if promoted training_params keys are miswired.
+
+    This provides a lightweight regression check in environments where the
+    pure-logic promotion path is imported without the full training stack.
+    """
+    mismatches = {
+        src: (expected_dst, _POLICY_PARAM_MAP.get(src))
+        for src, expected_dst in _EXPECTED_POLICY_PARAM_MAP.items()
+        if _POLICY_PARAM_MAP.get(src) != expected_dst
+    }
+    if mismatches:
+        details = ", ".join(
+            f"{src}->{actual!r} (expected {expected!r})"
+            for src, (expected, actual) in sorted(mismatches.items())
+        )
+        raise RuntimeError(f"Invalid _POLICY_PARAM_MAP entries: {details}")
+
+
+_validate_policy_param_map()
 def _fmt_value(v: Any) -> str:
     """Format a param value for use in a directory name.
 

--- a/grid_search.py
+++ b/grid_search.py
@@ -77,8 +77,16 @@ _ABBREV = {
     "policy_type": "pt",
     "do_pretrain": "dpt",
     "patience": "pat",
-    # neural_net policy params
+    # neural_net / reinforce / neural_dqn policy params
     "hidden_sizes": "hs",
+    "hidden_size": "hsize",
+    "learning_rate": "lr",
+    "entropy_coeff": "ec",
+    "baseline": "base",
+    # neural_dqn params
+    "batch_size": "bs",
+    "target_update_freq": "tuf",
+    "epsilon_decay_steps": "eds",
     # genetic policy params
     "population_size": "pop",
     "elite_k": "ek",
@@ -119,17 +127,24 @@ _ABBREV = {
 # Allows grid axes like `epsilon: [0.5, 1.0]` without nesting inside policy_params.
 # mcts_c is renamed to c because that's what MCTSPolicy.from_cfg expects.
 _POLICY_PARAM_MAP = {
-    "hidden_sizes": "hidden_sizes",  # neural_net
+    "hidden_sizes": "hidden_sizes",  # neural_net / reinforce / neural_dqn
+    "hidden_size": "hidden_size",  # lstm
+    "learning_rate": "learning_rate",  # reinforce / neural_dqn
+    "entropy_coeff": "entropy_coeff",  # reinforce
+    "baseline": "baseline",  # reinforce
+    "batch_size": "batch_size",  # neural_dqn
+    "target_update_freq": "target_update_freq",  # neural_dqn
+    "epsilon_decay_steps": "epsilon_decay_steps",  # neural_dqn
     "epsilon": "epsilon",  # epsilon_greedy
     "epsilon_decay": "epsilon_decay",  # epsilon_greedy
     "epsilon_min": "epsilon_min",  # epsilon_greedy
     "alpha": "alpha",  # epsilon_greedy / mcts
-    "gamma": "gamma",  # epsilon_greedy / mcts
+    "gamma": "gamma",  # epsilon_greedy / mcts / neural_dqn / reinforce
     "n_bins": "n_bins",  # epsilon_greedy / mcts
     "mcts_c": "c",  # mcts (renamed)
-    "population_size": "population_size",  # genetic / cmaes
+    "population_size": "population_size",  # genetic / cmaes / lstm
     "elite_k": "elite_k",  # genetic
-    "initial_sigma": "initial_sigma",  # cmaes
+    "initial_sigma": "initial_sigma",  # cmaes / lstm
 }
 
 

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -1,7 +1,7 @@
 """Tests for grid_search.py — grid expansion and name generation."""
 from __future__ import annotations
 
-from grid_search import _expand_grid, _make_experiment_name, _fmt_value
+from grid_search import _expand_grid, _make_experiment_name, _fmt_value, _build_policy_params, _POLICY_PARAM_MAP
 
 
 class TestExpandGrid:
@@ -80,6 +80,58 @@ class TestMakeExperimentName:
     def test_unknown_key_uses_key_itself(self):
         name = _make_experiment_name("gs", {"my_custom_param": 42}, ["my_custom_param"])
         assert "my_custom_param42" in name
+
+
+class TestBuildPolicyParams:
+    def test_nested_policy_params_passed_through(self):
+        t = {"policy_params": {"hidden_sizes": [64, 64], "gamma": 0.99}}
+        pp = _build_policy_params(t)
+        assert pp["hidden_sizes"] == [64, 64]
+        assert pp["gamma"] == 0.99
+
+    def test_top_level_key_promoted_to_policy_params(self):
+        t = {"learning_rate": 0.001, "batch_size": 32}
+        pp = _build_policy_params(t)
+        assert pp["learning_rate"] == 0.001
+        assert pp["batch_size"] == 32
+
+    def test_top_level_overrides_nested(self):
+        t = {"learning_rate": 0.005, "policy_params": {"learning_rate": 0.001}}
+        pp = _build_policy_params(t)
+        assert pp["learning_rate"] == 0.005
+
+    def test_all_new_policy_param_keys_are_mapped(self):
+        new_keys = {
+            "hidden_sizes", "hidden_size", "learning_rate", "entropy_coeff",
+            "baseline", "batch_size", "target_update_freq", "epsilon_decay_steps",
+        }
+        assert new_keys.issubset(_POLICY_PARAM_MAP.keys())
+
+    def test_promoted_keys_have_correct_target_names(self):
+        identity_mapped = {
+            "hidden_sizes", "hidden_size", "learning_rate", "entropy_coeff",
+            "baseline", "batch_size", "target_update_freq", "epsilon_decay_steps",
+        }
+        for key in identity_mapped:
+            assert _POLICY_PARAM_MAP[key] == key, (
+                f"_POLICY_PARAM_MAP[{key!r}] = {_POLICY_PARAM_MAP[key]!r}, expected {key!r}"
+            )
+
+    def test_no_policy_params_key_returns_empty(self):
+        t = {"speed": 10.0, "n_sims": 50}
+        pp = _build_policy_params(t)
+        assert pp == {}
+
+    def test_lstm_hidden_size_promoted(self):
+        t = {"hidden_size": 64}
+        pp = _build_policy_params(t)
+        assert pp["hidden_size"] == 64
+
+    def test_reinforce_baseline_promoted(self):
+        t = {"baseline": "none", "entropy_coeff": 0.05}
+        pp = _build_policy_params(t)
+        assert pp["baseline"] == "none"
+        assert pp["entropy_coeff"] == 0.05
 
 
 class TestFmtValue:


### PR DESCRIPTION
## Summary
This PR introduces three new reinforcement learning policies to the training framework: **NeuralDQNPolicy** (Deep Q-learning with replay buffer), **REINFORCEPolicy** (Monte Carlo policy gradient), and **LSTMEvolutionPolicy** (recurrent policy trained via evolutionary search). Corresponding grid search configuration files are added for hyperparameter tuning of each policy.

## Key Changes

### New Policies (documented in CLAUDE.md)
- **NeuralDQNPolicy**: MLP Q-network with experience replay and target network. Supports ε-greedy exploration with linear decay. Hyperparameters include `hidden_sizes`, `replay_buffer_size`, `batch_size`, `min_replay_size`, `target_update_freq`, `learning_rate`, `epsilon_start/end`, `epsilon_decay_steps`, and `gamma`.
- **REINFORCEPolicy**: Monte Carlo policy gradient over discrete actions with optional running-mean baseline for variance reduction. Hyperparameters include `hidden_sizes`, `learning_rate`, `gamma`, `entropy_coeff`, and `baseline` selection.
- **LSTMEvolutionPolicy**: Recurrent LSTM policy trained by CMA-ES-style evolutionary search. Hyperparameters include `hidden_size`, `population_size`, and `initial_sigma`. Note: saved weights are incompatible across different `hidden_size` or `n_lidar_rays` values.

### Grid Search Configurations
- **gs_neural_dqn_v1.yaml**: 16-combo grid (2×2×2×2) sweeping `learning_rate`, `batch_size`, `target_update_freq`, and `epsilon_decay_steps` with 100 simulations.
- **gs_reinforce_v1.yaml**: 16-combo grid (2×2×2×2) sweeping `learning_rate`, `entropy_coeff`, `baseline`, and `hidden_sizes` with 200 episodes.
- **gs_lstm_v1.yaml**: 8-combo grid (2×2×2) sweeping `hidden_size`, `population_size`, and `initial_sigma` with 30 generations (600 total episodes).

### Grid Search Framework Updates (grid_search.py)
- Extended `_SHORTHAND_MAP` to include new hyperparameters: `hidden_size`, `learning_rate`, `entropy_coeff`, `baseline`, `batch_size`, `target_update_freq`, `epsilon_decay_steps`.
- Updated `_POLICY_PARAM_MAP` to route these parameters to the correct policies and clarified which policies use shared parameters like `gamma`, `population_size`, and `initial_sigma`.

## Implementation Details
- All three policies operate on the 9-element discrete action set (`DISCRETE_ACTIONS`).
- NeuralDQNPolicy and REINFORCEPolicy use pure numpy MLPs; LSTMEvolutionPolicy uses LSTM cells.
- Grid search configurations include detailed comments explaining the role of each hyperparameter and the rationale for chosen ranges.
- Reward parameters are consistent across all three new grid search configs (progress-weighted with finish bonus).

https://claude.ai/code/session_01V4BBTxHav2bUyNfAK7pk8n