### PR TITLE
feat(games): add Assetto Corsa as an RL environment (#79)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Run tests
         # test_env_termination and test_grid_search require tminterface
         # (Windows-only, not on PyPI) so they are excluded from CI.
+        # tests/assetto_corsa/ uses a stub gym env (see test_smoke.py) so it
+        # runs on every PR without needing the assetto-corsa-rl package.
         # PYTHONPATH=. puts the repo root on sys.path so `import clients` etc.
         # resolve regardless of pytest's import-mode/rootdir handling.
         env:

--- a/docs/README_ASSETTO.md
+++ b/docs/README_ASSETTO.md
@@ -1,0 +1,65 @@
+# Assetto Corsa Integration
+
+This guide covers training agents against [Assetto Corsa](https://store.steampowered.com/app/244210/Assetto_Corsa/) via the `games/assetto_corsa/` package.
+
+## Install
+
+The Assetto Corsa integration depends on a Gymnasium-compatible AC wrapper that registers the `AssettoCorsa-v0` environment. Install the optional Poetry group:
+
+```bash
+poetry install --with assetto_corsa
+```
+
+Two viable upstream wrappers are known at the time of writing:
+
+- `assetto-corsa-rl` — referenced by issue #79; install with `pip install assetto-corsa-rl` if/when published to PyPI.
+- [`dasGringuen/assetto_corsa_gym`](https://github.com/dasGringuen/assetto_corsa_gym) — install from source per the repo's own instructions.
+
+The framework imports the wrapper lazily from inside `games.assetto_corsa.clients.ac_client`, so neither package needs to be installed for unit tests to run on Linux CI.
+
+## Pointing at a local AC installation
+
+The wrapper reads the AC install path from environment variables (the exact name depends on which wrapper you use; check its README). Typical values:
+
+```bash
+export ASSETTO_CORSA_INSTALL_DIR="C:/Program Files (x86)/Steam/steamapps/common/assettocorsa"
+```
+
+On Windows you can use `scripts/launch_assetto.ps1` to ensure the game is running before training starts. On Linux/macOS `scripts/launch_assetto.sh` is a no-op (the binary is Windows-only) but the gym wrapper itself still works.
+
+## Quick start
+
+```bash
+# 1. Make sure AC is running (Windows only).
+pwsh scripts/launch_assetto.ps1
+
+# 2. Train with the default genetic policy.
+python main.py --game assetto first_run
+
+# Equivalent to:
+python -m rl.main --game assetto first_run
+```
+
+The first run creates `experiments/assetto_corsa/<track>/first_run/` and copies in:
+
+- `training_params.yaml` — hyperparams (policy type, mutation, episode length).
+- `reward_config.yaml`   — reward weights.
+- `policy_weights.yaml`  — saved at the end of each improving sim.
+- `results/`             — analytics plots and `results.md`.
+
+Edit the experiment-local copies to tune without affecting other experiments.
+
+## Observation space
+
+See `games/assetto_corsa/obs_spec.py`. The base observation is 16 features (speed, lateral offset, yaw error, pitch, roll, track progress, steering, RPM, gear, four wheel slips, three angular-velocity components). Vision features can be appended via `n_vision > 0` in `training_params.yaml`.
+
+## Action space
+
+```
+Box([-1, 0, 0], [1, 1, 1], shape=(3,), dtype=float32)
+    [0] steer  ∈ [-1, 1]
+    [1] accel  ∈ [0, 1]   (thresholded at 0.5 → bool)
+    [2] brake  ∈ [0, 1]   (thresholded at 0.5 → bool)
+```
+
+This is identical to TMNF's action space, so framework policies (genetic, CMA-ES, DQN, REINFORCE, …) work unchanged.

--- a/docs/README_ASSETTO.md
+++ b/docs/README_ASSETTO.md
@@ -62,4 +62,4 @@ Box([-1, 0, 0], [1, 1, 1], shape=(3,), dtype=float32)
     [2] brake  ∈ [0, 1]   (thresholded at 0.5 → bool)
 ```
 
-This is identical to TMNF's action space, so framework policies (genetic, CMA-ES, DQN, REINFORCE, …) work unchanged.
+This is identical to TMNF's action space, so the default genetic policy works unchanged. Other TMNF policy families may be compatible in principle, but for Assetto you should only use the policy types currently exposed by the Assetto entrypoint; unsupported values will fail with `Unknown policy_type`.

--- a/games/assetto_corsa/__init__.py
+++ b/games/assetto_corsa/__init__.py
@@ -1,0 +1,8 @@
+"""Assetto Corsa game integration.
+
+Implements the framework's abstract interfaces using the assetto-corsa-rl
+Gymnasium wrapper. Unlike the TMNF integration, this package has no
+Windows-only or game-process dependencies at import time — the underlying
+gym env is imported lazily inside the client wrapper so the package can be
+introspected and stubbed on any OS (including Linux CI).
+"""

--- a/games/assetto_corsa/actions.py
+++ b/games/assetto_corsa/actions.py
@@ -1,0 +1,47 @@
+"""Assetto Corsa action definitions.
+
+The continuous action layout is identical to TMNF's so framework policies
+(WeightedLinearPolicy, NeuralNetPolicy, CMAESPolicy, …) work unchanged:
+
+    action[0] steer  ∈ [-1, 1]
+    action[1] accel  ∈ [0, 1]   (thresholded at 0.5 for discrete output heads)
+    action[2] brake  ∈ [0, 1]   (thresholded at 0.5)
+
+For Q-table policies (epsilon_greedy, mcts) the same 9-action discrete grid
+as TMNF is used.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+# 9-action discrete grid: {brake, coast, accel} × {left, straight, right}
+DISCRETE_ACTIONS = np.array([
+    [-1., 0., 1.],   # 0: brake + left
+    [ 0., 0., 1.],   # 1: brake + straight
+    [ 1., 0., 1.],   # 2: brake + right
+    [-1., 0., 0.],   # 3: coast + left
+    [ 0., 0., 0.],   # 4: coast + straight
+    [ 1., 0., 0.],   # 5: coast + right
+    [-1., 1., 0.],   # 6: accel + left
+    [ 0., 1., 0.],   # 7: accel + straight
+    [ 1., 1., 0.],   # 8: accel + right
+], dtype=np.float32)
+
+
+# Probe phase fixed-action episodes — used only by the hill-climbing policy.
+# The AC env defaults to the genetic policy, so an empty list is fine in
+# normal operation; populating it lets users opt into hill-climbing later.
+PROBE_ACTIONS: list[tuple[np.ndarray, str]] = [
+    (np.array([-1., 1., 0.], dtype=np.float32), "accel left"),
+    (np.array([ 0., 1., 0.], dtype=np.float32), "accel"),
+    (np.array([ 1., 1., 0.], dtype=np.float32), "accel right"),
+    (np.array([-1., 0., 1.], dtype=np.float32), "brake left"),
+    (np.array([ 0., 0., 1.], dtype=np.float32), "brake"),
+    (np.array([ 1., 0., 1.], dtype=np.float32), "brake right"),
+]
+
+
+# Forced action used during episode warmup (first N steps): full throttle, straight.
+WARMUP_ACTION = np.array([0., 1., 0.], dtype=np.float32)

--- a/games/assetto_corsa/actions.py
+++ b/games/assetto_corsa/actions.py
@@ -1,14 +1,16 @@
 """Assetto Corsa action definitions.
 
-The continuous action layout is identical to TMNF's so framework policies
-(WeightedLinearPolicy, NeuralNetPolicy, CMAESPolicy, …) work unchanged:
+The continuous action layout is identical to TMNF's, so the framework's
+supported continuous-action policy types for Assetto (`hill_climbing` and
+`neural_net`) can use it unchanged:
 
     action[0] steer  ∈ [-1, 1]
     action[1] accel  ∈ [0, 1]   (thresholded at 0.5 for discrete output heads)
     action[2] brake  ∈ [0, 1]   (thresholded at 0.5)
 
-For Q-table policies (epsilon_greedy, mcts) the same 9-action discrete grid
-as TMNF is used.
+The same 9-action discrete grid as TMNF is used for the supported framework
+`policy_type` values: `hill_climbing`, `neural_net`, `epsilon_greedy`,
+`mcts`, and `genetic`.
 """
 
 from __future__ import annotations

--- a/games/assetto_corsa/analytics.py
+++ b/games/assetto_corsa/analytics.py
@@ -1,0 +1,71 @@
+"""Assetto Corsa analytics: thin wrapper around framework analytics.
+
+The AC integration doesn't yet ship game-specific plots — the framework
+plots (probe rewards, cold-start, greedy, reward trajectory) are sufficient
+for early experiments. Game-specific plots (track-relative trajectory,
+slip heatmap, …) can be added here later without touching the framework.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from framework.analytics import (
+    ExperimentData,
+    plot_probe_rewards,
+    plot_cold_start_rewards,
+    plot_greedy_rewards,
+    plot_reward_trajectory,
+    _probe_table_md,
+    _cold_start_table_md,
+    _greedy_table_md,
+    _timings_md,
+    _summary_md,
+    save_grid_summary as _framework_save_grid_summary,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def save_experiment_results(data: ExperimentData, results_dir: str) -> None:
+    """Generate framework plots and a results.md report into *results_dir*."""
+    os.makedirs(results_dir, exist_ok=True)
+
+    track_line = f"\n**Track:** {data.track}\n" if data.track else ""
+    sections = [
+        f"# Experiment: {data.experiment_name}\n{track_line}\n",
+        _timings_md(data),
+        _summary_md(data),
+    ]
+
+    if data.probe_results:
+        plot_probe_rewards(data, results_dir)
+        sections.append(_probe_table_md(data))
+        sections.append("\n![Probe rewards](probe_rewards.png)\n\n")
+
+    if data.cold_start_restarts:
+        plot_cold_start_rewards(data, results_dir)
+        sections.append(_cold_start_table_md(data))
+        sections.append("\n![Cold-start best rewards](cold_start_best_rewards.png)\n\n")
+
+    if data.greedy_sims:
+        plot_greedy_rewards(data, results_dir)
+        sections.append(_greedy_table_md(data))
+        sections.append("\n![Greedy rewards](greedy_rewards.png)\n\n")
+
+    plot_reward_trajectory(data, results_dir)
+    sections.append("## Additional Plots\n\n")
+    sections.append("![Reward trajectory](reward_trajectory.png)\n\n")
+
+    report_path = os.path.join(results_dir, "results.md")
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.writelines(sections)
+
+    n = len(os.listdir(results_dir))
+    logger.info("Saved %d file(s) to %s/ (report: results.md)", n, results_dir)
+
+
+def save_grid_summary(*args, **kwargs) -> None:
+    """AC grid-summary wrapper: framework defaults, no extra plots."""
+    _framework_save_grid_summary(*args, **kwargs)

--- a/games/assetto_corsa/clients/__init__.py
+++ b/games/assetto_corsa/clients/__init__.py
@@ -1,0 +1,5 @@
+"""Assetto Corsa client wrappers.
+
+ac_client wraps the upstream gym env so the rest of the package consumes
+a stable, narrow interface.
+"""

--- a/games/assetto_corsa/clients/ac_client.py
+++ b/games/assetto_corsa/clients/ac_client.py
@@ -1,0 +1,226 @@
+"""Thin wrapper around the assetto-corsa-rl gym environment.
+
+The upstream package is imported lazily so the rest of the codebase
+(including unit tests on Linux CI) can run without it installed.
+
+ACStepState is the dict-like state object the env and reward calculator
+consume. It exposes the telemetry fields each layer reads as plain
+attributes so we can swap raw obs encodings without touching downstream
+code.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+
+# Default upstream env id, per issue #79.
+DEFAULT_ENV_ID = "AssettoCorsa-v0"
+
+
+@dataclass
+class ACStepState:
+    """Normalised view of one AC env step.
+
+    Fields mirror the AC_OBS_SPEC vocabulary so env._build_obs() and
+    RewardCalculator.compute() can read them by name.
+    """
+
+    raw_obs: Any
+    reward: float
+    terminated: bool
+    truncated: bool
+    info: dict
+    speed_ms: float = 0.0
+    lateral_offset: float | None = None
+    vertical_offset: float | None = None
+    yaw_error: float = 0.0
+    pitch: float = 0.0
+    roll: float = 0.0
+    track_progress: float | None = None
+    steering_angle: float = 0.0
+    engine_rpm: float = 0.0
+    gear: float = 0.0
+    wheel_slip: tuple[float, float, float, float] = (0.0, 0.0, 0.0, 0.0)
+    angular_velocity: tuple[float, float, float] = (0.0, 0.0, 0.0)
+    pos_x: float = 0.0
+    pos_z: float = 0.0
+    finished: bool = False
+    vision: np.ndarray | None = None
+
+
+class ACClient:
+    """Synchronous wrapper that converts AC gym output to ACStepState.
+
+    The constructor delegates env creation to a factory callable so tests
+    can inject a stub without monkey-patching ``gymnasium.make``.
+    """
+
+    def __init__(
+        self,
+        env_id: str = DEFAULT_ENV_ID,
+        env_factory: Callable[..., Any] | None = None,
+        env_kwargs: dict | None = None,
+    ) -> None:
+        self._env_kwargs = env_kwargs or {}
+        if env_factory is None:
+            env_factory = _default_env_factory
+        self._env = env_factory(env_id, **self._env_kwargs)
+
+    # ------------------------------------------------------------------
+    # Gym passthroughs
+    # ------------------------------------------------------------------
+
+    def reset(self) -> ACStepState:
+        result = self._env.reset()
+        # Gymnasium returns (obs, info); legacy gym returns just obs.
+        if isinstance(result, tuple) and len(result) == 2:
+            obs, info = result
+        else:
+            obs, info = result, {}
+        return self._to_step_state(obs, reward=0.0, terminated=False,
+                                   truncated=False, info=info)
+
+    def step(self, action: np.ndarray) -> ACStepState:
+        result = self._env.step(action)
+        if len(result) == 5:
+            obs, reward, terminated, truncated, info = result
+        else:
+            # Legacy gym 4-tuple
+            obs, reward, done, info = result
+            terminated = bool(done)
+            truncated = False
+        return self._to_step_state(obs, float(reward), bool(terminated),
+                                   bool(truncated), info)
+
+    def close(self) -> None:
+        try:
+            self._env.close()
+        except Exception:
+            logger.warning("AC env close() raised; ignoring", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Translation
+    # ------------------------------------------------------------------
+
+    def _to_step_state(
+        self,
+        obs: Any,
+        reward: float,
+        terminated: bool,
+        truncated: bool,
+        info: dict,
+    ) -> ACStepState:
+        """Map raw obs/info into ACStepState by best-effort field lookup.
+
+        AC gym wrappers vary in exact keys; we accept both flat dicts and
+        ``info``-only telemetry. Missing fields default to neutral values.
+        """
+        info = dict(info) if info else {}
+        getter = _make_getter(obs, info)
+
+        wheel_slip = getter(
+            ["wheel_slip", "tyre_slip", "tire_slip"],
+            default=(0.0, 0.0, 0.0, 0.0),
+        )
+        if not isinstance(wheel_slip, (list, tuple, np.ndarray)):
+            wheel_slip = (float(wheel_slip),) * 4
+        wheel_slip = tuple(float(x) for x in list(wheel_slip)[:4])
+        if len(wheel_slip) < 4:
+            wheel_slip = wheel_slip + (0.0,) * (4 - len(wheel_slip))
+
+        angular = getter(["angular_velocity", "ang_vel"], default=(0.0, 0.0, 0.0))
+        if not isinstance(angular, (list, tuple, np.ndarray)):
+            angular = (0.0, 0.0, 0.0)
+        angular = tuple(float(x) for x in list(angular)[:3])
+        if len(angular) < 3:
+            angular = angular + (0.0,) * (3 - len(angular))
+
+        finished = bool(info.get("finished", False)) or (
+            terminated and bool(info.get("lap_completed", False))
+        )
+
+        return ACStepState(
+            raw_obs        = obs,
+            reward         = reward,
+            terminated     = terminated,
+            truncated      = truncated,
+            info           = info,
+            speed_ms       = float(getter(["speed_ms", "speed"], default=0.0)),
+            lateral_offset = _as_float_or_none(getter(["lateral_offset", "lateral_offset_m"])),
+            vertical_offset= _as_float_or_none(getter(["vertical_offset", "vertical_offset_m"])),
+            yaw_error      = float(getter(["yaw_error", "yaw_error_rad"], default=0.0)),
+            pitch          = float(getter(["pitch", "pitch_rad"], default=0.0)),
+            roll           = float(getter(["roll", "roll_rad"], default=0.0)),
+            track_progress = _as_float_or_none(getter(["track_progress", "normalized_position"])),
+            steering_angle = float(getter(["steering_angle", "steer"], default=0.0)),
+            engine_rpm     = float(getter(["engine_rpm", "rpm"], default=0.0)),
+            gear           = float(getter(["gear"], default=0.0)),
+            wheel_slip     = wheel_slip,  # type: ignore[arg-type]
+            angular_velocity = angular,   # type: ignore[arg-type]
+            pos_x          = float(getter(["pos_x", "x"], default=0.0)),
+            pos_z          = float(getter(["pos_z", "z"], default=0.0)),
+            finished       = finished,
+            vision         = _maybe_array(getter(["vision", "lidar"])),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _default_env_factory(env_id: str, **kwargs: Any) -> Any:
+    """Lazy import of gymnasium / assetto_corsa_rl.
+
+    Importing these at module-load time would break Linux CI where the
+    upstream package isn't installed; importing here keeps the AC package
+    introspectable everywhere.
+    """
+    try:
+        # Importing assetto_corsa_rl registers the AssettoCorsa-v0 env id.
+        import assetto_corsa_rl  # noqa: F401
+    except ImportError:
+        logger.debug("assetto_corsa_rl not installed; gym.make may still find the env.")
+    try:
+        import gymnasium as gym  # type: ignore
+    except ImportError:
+        import gym  # type: ignore
+    return gym.make(env_id, **kwargs)
+
+
+def _make_getter(obs: Any, info: dict) -> Callable[..., Any]:
+    """Return a function that resolves the first matching key from obs/info."""
+
+    def get(keys: list[str], default: Any = None) -> Any:
+        for k in keys:
+            if isinstance(obs, dict) and k in obs:
+                return obs[k]
+            if k in info:
+                return info[k]
+            if hasattr(obs, k):
+                return getattr(obs, k)
+        return default
+
+    return get
+
+
+def _as_float_or_none(v: Any) -> float | None:
+    if v is None:
+        return None
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def _maybe_array(v: Any) -> np.ndarray | None:
+    if v is None:
+        return None
+    arr = np.asarray(v, dtype=np.float32)
+    return arr if arr.size > 0 else None

--- a/games/assetto_corsa/clients/ac_client.py
+++ b/games/assetto_corsa/clients/ac_client.py
@@ -12,7 +12,7 @@ code.
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Callable
 
 import numpy as np

--- a/games/assetto_corsa/config/reward_config.yaml
+++ b/games/assetto_corsa/config/reward_config.yaml
@@ -1,0 +1,14 @@
+# Assetto Corsa reward configuration.
+# Mirrors the TMNF reward layout but with AC-friendly defaults
+# (longer par_time_s, no airborne / lidar terms).
+
+progress_weight:    1000.0
+centerline_weight:  -0.5
+centerline_exp:     2.0
+speed_weight:       0.05
+step_penalty:       -0.05
+finish_bonus:       500.0
+finish_time_weight: -1.0
+par_time_s:         150.0
+accel_bonus:        0.5
+crash_threshold_m:  25.0

--- a/games/assetto_corsa/config/training_params.yaml
+++ b/games/assetto_corsa/config/training_params.yaml
@@ -3,7 +3,7 @@
 # enable_vision=False"); tune freely.
 
 track: assetto_default      # informational; AC env doesn't load a track .npy
-speed: 5.0                  # game speed multiplier (forwarded to env wrapper)
+speed: 5.0                  # retained for config/API parity; may not affect AC env
 in_game_episode_s: 150.0    # episode time-limit in seconds
 n_sims: 100                 # greedy simulations / generations after cold-start
 mutation_scale: 0.05

--- a/games/assetto_corsa/config/training_params.yaml
+++ b/games/assetto_corsa/config/training_params.yaml
@@ -1,0 +1,23 @@
+# Assetto Corsa training parameters.
+# Defaults are taken from issue #79 ("default speed=5.0, max_episode_time_s=150,
+# enable_vision=False"); tune freely.
+
+track: assetto_default      # informational; AC env doesn't load a track .npy
+speed: 5.0                  # game speed multiplier (forwarded to env wrapper)
+in_game_episode_s: 150.0    # episode time-limit in seconds
+n_sims: 100                 # greedy simulations / generations after cold-start
+mutation_scale: 0.05
+mutation_share: 1.0
+adaptive_mutation: true
+probe_s: 15.0
+cold_restarts: 5
+cold_sims: 5
+n_vision: 0                 # vision features appended to obs (0 = disabled)
+patience: 0
+
+# Default to genetic policy — same default as TMNF.
+policy_type: genetic
+
+policy_params:
+  population_size: 20
+  elite_k: 3

--- a/games/assetto_corsa/entry.py
+++ b/games/assetto_corsa/entry.py
@@ -1,0 +1,100 @@
+"""Assetto Corsa training entry point.
+
+Reads experiment config, wires AC-specific objects into the game-agnostic
+framework.training.train_rl(), then saves results. Mirrors
+games.tmnf.entry.run() so main.py only has to dispatch on --game.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shutil
+from pathlib import Path
+
+import yaml
+
+from framework.training import train_rl
+from games.assetto_corsa.actions import DISCRETE_ACTIONS, PROBE_ACTIONS, WARMUP_ACTION
+from games.assetto_corsa.analytics import save_experiment_results
+from games.assetto_corsa.env import make_env
+from games.assetto_corsa.obs_spec import AC_OBS_SPEC, with_vision
+
+logger = logging.getLogger(__name__)
+
+
+_PKG_DIR    = Path(__file__).resolve().parent
+_CONFIG_DIR = _PKG_DIR / "config"
+
+
+def run(args: argparse.Namespace) -> None:
+    """Train an AC experiment from a parsed argparse Namespace.
+
+    The Namespace must expose: experiment, no_interrupt, re_initialize.
+    """
+    # Master-config bootstrap, mirroring games.tmnf.entry.run().
+    master_training = _CONFIG_DIR / "training_params.yaml"
+    master_reward   = _CONFIG_DIR / "reward_config.yaml"
+
+    with open(master_training) as f:
+        master_p = yaml.safe_load(f)
+    track = master_p.get("track", "assetto_default")
+
+    experiment_dir       = Path(f"experiments/assetto_corsa/{track}/{args.experiment}")
+    weights_file         = str(experiment_dir / "policy_weights.yaml")
+    reward_cfg_file      = str(experiment_dir / "reward_config.yaml")
+    training_params_file = str(experiment_dir / "training_params.yaml")
+
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+    if not os.path.exists(reward_cfg_file):
+        shutil.copy(master_reward, reward_cfg_file)
+        logger.info("Copied master AC reward config → %s", reward_cfg_file)
+    if not os.path.exists(training_params_file):
+        shutil.copy(master_training, training_params_file)
+        logger.info("Copied master AC training params → %s", training_params_file)
+
+    with open(training_params_file) as f:
+        p = yaml.safe_load(f)
+    track = p.get("track", track)
+
+    n_vision      = int(p.get("n_vision", 0))
+    obs_spec      = with_vision(n_vision)
+    policy_type   = p.get("policy_type", "genetic")
+    policy_params = p.get("policy_params") or {}
+
+    data = train_rl(
+        experiment_name     = args.experiment,
+        make_env_fn         = lambda: make_env(
+            experiment_dir    = str(experiment_dir),
+            speed             = p["speed"],
+            in_game_episode_s = p["in_game_episode_s"],
+            n_vision          = n_vision,
+        ),
+        obs_spec            = obs_spec,
+        head_names          = ["steer", "accel", "brake"],
+        discrete_actions    = DISCRETE_ACTIONS,
+        speed               = p["speed"],
+        n_sims              = p["n_sims"],
+        in_game_episode_s   = p["in_game_episode_s"],
+        weights_file        = weights_file,
+        reward_config_file  = reward_cfg_file,
+        mutation_scale      = p["mutation_scale"],
+        mutation_share      = p.get("mutation_share", 1.0),
+        probe_actions       = PROBE_ACTIONS,
+        probe_in_game_s     = p["probe_s"],
+        cold_start_restarts = p["cold_restarts"],
+        cold_start_sims     = p["cold_sims"],
+        warmup_action       = WARMUP_ACTION,
+        warmup_steps        = 5,
+        training_params     = p,
+        no_interrupt        = args.no_interrupt,
+        re_initialize       = args.re_initialize,
+        policy_type         = policy_type,
+        policy_params       = policy_params,
+        track               = track,
+        adaptive_mutation   = p.get("adaptive_mutation", True),
+        patience            = p.get("patience", 0),
+    )
+
+    save_experiment_results(data, results_dir=str(experiment_dir / "results"))

--- a/games/assetto_corsa/env.py
+++ b/games/assetto_corsa/env.py
@@ -1,0 +1,254 @@
+"""AssettoCorsaEnv — Gymnasium environment for Assetto Corsa.
+
+Wraps an upstream ACClient (which itself wraps the assetto-corsa-rl gym
+environment) to satisfy the framework's BaseGameEnv interface. The action
+space matches TMNF's ([steer, accel, brake]) so framework policies are
+drop-in compatible.
+
+Observation
+-----------
+See games.assetto_corsa.obs_spec.AC_OBS_SPEC for the full feature list.
+Vision features (when enabled) are appended at the end and exposed via
+``AC_OBS_SPEC.with_vision(n_vision)``.
+
+Action
+------
+Box([-1, 0, 0], [1, 1, 1], shape=(3,), dtype=float32)
+    [0] steer  ∈ [-1, 1]
+    [1] accel  ∈ [0, 1]   (thresholded at 0.5 → bool)
+    [2] brake  ∈ [0, 1]   (thresholded at 0.5 → bool)
+
+Termination
+-----------
+Terminated: client reports finished, or |lateral_offset| > crash_threshold_m
+Truncated:  elapsed > max_episode_time_s
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+from gymnasium import spaces
+
+from framework.base_env import BaseGameEnv
+from games.assetto_corsa.clients.ac_client import ACClient, ACStepState, DEFAULT_ENV_ID
+from games.assetto_corsa.obs_spec import AC_OBS_SPEC, with_vision
+from games.assetto_corsa.reward import RewardCalculator, RewardConfig
+
+logger = logging.getLogger(__name__)
+
+
+_DEFAULT_REWARD_CONFIG = os.path.join(
+    os.path.dirname(__file__), "config", "reward_config.yaml"
+)
+
+
+class AssettoCorsaEnv(BaseGameEnv):
+    """Gymnasium environment for Assetto Corsa reinforcement learning.
+
+    Parameters
+    ----------
+    reward_config:
+        RewardConfig instance. If None, loaded from the package default.
+    max_episode_time_s:
+        Wall-clock seconds before the episode is truncated.
+    n_vision:
+        Number of vision-distance features appended to the observation
+        (0 = vision disabled).
+    env_id:
+        Upstream gym env id (defaults to ``"AssettoCorsa-v0"``).
+    env_factory:
+        Optional callable used in place of ``gymnasium.make``. Tests
+        inject a stub here so no real AC binary is required.
+    env_kwargs:
+        Extra keyword arguments forwarded to the env factory.
+    """
+
+    metadata = {"render_modes": []}
+
+    def __init__(
+        self,
+        reward_config: RewardConfig | None = None,
+        max_episode_time_s: float = 150.0,
+        n_vision: int = 0,
+        env_id: str = DEFAULT_ENV_ID,
+        env_factory: Callable[..., Any] | None = None,
+        env_kwargs: dict | None = None,
+    ) -> None:
+        super().__init__()
+
+        self._reward_config = reward_config or RewardConfig.from_yaml(_DEFAULT_REWARD_CONFIG)
+        self._max_episode_time_s = max_episode_time_s
+        self._n_vision = n_vision
+        self._reward_calc = RewardCalculator(self._reward_config)
+
+        self._obs_spec = with_vision(n_vision)
+
+        self.observation_space = spaces.Box(
+            low=-np.inf, high=np.inf, shape=(self._obs_spec.dim,), dtype=np.float32,
+        )
+        self.action_space = spaces.Box(
+            low=np.array([-1.0, 0.0, 0.0], dtype=np.float32),
+            high=np.array([ 1.0, 1.0, 1.0], dtype=np.float32),
+            dtype=np.float32,
+        )
+
+        self._client = ACClient(env_id=env_id, env_factory=env_factory,
+                                env_kwargs=env_kwargs)
+
+        self._prev_state: ACStepState | None = None
+        self._elapsed_s: float = 0.0
+        self._episode_start_s: float = 0.0
+        self._laps_completed: int = 0
+
+    # ------------------------------------------------------------------
+    # Gymnasium interface
+    # ------------------------------------------------------------------
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[np.ndarray, dict]:
+        super().reset(seed=seed)
+        step = self._client.reset()
+        self._prev_state = step
+        self._elapsed_s = 0.0
+        self._episode_start_s = time.monotonic()
+        self._laps_completed = 0
+        obs = self._build_obs(step)
+        return obs, {}
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, bool, dict]:
+        step = self._client.step(np.asarray(action, dtype=np.float32))
+        self._elapsed_s = time.monotonic() - self._episode_start_s
+
+        finished = bool(step.finished) or (
+            step.track_progress is not None and step.track_progress >= 1.0
+        )
+        crashed = (
+            step.lateral_offset is not None
+            and abs(step.lateral_offset) > self._reward_config.crash_threshold_m
+        )
+        time_over = self._elapsed_s > self._max_episode_time_s
+
+        accelerating = bool(float(action[1]) >= 0.5) if len(action) >= 2 else False
+
+        reward = self._reward_calc.compute(
+            prev_state = self._prev_state,
+            curr_state = step,
+            finished   = finished,
+            elapsed_s  = self._elapsed_s,
+            info       = {"accelerating": accelerating},
+            n_ticks    = 1,
+        )
+
+        terminated = finished or crashed or step.terminated
+        truncated  = step.truncated or (time_over and not terminated)
+
+        if finished:
+            termination_reason: str | None = "finish"
+            self._laps_completed += 1
+        elif crashed:
+            termination_reason = "crash"
+        elif time_over:
+            termination_reason = "timeout"
+        elif step.terminated:
+            termination_reason = "env"
+        else:
+            termination_reason = None
+
+        info = self._get_game_info()
+        info.update({
+            "finished":        finished,
+            "laps_completed":  self._laps_completed,
+            "elapsed_s":       self._elapsed_s,
+            "termination_reason": termination_reason,
+        })
+
+        self._prev_state = step
+        obs = self._build_obs(step)
+        return obs, reward, terminated, truncated, info
+
+    def close(self) -> None:
+        self._client.close()
+
+    # ------------------------------------------------------------------
+    # BaseGameEnv hooks
+    # ------------------------------------------------------------------
+
+    def get_episode_time_limit(self) -> float:
+        return self._max_episode_time_s
+
+    def set_episode_time_limit(self, seconds: float) -> None:
+        self._max_episode_time_s = seconds
+
+    def _get_game_info(self) -> dict:
+        s = self._prev_state
+        if s is None:
+            return {}
+        return {
+            "pos_x":          s.pos_x,
+            "pos_z":          s.pos_z,
+            "track_progress": s.track_progress or 0.0,
+            "lateral_offset": s.lateral_offset or 0.0,
+        }
+
+    def _build_obs(self, step: ACStepState) -> np.ndarray:
+        wheels = step.wheel_slip
+        ang    = step.angular_velocity
+        state = np.array(
+            [
+                step.speed_ms,
+                step.lateral_offset or 0.0,
+                step.yaw_error,
+                step.pitch,
+                step.roll,
+                step.track_progress or 0.0,
+                step.steering_angle,
+                step.engine_rpm,
+                step.gear,
+                wheels[0], wheels[1], wheels[2], wheels[3],
+                ang[0],    ang[1],    ang[2],
+            ],
+            dtype=np.float32,
+        )
+        if self._n_vision > 0:
+            vis = step.vision
+            if vis is None or vis.size != self._n_vision:
+                vis = np.zeros(self._n_vision, dtype=np.float32)
+            state = np.concatenate([state, vis.astype(np.float32)])
+        return state
+
+
+def make_env(
+    experiment_dir: str | Path,
+    speed: float = 1.0,
+    in_game_episode_s: float = 150.0,
+    n_vision: int = 0,
+    env_factory: Callable[..., Any] | None = None,
+) -> AssettoCorsaEnv:
+    """Factory mirroring games.tmnf.env.make_env.
+
+    *speed* is accepted for API parity with TMNF; AC's gym wrapper does not
+    expose a real-time-acceleration knob at this layer.
+    """
+    experiment_dir = Path(experiment_dir)
+    reward_cfg_path = experiment_dir / "reward_config.yaml"
+    reward_config = (
+        RewardConfig.from_yaml(str(reward_cfg_path))
+        if reward_cfg_path.exists()
+        else RewardConfig.from_yaml(_DEFAULT_REWARD_CONFIG)
+    )
+    return AssettoCorsaEnv(
+        reward_config       = reward_config,
+        max_episode_time_s  = in_game_episode_s,
+        n_vision            = n_vision,
+        env_factory         = env_factory,
+    )

--- a/games/assetto_corsa/env.py
+++ b/games/assetto_corsa/env.py
@@ -164,15 +164,15 @@ class AssettoCorsaEnv(BaseGameEnv):
         else:
             termination_reason = None
 
-        info = self._get_game_info()
+        self._prev_state = step
+
+        info = self._get_game_info(step)
         info.update({
             "finished":        finished,
             "laps_completed":  self._laps_completed,
             "elapsed_s":       self._elapsed_s,
             "termination_reason": termination_reason,
         })
-
-        self._prev_state = step
         obs = self._build_obs(step)
         return obs, reward, terminated, truncated, info
 
@@ -189,8 +189,8 @@ class AssettoCorsaEnv(BaseGameEnv):
     def set_episode_time_limit(self, seconds: float) -> None:
         self._max_episode_time_s = seconds
 
-    def _get_game_info(self) -> dict:
-        s = self._prev_state
+    def _get_game_info(self, state: ACStepState | None = None) -> dict:
+        s = state if state is not None else self._prev_state
         if s is None:
             return {}
         return {

--- a/games/assetto_corsa/obs_spec.py
+++ b/games/assetto_corsa/obs_spec.py
@@ -1,0 +1,59 @@
+"""Assetto Corsa observation space.
+
+Single source of truth for AC observation features. Mirrors the layout of
+games.tmnf.obs_spec but uses telemetry signals exposed by the AC gym
+wrapper. Vision features (when enabled) are appended at the end so all
+linear policies handle the variable-length observation transparently via
+ObsSpec.
+"""
+
+from __future__ import annotations
+
+from framework.obs_spec import ObsDim, ObsSpec
+
+
+# ---------------------------------------------------------------------------
+# Base AC observation dims
+# ---------------------------------------------------------------------------
+
+_AC_DIMS: list[ObsDim] = [
+    ObsDim("speed_ms",          50.0,    "Vehicle speed in m/s"),
+    ObsDim("lateral_offset_m",   5.0,    "Metres from track centreline (neg=left, pos=right)"),
+    ObsDim("yaw_error_rad",      3.14159, "Track heading minus car heading, [−π, π]"),
+    ObsDim("pitch_rad",          0.3,    "Nose-up/down rotation"),
+    ObsDim("roll_rad",           0.3,    "Tilt left/right"),
+    ObsDim("track_progress",     1.0,    "Fraction of track completed, [0, 1]"),
+    ObsDim("steering_angle",     1.0,    "Current steering input in [-1, 1]"),
+    ObsDim("engine_rpm",      8000.0,    "Engine RPM"),
+    ObsDim("gear",               6.0,    "Current gear (0=R, 1=N, 2..7 forward)"),
+    ObsDim("wheel_0_slip",       1.0,    "Front-left wheel slip ratio"),
+    ObsDim("wheel_1_slip",       1.0,    "Front-right wheel slip ratio"),
+    ObsDim("wheel_2_slip",       1.0,    "Rear-left wheel slip ratio"),
+    ObsDim("wheel_3_slip",       1.0,    "Rear-right wheel slip ratio"),
+    ObsDim("angular_vel_x",      5.0,    "Roll rate (rad/s)"),
+    ObsDim("angular_vel_y",      5.0,    "Yaw rate (rad/s)"),
+    ObsDim("angular_vel_z",      5.0,    "Pitch rate (rad/s)"),
+]
+
+#: The canonical AC observation spec (no vision features).
+#: Use ``AC_OBS_SPEC.with_vision(n)`` to extend with vision rays.
+AC_OBS_SPEC: ObsSpec = ObsSpec(_AC_DIMS)
+
+
+#: Number of base observation features (no vision).
+BASE_OBS_DIM: int = AC_OBS_SPEC.dim
+
+
+def with_vision(n_vision: int) -> ObsSpec:
+    """Return an AC ObsSpec extended with *n_vision* vision-distance features.
+
+    Vision features are normalised to ~[0, 1] so their scale is 1.0.
+    Returns the base spec unchanged when n_vision == 0.
+    """
+    if n_vision == 0:
+        return AC_OBS_SPEC
+    extra = [
+        ObsDim(f"vision_{i}", 1.0, "Vision distance feature ~[0, 1]")
+        for i in range(n_vision)
+    ]
+    return ObsSpec(_AC_DIMS + extra)

--- a/games/assetto_corsa/reward.py
+++ b/games/assetto_corsa/reward.py
@@ -1,0 +1,109 @@
+"""Assetto Corsa reward calculator.
+
+Subclasses the framework's RewardCalculatorBase. Reward signals are read
+from a state dict (the ACStepState produced by the gym wrapper) so this
+module has no dependency on TMNF-specific data classes.
+
+The signal mix is intentionally simple — extra terms (engine RPM bonus,
+slip penalty, etc.) can be added later via the optional kwargs in
+RewardConfig without changing the public interface.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any
+
+import yaml
+
+from framework.base_reward import RewardCalculatorBase
+
+
+@dataclass
+class RewardConfig:
+    """Reward weights for the AC environment.
+
+    Defaults are progress-dominant, mirroring the TMNF defaults so policies
+    trained on one game transfer reasonably to the other.
+    """
+
+    progress_weight:    float = 1000.0
+    centerline_weight:  float = -0.5
+    centerline_exp:     float = 2.0
+    speed_weight:       float = 0.05
+    step_penalty:       float = -0.05
+    finish_bonus:       float = 500.0
+    finish_time_weight: float = -1.0
+    par_time_s:         float = 150.0
+    accel_bonus:        float = 0.5
+    crash_threshold_m:  float = 25.0
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "RewardConfig":
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        valid = {f.name for f in fields(cls)}
+        unknown = set(data.keys()) - valid
+        if unknown:
+            raise ValueError(
+                f"{path}: unknown reward config keys: {sorted(unknown)}\n"
+                f"Valid keys: {sorted(valid)}"
+            )
+        return cls(**data)
+
+
+class RewardCalculator(RewardCalculatorBase):
+    """Linear-weighted reward computed from telemetry fields.
+
+    Stateless; the framework calls compute() on every RL step.
+    """
+
+    def __init__(self, config: RewardConfig) -> None:
+        self.config = config
+
+    def compute(
+        self,
+        prev_state: Any,
+        curr_state: Any,
+        finished: bool,
+        elapsed_s: float,
+        info: dict,
+        n_ticks: int = 1,
+    ) -> float:
+        cfg = self.config
+        reward = 0.0
+
+        prev_progress = self._get(prev_state, "track_progress")
+        curr_progress = self._get(curr_state, "track_progress")
+        if prev_progress is not None and curr_progress is not None:
+            reward += (curr_progress - prev_progress) * cfg.progress_weight
+
+        lateral = self._get(curr_state, "lateral_offset")
+        if lateral is not None:
+            reward += (
+                cfg.centerline_weight * abs(lateral) ** cfg.centerline_exp * n_ticks
+            )
+
+        speed = self._get(curr_state, "speed_ms")
+        if speed is not None:
+            reward += cfg.speed_weight * speed * n_ticks
+
+        if bool(info.get("accelerating", False)):
+            reward += cfg.accel_bonus * n_ticks
+
+        reward += cfg.step_penalty * n_ticks
+
+        if finished:
+            reward += cfg.finish_bonus
+            reward += cfg.finish_time_weight * (elapsed_s - cfg.par_time_s)
+
+        return reward
+
+    @staticmethod
+    def _get(state: Any, key: str) -> Any:
+        """Read *key* from a dict-like or attr-like state object."""
+        if state is None:
+            return None
+        if isinstance(state, dict):
+            return state.get(key)
+        return getattr(state, key, None)

--- a/games/tmnf/entry.py
+++ b/games/tmnf/entry.py
@@ -1,0 +1,198 @@
+"""TMNF training entry point.
+
+The body of this module was previously inlined in main.py. Moving it here
+keeps games/tmnf/ self-contained and lets main.py dispatch on --game.
+The behaviour and CLI-visible side effects (config copying, train_rl
+arguments, analytics output paths) are unchanged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import shutil
+
+import yaml
+
+from framework.training import train_rl
+from games.tmnf.actions import DISCRETE_ACTIONS, PROBE_ACTIONS, WARMUP_ACTION
+from games.tmnf.analytics import save_experiment_results
+from games.tmnf.env import make_env
+from games.tmnf.obs_spec import TMNF_OBS_SPEC
+from games.tmnf.policies import (
+    CMAESPolicy,
+    LSTMEvolutionPolicy,
+    LSTMPolicy,
+    NeuralDQNPolicy,
+    REINFORCEPolicy,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def run(args: argparse.Namespace) -> None:
+    # Bootstrap: read track from master config before the experiment dir exists,
+    # then re-read the experiment-local copy once it has been created.
+    with open("config/training_params.yaml") as f:
+        master_p = yaml.safe_load(f)
+    track = master_p.get("track", "a03_centerline")
+
+    experiment_dir       = f"experiments/{track}/{args.experiment}"
+    weights_file         = f"{experiment_dir}/policy_weights.yaml"
+    reward_cfg_file      = f"{experiment_dir}/reward_config.yaml"
+    training_params_file = f"{experiment_dir}/training_params.yaml"
+
+    os.makedirs(experiment_dir, exist_ok=True)
+    if not os.path.exists(reward_cfg_file):
+        shutil.copy("config/reward_config.yaml", reward_cfg_file)
+        logger.info("Copied master reward config → %s", reward_cfg_file)
+    if not os.path.exists(training_params_file):
+        shutil.copy("config/training_params.yaml", training_params_file)
+        logger.info("Copied master training params → %s", training_params_file)
+
+    with open(training_params_file) as f:
+        p = yaml.safe_load(f)
+    track = p.get("track", track)
+
+    n_lidar_rays = p.get("n_lidar_rays", 0)
+    obs_spec     = TMNF_OBS_SPEC.with_lidar(n_lidar_rays)
+    policy_type  = p.get("policy_type", "hill_climbing")
+    policy_params = p.get("policy_params") or {}
+    re_initialize = args.re_initialize
+
+    # Factory callables for TMNF-specific policy types (injected into framework).
+    def _make_neural_dqn() -> NeuralDQNPolicy:
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as _f:
+                _cfg = yaml.safe_load(_f)
+            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "neural_dqn":
+                return NeuralDQNPolicy.from_cfg(_cfg, n_lidar_rays=n_lidar_rays)
+        return NeuralDQNPolicy(
+            hidden_sizes        = policy_params.get("hidden_sizes",        [64, 64]),
+            replay_buffer_size  = policy_params.get("replay_buffer_size",  10000),
+            batch_size          = policy_params.get("batch_size",          64),
+            min_replay_size     = policy_params.get("min_replay_size",     500),
+            target_update_freq  = policy_params.get("target_update_freq",  200),
+            learning_rate       = policy_params.get("learning_rate",       0.001),
+            epsilon_start       = policy_params.get("epsilon_start",       1.0),
+            epsilon_end         = policy_params.get("epsilon_end",         0.05),
+            epsilon_decay_steps = policy_params.get("epsilon_decay_steps", 5000),
+            gamma               = policy_params.get("gamma",               0.99),
+            n_lidar_rays        = n_lidar_rays,
+        )
+
+    def _make_cmaes() -> CMAESPolicy:
+        pop_size = policy_params.get("population_size", 20)
+        sigma    = policy_params.get("initial_sigma",   0.3)
+        policy   = CMAESPolicy(
+            population_size = pop_size,
+            initial_sigma   = sigma,
+            n_lidar_rays    = n_lidar_rays,
+        )
+        if os.path.exists(weights_file) and not re_initialize:
+            from games.tmnf.policies import WeightedLinearPolicy as _WLP
+            champion = _WLP.from_cfg(
+                yaml.safe_load(open(weights_file)) or {}, n_lidar_rays=n_lidar_rays
+            )
+            policy.initialize_from_champion(champion)
+        else:
+            policy.initialize_random()
+        return policy
+
+    def _make_reinforce() -> REINFORCEPolicy:
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as _f:
+                _cfg = yaml.safe_load(_f) or {}
+            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "reinforce":
+                return REINFORCEPolicy.from_cfg(_cfg, n_lidar_rays=n_lidar_rays)
+        return REINFORCEPolicy(
+            hidden_sizes  = policy_params.get("hidden_sizes",  [64, 64]),
+            learning_rate = policy_params.get("learning_rate", 0.001),
+            gamma         = policy_params.get("gamma",         0.99),
+            entropy_coeff = policy_params.get("entropy_coeff", 0.01),
+            baseline      = policy_params.get("baseline",      "running_mean"),
+            n_lidar_rays  = n_lidar_rays,
+        )
+
+    def _make_lstm() -> LSTMEvolutionPolicy:
+        hidden_size = policy_params.get("hidden_size",     32)
+        pop_size    = policy_params.get("population_size", 20)
+        sigma       = policy_params.get("initial_sigma",   0.05)
+        policy      = LSTMEvolutionPolicy(
+            hidden_size     = hidden_size,
+            population_size = pop_size,
+            initial_sigma   = sigma,
+            n_lidar_rays    = n_lidar_rays,
+        )
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as _f:
+                _cfg = yaml.safe_load(_f) or {}
+            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "lstm":
+                saved_hidden_size = _cfg.get("hidden_size")
+                saved_n_lidar_rays = _cfg.get("n_lidar_rays")
+                if saved_hidden_size is not None and saved_hidden_size != hidden_size:
+                    raise ValueError(
+                        "Saved LSTM champion hidden_size does not match current run: "
+                        f"saved={saved_hidden_size}, current={hidden_size}"
+                    )
+                if saved_n_lidar_rays is not None and saved_n_lidar_rays != n_lidar_rays:
+                    raise ValueError(
+                        "Saved LSTM champion n_lidar_rays does not match current run: "
+                        f"saved={saved_n_lidar_rays}, current={n_lidar_rays}"
+                    )
+                champion = LSTMPolicy.from_cfg(_cfg)
+                policy.initialize_from_champion(champion)
+        return policy
+
+    extra_policy_types = {
+        "neural_dqn": _make_neural_dqn,
+        "cmaes":      _make_cmaes,
+        "reinforce":  _make_reinforce,
+        "lstm":       _make_lstm,
+    }
+    extra_loop_dispatch = {
+        "neural_dqn": "q_learning",
+        "cmaes":      "cmaes",
+        "reinforce":  "q_learning",
+        "lstm":       "cmaes",
+    }
+
+    data = train_rl(
+        experiment_name     = args.experiment,
+        make_env_fn         = lambda: make_env(
+            experiment_dir    = experiment_dir,
+            speed             = p["speed"],
+            in_game_episode_s = p["in_game_episode_s"],
+            n_lidar_rays      = n_lidar_rays,
+        ),
+        obs_spec            = obs_spec,
+        head_names          = ["steer", "accel", "brake"],
+        discrete_actions    = DISCRETE_ACTIONS,
+        speed               = p["speed"],
+        n_sims              = p["n_sims"],
+        in_game_episode_s   = p["in_game_episode_s"],
+        weights_file        = weights_file,
+        reward_config_file  = reward_cfg_file,
+        mutation_scale      = p["mutation_scale"],
+        mutation_share      = p.get("mutation_share", 1.0),
+        probe_actions       = PROBE_ACTIONS,
+        probe_in_game_s     = p["probe_s"],
+        cold_start_restarts = p["cold_restarts"],
+        cold_start_sims     = p["cold_sims"],
+        warmup_action       = WARMUP_ACTION,
+        warmup_steps        = 5,
+        training_params     = p,
+        no_interrupt        = args.no_interrupt,
+        re_initialize       = re_initialize,
+        do_pretrain         = p.get("do_pretrain", False),
+        policy_type         = policy_type,
+        policy_params       = policy_params,
+        track               = track,
+        adaptive_mutation   = p.get("adaptive_mutation", True),
+        extra_policy_types  = extra_policy_types,
+        extra_loop_dispatch = extra_loop_dispatch,
+        patience            = p.get("patience", 0),
+    )
+
+    save_experiment_results(data, results_dir=f"{experiment_dir}/results")

--- a/main.py
+++ b/main.py
@@ -1,35 +1,35 @@
-"""TMNF RL training entry point.
+"""Top-level RL training entry point.
 
-Thin glue layer: reads experiment config, wires TMNF-specific objects into the
-game-agnostic framework.training.train_rl(), then saves results.
+Dispatches to a per-game entry module based on --game. Game-specific
+wiring (env factory, obs_spec, policy factories, analytics) lives in
+games/<name>/entry.py so this file stays game-agnostic.
 
-All algorithm logic lives in framework/training.py.
-All TMNF game logic lives in games/tmnf/.
+Defaults to --game tmnf to preserve existing CLI invocations.
 """
+
 from __future__ import annotations
 
 import argparse
+import importlib
 import logging
-import os
-import shutil
 
-import yaml
 
-from framework.training import train_rl
-from games.tmnf.obs_spec import TMNF_OBS_SPEC
-from games.tmnf.actions import DISCRETE_ACTIONS, PROBE_ACTIONS, WARMUP_ACTION
-from games.tmnf.env import make_env
-from games.tmnf.policies import NeuralDQNPolicy, CMAESPolicy, REINFORCEPolicy, LSTMPolicy, LSTMEvolutionPolicy
-from games.tmnf.analytics import save_experiment_results
-
-logger = logging.getLogger(__name__)
+# Per-game entry modules. Each module exposes ``run(args)``.
+GAMES: dict[str, str] = {
+    "tmnf":    "games.tmnf.entry",
+    "assetto": "games.assetto_corsa.entry",
+}
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(description="TMNF RL training")
+    parser = argparse.ArgumentParser(description="RL training (multi-game)")
     parser.add_argument(
         "experiment",
-        help="Experiment name — files stored in experiments/<track>/<name>/",
+        help="Experiment name — files stored in experiments/<...>/<name>/",
+    )
+    parser.add_argument(
+        "--game", default="tmnf", choices=sorted(GAMES.keys()),
+        help="Game integration to train against (default: tmnf)",
     )
     parser.add_argument(
         "--no-interrupt", action="store_true",
@@ -53,170 +53,8 @@ def main() -> None:
         datefmt="%H:%M:%S",
     )
 
-    # Bootstrap: read track from master config before the experiment dir exists,
-    # then re-read the experiment-local copy once it has been created.
-    with open("config/training_params.yaml") as f:
-        master_p = yaml.safe_load(f)
-    track = master_p.get("track", "a03_centerline")
-
-    experiment_dir       = f"experiments/{track}/{args.experiment}"
-    weights_file         = f"{experiment_dir}/policy_weights.yaml"
-    reward_cfg_file      = f"{experiment_dir}/reward_config.yaml"
-    training_params_file = f"{experiment_dir}/training_params.yaml"
-
-    os.makedirs(experiment_dir, exist_ok=True)
-    if not os.path.exists(reward_cfg_file):
-        shutil.copy("config/reward_config.yaml", reward_cfg_file)
-        logger.info("Copied master reward config → %s", reward_cfg_file)
-    if not os.path.exists(training_params_file):
-        shutil.copy("config/training_params.yaml", training_params_file)
-        logger.info("Copied master training params → %s", training_params_file)
-
-    with open(training_params_file) as f:
-        p = yaml.safe_load(f)
-    track = p.get("track", track)
-
-    n_lidar_rays = p.get("n_lidar_rays", 0)
-    obs_spec     = TMNF_OBS_SPEC.with_lidar(n_lidar_rays)
-    policy_type  = p.get("policy_type", "hill_climbing")
-    policy_params = p.get("policy_params") or {}
-    re_initialize = args.re_initialize
-
-    # Factory callables for TMNF-specific policy types (injected into framework).
-    def _make_neural_dqn() -> NeuralDQNPolicy:
-        if os.path.exists(weights_file) and not re_initialize:
-            with open(weights_file) as _f:
-                _cfg = yaml.safe_load(_f)
-            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "neural_dqn":
-                return NeuralDQNPolicy.from_cfg(_cfg, n_lidar_rays=n_lidar_rays)
-        return NeuralDQNPolicy(
-            hidden_sizes        = policy_params.get("hidden_sizes",        [64, 64]),
-            replay_buffer_size  = policy_params.get("replay_buffer_size",  10000),
-            batch_size          = policy_params.get("batch_size",          64),
-            min_replay_size     = policy_params.get("min_replay_size",     500),
-            target_update_freq  = policy_params.get("target_update_freq",  200),
-            learning_rate       = policy_params.get("learning_rate",       0.001),
-            epsilon_start       = policy_params.get("epsilon_start",       1.0),
-            epsilon_end         = policy_params.get("epsilon_end",         0.05),
-            epsilon_decay_steps = policy_params.get("epsilon_decay_steps", 5000),
-            gamma               = policy_params.get("gamma",               0.99),
-            n_lidar_rays        = n_lidar_rays,
-        )
-
-    def _make_cmaes() -> CMAESPolicy:
-        pop_size = policy_params.get("population_size", 20)
-        sigma    = policy_params.get("initial_sigma",   0.3)
-        policy   = CMAESPolicy(
-            population_size = pop_size,
-            initial_sigma   = sigma,
-            n_lidar_rays    = n_lidar_rays,
-        )
-        if os.path.exists(weights_file) and not re_initialize:
-            from games.tmnf.policies import WeightedLinearPolicy as _WLP
-            champion = _WLP.from_cfg(
-                yaml.safe_load(open(weights_file)) or {}, n_lidar_rays=n_lidar_rays
-            )
-            policy.initialize_from_champion(champion)
-        else:
-            policy.initialize_random()
-        return policy
-
-    def _make_reinforce() -> REINFORCEPolicy:
-        if os.path.exists(weights_file) and not re_initialize:
-            with open(weights_file) as _f:
-                _cfg = yaml.safe_load(_f) or {}
-            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "reinforce":
-                return REINFORCEPolicy.from_cfg(_cfg, n_lidar_rays=n_lidar_rays)
-        return REINFORCEPolicy(
-            hidden_sizes  = policy_params.get("hidden_sizes",  [64, 64]),
-            learning_rate = policy_params.get("learning_rate", 0.001),
-            gamma         = policy_params.get("gamma",         0.99),
-            entropy_coeff = policy_params.get("entropy_coeff", 0.01),
-            baseline      = policy_params.get("baseline",      "running_mean"),
-            n_lidar_rays  = n_lidar_rays,
-        )
-
-    def _make_lstm() -> LSTMEvolutionPolicy:
-        hidden_size = policy_params.get("hidden_size",     32)
-        pop_size    = policy_params.get("population_size", 20)
-        sigma       = policy_params.get("initial_sigma",   0.05)
-        policy      = LSTMEvolutionPolicy(
-            hidden_size     = hidden_size,
-            population_size = pop_size,
-            initial_sigma   = sigma,
-            n_lidar_rays    = n_lidar_rays,
-        )
-        if os.path.exists(weights_file) and not re_initialize:
-            with open(weights_file) as _f:
-                _cfg = yaml.safe_load(_f) or {}
-            if isinstance(_cfg, dict) and _cfg.get("policy_type") == "lstm":
-                saved_hidden_size = _cfg.get("hidden_size")
-                saved_n_lidar_rays = _cfg.get("n_lidar_rays")
-                if saved_hidden_size is not None and saved_hidden_size != hidden_size:
-                    raise ValueError(
-                        "Saved LSTM champion hidden_size does not match current run: "
-                        f"saved={saved_hidden_size}, current={hidden_size}"
-                    )
-                if saved_n_lidar_rays is not None and saved_n_lidar_rays != n_lidar_rays:
-                    raise ValueError(
-                        "Saved LSTM champion n_lidar_rays does not match current run: "
-                        f"saved={saved_n_lidar_rays}, current={n_lidar_rays}"
-                    )
-                champion = LSTMPolicy.from_cfg(_cfg)
-                policy.initialize_from_champion(champion)
-        return policy
-
-    extra_policy_types = {
-        "neural_dqn": _make_neural_dqn,
-        "cmaes":      _make_cmaes,
-        "reinforce":  _make_reinforce,
-        "lstm":       _make_lstm,
-    }
-    extra_loop_dispatch = {
-        "neural_dqn": "q_learning",
-        "cmaes":      "cmaes",
-        "reinforce":  "q_learning",
-        "lstm":       "cmaes",
-    }
-
-    data = train_rl(
-        experiment_name     = args.experiment,
-        make_env_fn         = lambda: make_env(
-            experiment_dir    = experiment_dir,
-            speed             = p["speed"],
-            in_game_episode_s = p["in_game_episode_s"],
-            n_lidar_rays      = n_lidar_rays,
-        ),
-        obs_spec            = obs_spec,
-        head_names          = ["steer", "accel", "brake"],
-        discrete_actions    = DISCRETE_ACTIONS,
-        speed               = p["speed"],
-        n_sims              = p["n_sims"],
-        in_game_episode_s   = p["in_game_episode_s"],
-        weights_file        = weights_file,
-        reward_config_file  = reward_cfg_file,
-        mutation_scale      = p["mutation_scale"],
-        mutation_share      = p.get("mutation_share", 1.0),
-        probe_actions       = PROBE_ACTIONS,
-        probe_in_game_s     = p["probe_s"],
-        cold_start_restarts = p["cold_restarts"],
-        cold_start_sims     = p["cold_sims"],
-        warmup_action       = WARMUP_ACTION,
-        warmup_steps        = 5,
-        training_params     = p,
-        no_interrupt        = args.no_interrupt,
-        re_initialize       = re_initialize,
-        do_pretrain         = p.get("do_pretrain", False),
-        policy_type         = policy_type,
-        policy_params       = policy_params,
-        track               = track,
-        adaptive_mutation   = p.get("adaptive_mutation", True),
-        extra_policy_types  = extra_policy_types,
-        extra_loop_dispatch = extra_loop_dispatch,
-        patience            = p.get("patience", 0),
-    )
-
-    save_experiment_results(data, results_dir=f"{experiment_dir}/results")
+    module = importlib.import_module(GAMES[args.game])
+    module.run(args)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,14 @@ optional = true
 # Per issue #79. The wrapper is imported lazily by
 # games.assetto_corsa.clients.ac_client so the rest of the codebase (and
 # Linux CI) work fine without this group installed.
+# Keep the Assetto Corsa install path self-contained so
+# `poetry install --with assetto_corsa` includes the common runtime
+# dependencies used by the integration and analytics code paths.
 assetto-corsa-rl = ">=0.1"
 gymnasium = ">=0.29"
+numpy = ">=1.26"
+pyyaml = ">=6.0"
+matplotlib = ">=3.8"
 
 [build-system]
 requires = ["poetry-core"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,16 @@ numpy = ">=1.26"
 scipy = ">=1.12"
 pyyaml = ">=6.0"
 
+[tool.poetry.group.assetto_corsa]
+optional = true
+
+[tool.poetry.group.assetto_corsa.dependencies]
+# Per issue #79. The wrapper is imported lazily by
+# games.assetto_corsa.clients.ac_client so the rest of the codebase (and
+# Linux CI) work fine without this group installed.
+assetto-corsa-rl = ">=0.1"
+gymnasium = ">=0.29"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/rl/main.py
+++ b/rl/main.py
@@ -1,0 +1,13 @@
+"""Module alias for the top-level RL trainer.
+
+Allows ``python -m rl.main --game assetto my_experiment`` (per issue #79
+acceptance criterion 1) to drive the same entry point as ``python main.py``.
+"""
+
+from __future__ import annotations
+
+from main import main
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/launch_assetto.ps1
+++ b/scripts/launch_assetto.ps1
@@ -1,0 +1,26 @@
+# Launch Assetto Corsa via Steam if it isn't already running.
+# Per issue #79: small launcher that checks the AC executable is running and starts it if not.
+
+$ErrorActionPreference = "Stop"
+
+$proc = Get-Process -Name "acs" -ErrorAction SilentlyContinue
+if ($null -ne $proc) {
+    Write-Host "Assetto Corsa already running (PID $($proc.Id))"
+    exit 0
+}
+
+Write-Host "Assetto Corsa not running — launching via Steam..."
+Start-Process "steam://rungameid/244210"
+
+# Wait up to 60s for the process to appear.
+for ($i = 0; $i -lt 60; $i++) {
+    Start-Sleep -Seconds 1
+    $proc = Get-Process -Name "acs" -ErrorAction SilentlyContinue
+    if ($null -ne $proc) {
+        Write-Host "Assetto Corsa started (PID $($proc.Id))"
+        exit 0
+    }
+}
+
+Write-Error "Timed out waiting for Assetto Corsa to start"
+exit 1

--- a/scripts/launch_assetto.sh
+++ b/scripts/launch_assetto.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# POSIX counterpart to launch_assetto.ps1.
+#
+# Assetto Corsa is Windows-only at the binary level, so this script is a
+# no-op on Linux/macOS. It exists so CI workflows can invoke a single
+# launcher path on every OS without OS-specific branching.
+
+set -euo pipefail
+
+case "$(uname -s)" in
+    Linux*|Darwin*)
+        echo "launch_assetto.sh: Assetto Corsa is Windows-only; this is a no-op on $(uname -s)."
+        echo "On Linux you can run training against the gym wrapper without the AC binary."
+        exit 0
+        ;;
+    *)
+        echo "launch_assetto.sh: unsupported platform $(uname -s)" >&2
+        exit 1
+        ;;
+esac

--- a/tests/assetto_corsa/test_smoke.py
+++ b/tests/assetto_corsa/test_smoke.py
@@ -1,0 +1,176 @@
+"""Smoke tests for the Assetto Corsa game integration.
+
+Uses a stub gym env so the test runs on Linux CI without the upstream
+assetto-corsa-rl package or the AC binary. Verifies:
+
+- AssettoCorsaEnv constructs against an injected env factory.
+- reset() returns an observation matching the obs_spec dimension.
+- step() returns the standard 5-tuple with finite reward and the
+  canonical info keys (pos_x, pos_z, track_progress, lateral_offset).
+- A 5-episode training loop runs end-to-end with WeightedLinearPolicy
+  (acceptance criterion #3).
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from framework.policies import WeightedLinearPolicy
+from games.assetto_corsa.env import AssettoCorsaEnv
+from games.assetto_corsa.obs_spec import AC_OBS_SPEC, BASE_OBS_DIM, with_vision
+from games.assetto_corsa.reward import RewardCalculator, RewardConfig
+
+
+# ---------------------------------------------------------------------------
+# Stub gym env
+# ---------------------------------------------------------------------------
+
+class _StubACEnv:
+    """Minimal gym-compatible env that emits deterministic AC-shaped telemetry."""
+
+    def __init__(self, episode_len: int = 8) -> None:
+        self.episode_len = episode_len
+        self._t = 0
+
+    # Gymnasium reset: (obs, info)
+    def reset(self):
+        self._t = 0
+        obs = self._obs(progress=0.0)
+        return obs, {}
+
+    # Gymnasium step: (obs, reward, terminated, truncated, info)
+    def step(self, action):
+        self._t += 1
+        progress = min(1.0, self._t / float(self.episode_len))
+        terminated = progress >= 1.0
+        return self._obs(progress=progress), 0.0, terminated, False, {}
+
+    def close(self) -> None:
+        pass
+
+    def _obs(self, progress: float) -> dict:
+        return {
+            "speed_ms":        20.0 + progress * 30.0,
+            "lateral_offset":  0.5,
+            "yaw_error":       0.0,
+            "pitch":           0.0,
+            "roll":            0.0,
+            "track_progress":  progress,
+            "steering_angle":  0.0,
+            "engine_rpm":      4000.0,
+            "gear":            3.0,
+            "wheel_slip":      (0.1, 0.1, 0.1, 0.1),
+            "angular_velocity":(0.0, 0.0, 0.0),
+            "pos_x":           progress * 100.0,
+            "pos_z":           0.0,
+        }
+
+
+def _factory(_env_id, **_kwargs):
+    return _StubACEnv()
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_obs_spec_dimensions_match_base_obs_dim():
+    assert AC_OBS_SPEC.dim == BASE_OBS_DIM
+    assert with_vision(0).dim == BASE_OBS_DIM
+    assert with_vision(4).dim == BASE_OBS_DIM + 4
+
+
+def test_env_reset_returns_correct_obs_shape():
+    env = AssettoCorsaEnv(env_factory=_factory)
+    try:
+        obs, info = env.reset()
+        assert obs.shape == (AC_OBS_SPEC.dim,)
+        assert obs.dtype == np.float32
+        assert info == {}
+    finally:
+        env.close()
+
+
+def test_env_step_returns_5_tuple_with_finite_reward():
+    env = AssettoCorsaEnv(env_factory=_factory)
+    try:
+        env.reset()
+        action = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+        obs, reward, terminated, truncated, info = env.step(action)
+        assert obs.shape == (AC_OBS_SPEC.dim,)
+        assert math.isfinite(reward)
+        assert isinstance(terminated, bool)
+        assert isinstance(truncated, bool)
+        for key in ("pos_x", "pos_z", "track_progress", "lateral_offset",
+                    "finished", "termination_reason"):
+            assert key in info, f"missing info key: {key}"
+    finally:
+        env.close()
+
+
+def test_env_terminates_on_finish():
+    env = AssettoCorsaEnv(env_factory=_factory)
+    try:
+        env.reset()
+        action = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+        terminated = False
+        for _ in range(20):
+            _, _, terminated, _, info = env.step(action)
+            if terminated:
+                break
+        assert terminated
+        assert info.get("termination_reason") == "finish"
+        assert info.get("laps_completed") == 1
+    finally:
+        env.close()
+
+
+def test_env_with_vision_features():
+    """Vision features default to zeros when the stub doesn't supply them."""
+    env = AssettoCorsaEnv(env_factory=_factory, n_vision=4)
+    try:
+        obs, _ = env.reset()
+        assert obs.shape == (BASE_OBS_DIM + 4,)
+        # Last 4 entries are vision; stub emits none → zeros.
+        assert np.allclose(obs[-4:], 0.0)
+    finally:
+        env.close()
+
+
+def test_reward_calculator_computes_finite_value():
+    cfg = RewardConfig()
+    calc = RewardCalculator(cfg)
+    prev = {"track_progress": 0.0, "lateral_offset": 0.0, "speed_ms": 0.0}
+    curr = {"track_progress": 0.1, "lateral_offset": 0.5, "speed_ms": 20.0}
+    r = calc.compute(prev, curr, finished=False, elapsed_s=1.0,
+                     info={"accelerating": True}, n_ticks=1)
+    assert math.isfinite(r)
+    # Progress delta dominates (0.1 * progress_weight).
+    assert r > 0
+
+
+def test_five_episode_training_loop_with_linear_policy():
+    """Acceptance criterion #3: existing policies trainable for ≥5 episodes."""
+    env = AssettoCorsaEnv(env_factory=_factory)
+    obs_spec = AC_OBS_SPEC
+    policy = WeightedLinearPolicy(obs_spec, ["steer", "accel", "brake"], None)
+
+    try:
+        rewards = []
+        for _ in range(5):
+            obs, _ = env.reset()
+            total = 0.0
+            for _ in range(50):
+                action = policy(obs)
+                obs, r, term, trunc, _ = env.step(action)
+                total += r
+                if term or trunc:
+                    break
+            rewards.append(total)
+        assert len(rewards) == 5
+        assert all(math.isfinite(r) for r in rewards)
+    finally:
+        env.close()

--- a/tests/assetto_corsa/test_smoke.py
+++ b/tests/assetto_corsa/test_smoke.py
@@ -111,6 +111,26 @@ def test_env_step_returns_5_tuple_with_finite_reward():
         env.close()
 
 
+def test_info_reflects_current_step_not_previous():
+    """info dict must contain the current step's state, not _prev_state."""
+    env = AssettoCorsaEnv(env_factory=_factory)
+    episode_len = 8
+    try:
+        env.reset()
+        action = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+        for t in range(1, episode_len + 1):
+            _, _, terminated, _, info = env.step(action)
+            expected_progress = min(1.0, t / float(episode_len))
+            assert info["track_progress"] == pytest.approx(expected_progress), (
+                f"step {t}: info['track_progress'] should be current step's "
+                f"progress {expected_progress}, got {info['track_progress']}"
+            )
+            if terminated:
+                break
+    finally:
+        env.close()
+
+
 def test_env_terminates_on_finish():
     env = AssettoCorsaEnv(env_factory=_factory)
     try:


### PR DESCRIPTION
Add games/assetto_corsa/ as a second game integration alongside TMNF.
The new package mirrors the games/tmnf/ layout (obs_spec, actions, env,
clients, reward, analytics, config, entry) and wires AC into the
game-agnostic framework.training.train_rl loop without touching any
TMNF code.

main.py now dispatches on a --game {tmnf,assetto} flag (default tmnf
preserves the existing CLI). The TMNF wiring previously inlined in
main.py moves to games/tmnf/entry.py. rl/main.py is a module alias so
`python -m rl.main --game assetto <name>` works per the issue spec.

The upstream gym wrapper (assetto-corsa-rl / dasGringuen/assetto_corsa_gym)
is imported lazily inside the AC client, and tests use a stub env so
Linux CI exercises the smoke path on every PR without needing the AC
binary or the optional poetry group installed.

https://claude.ai/code/session_01NBzmAZPtH7evZqcwpFt7kp