### PR TITLE
fix: guard matplotlib imports in games/tmnf/analytics.py

### DIFF
--- a/games/tmnf/analytics.py
+++ b/games/tmnf/analytics.py
@@ -13,10 +13,14 @@ import os
 import numpy as np
 import yaml
 
-import matplotlib.pyplot as plt
-import matplotlib.cm as cm
-from matplotlib.axes import Axes
-from matplotlib.figure import Figure
+try:
+    import matplotlib.pyplot as plt
+    import matplotlib.cm as cm
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+    _HAS_MPL = True
+except ImportError:
+    _HAS_MPL = False
 
 
 from framework.analytics import (
@@ -40,6 +44,8 @@ logger = logging.getLogger(__name__)
 
 
 def _save(fig: "Figure", path: str) -> None:
+    if not _HAS_MPL:
+        return
     fig.savefig(path, dpi=150, bbox_inches="tight")
     plt.close(fig)
 
@@ -52,6 +58,8 @@ _THROTTLE_COLORS = ["#c0392b", "#95a5a6", "#27ae60"]
 # ---------------------------------------------------------------------------
 
 def _plot_throttle_trace(ax: "Axes", throttle_state: list, title: str) -> None:
+    if not _HAS_MPL:
+        return
     steps = range(len(throttle_state))
     accel = [t[0] for t in throttle_state]
     brake = [t[1] for t in throttle_state]
@@ -70,6 +78,8 @@ def _plot_throttle_trace(ax: "Axes", throttle_state: list, title: str) -> None:
 # ---------------------------------------------------------------------------
 
 def plot_probe_paths(data: ExperimentData, results_dir: str) -> None:
+    if not _HAS_MPL:
+        return
     probes = [p for p in sorted(data.probe_results, key=lambda p: p.action_idx)
               if p.trace and p.trace.pos_x]
     if not probes:
@@ -95,6 +105,8 @@ def plot_probe_paths(data: ExperimentData, results_dir: str) -> None:
 # ---------------------------------------------------------------------------
 
 def plot_cold_start_best_run(data: ExperimentData, results_dir: str) -> None:
+    if not _HAS_MPL:
+        return
     best_sim = None
     best_r   = float("-inf")
     for restart in data.cold_start_restarts:
@@ -121,6 +133,8 @@ def plot_cold_start_best_run(data: ExperimentData, results_dir: str) -> None:
 
 
 def plot_cold_start_action_dist(data: ExperimentData, results_dir: str) -> None:
+    if not _HAS_MPL:
+        return
     restarts = data.cold_start_restarts
     xs = [r.restart for r in restarts]
     accel_pcts, brake_pcts = [], []
@@ -153,6 +167,8 @@ def plot_cold_start_action_dist(data: ExperimentData, results_dir: str) -> None:
 # ---------------------------------------------------------------------------
 
 def plot_greedy_best_run(data: ExperimentData, results_dir: str) -> None:
+    if not _HAS_MPL:
+        return
     if not data.greedy_sims:
         return
     best  = max(data.greedy_sims, key=lambda s: s.reward)
@@ -175,6 +191,8 @@ def plot_greedy_best_run(data: ExperimentData, results_dir: str) -> None:
 
 
 def plot_greedy_action_dist(data: ExperimentData, results_dir: str) -> None:
+    if not _HAS_MPL:
+        return
     sims = data.greedy_sims
     xs   = [s.sim for s in sims]
     accel_pcts, brake_pcts = [], []
@@ -199,6 +217,8 @@ def plot_greedy_action_dist(data: ExperimentData, results_dir: str) -> None:
 
 
 def plot_greedy_progress(data: ExperimentData, results_dir: str) -> None:
+    if not _HAS_MPL:
+        return
     sims = data.greedy_sims
     xs   = [s.sim for s in sims]
     ys   = [s.laps_completed + s.final_track_progress for s in sims]
@@ -241,6 +261,8 @@ def plot_greedy_progress(data: ExperimentData, results_dir: str) -> None:
 # ---------------------------------------------------------------------------
 
 def plot_weight_heatmap(data: ExperimentData, results_dir: str) -> None:
+    if not _HAS_MPL:
+        return
     with open(data.weights_file) as f:
         cfg = yaml.safe_load(f) or {}
     if "steer_weights" not in cfg:
@@ -266,6 +288,8 @@ def plot_weight_heatmap(data: ExperimentData, results_dir: str) -> None:
 
 
 def plot_weight_evolution(data: ExperimentData, results_dir: str) -> None:
+    if not _HAS_MPL:
+        return
     sims = [s for s in data.greedy_sims
             if s.weights is not None and "steer_weights" in s.weights]
     if len(sims) < 2:
@@ -319,6 +343,8 @@ _REASON_ORDER = ["finish", "crash", "hard_crash", "timeout"]
 
 
 def plot_termination_reasons(data: ExperimentData, results_dir: str) -> None:
+    if not _HAS_MPL:
+        return
     sims = data.greedy_sims
     if not sims:
         return
@@ -361,6 +387,8 @@ def plot_gs_comparison_paths(
     runs: list[tuple[str, ExperimentData]],
     summary_dir: str,
 ) -> None:
+    if not _HAS_MPL:
+        return
     traced = []
     for name, data in runs:
         if not data.greedy_sims:
@@ -393,6 +421,8 @@ def plot_gs_comparison_progress(
     runs: list[tuple[str, ExperimentData]],
     summary_dir: str,
 ) -> None:
+    if not _HAS_MPL:
+        return
     series = []
     for name, data in runs:
         if not data.greedy_sims:

--- a/tests/test_analytics_no_matplotlib.py
+++ b/tests/test_analytics_no_matplotlib.py
@@ -1,0 +1,64 @@
+"""Regression test: analytics modules must be importable without matplotlib.
+
+These tests verify that neither framework.analytics nor games.tmnf.analytics
+raises ImportError when matplotlib is absent from sys.modules.
+"""
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+
+def _import_without_matplotlib(module_name: str) -> None:
+    """Import *module_name* after hiding matplotlib from sys.modules."""
+    # Stash real modules
+    stashed = {k: v for k, v in sys.modules.items()
+               if k == "matplotlib" or k.startswith("matplotlib.")}
+
+    # Block matplotlib by inserting a dummy that raises on attribute access
+    blocker = types.ModuleType("matplotlib")
+    blocker.__spec__ = None  # prevents importlib from treating it as a package
+
+    def _raise(*a, **kw):
+        raise ImportError("matplotlib blocked for test")
+
+    blocker.__getattr__ = _raise  # type: ignore[assignment]
+
+    # Remove any real matplotlib entries and install blocker
+    for k in list(sys.modules):
+        if k == "matplotlib" or k.startswith("matplotlib."):
+            del sys.modules[k]
+    sys.modules["matplotlib"] = blocker
+    # Also block submodules that analytics files import directly
+    for sub in ("matplotlib.pyplot", "matplotlib.cm", "matplotlib.patches",
+                "matplotlib.axes", "matplotlib.figure", "matplotlib.colors"):
+        sys.modules[sub] = blocker  # type: ignore[assignment]
+
+    # Remove target module so it re-executes
+    for k in list(sys.modules):
+        if k == module_name or k.startswith(module_name + "."):
+            del sys.modules[k]
+
+    try:
+        importlib.import_module(module_name)
+    finally:
+        # Restore original state
+        for k in list(sys.modules):
+            if k == "matplotlib" or k.startswith("matplotlib."):
+                del sys.modules[k]
+        sys.modules.update(stashed)
+        # Re-import the target so subsequent tests see the real module
+        for k in list(sys.modules):
+            if k == module_name or k.startswith(module_name + "."):
+                del sys.modules[k]
+
+
+def test_framework_analytics_importable_without_matplotlib():
+    """framework.analytics must not raise ImportError when matplotlib is absent."""
+    _import_without_matplotlib("framework.analytics")
+
+
+def test_tmnf_analytics_importable_without_matplotlib():
+    """games.tmnf.analytics must not raise ImportError when matplotlib is absent."""
+    _import_without_matplotlib("games.tmnf.analytics")


### PR DESCRIPTION
## Summary

Closes #64.

- `games/tmnf/analytics.py` had bare top-level `matplotlib` imports that raised `ImportError` whenever the module was loaded without matplotlib installed (e.g. `poetry install --only tmnf-test`)
- Wraps the four imports in a `try/except ImportError` guard setting `_HAS_MPL`, matching the existing pattern in `framework/analytics.py`
- Adds `if not _HAS_MPL: return` early-return guards to all 13 plot/helper functions in the file

## Regression test

Adds `tests/test_analytics_no_matplotlib.py` which temporarily hides matplotlib from `sys.modules` and asserts that both `framework.analytics` and `games.tmnf.analytics` import cleanly without it.
