### PR TITLE
feat: add StarCraft 2 game integration via PySC2 (#90)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,10 @@
 
 Trackmania Nations Forever RL agent. Drives autonomously via hill-climbing / evolutionary / CMA-ES / Q-learning trained against live TMInterface session.
 
-**Runtime Windows-only**: `pywin32`, `mss` window grab, `tminterface` bind to live game process.
+**Runtime per game**:
+- TMNF: Windows-only (`pywin32`, `mss` window grab, `tminterface` bind to live game process).
+- TORCS: Linux/Windows via `gym_torcs`.
+- SC2: Linux/Windows/Mac via PySC2; runs headless on Linux against the Blizzard SC2 binary.
 
 ---
 
@@ -19,7 +22,9 @@ tmnf-ai/
 ├── pyproject.toml
 ├── framework/              # Game-agnostic training loop, obs spec, analytics, base policies
 ├── games/
-│   └── tmnf/               # TMNF-specific env, reward, lidar, steering, policies, clients, tools
+│   ├── tmnf/               # TMNF-specific env, reward, lidar, steering, policies, clients, tools
+│   ├── torcs/              # TORCS racing simulator integration
+│   └── sc2/                # StarCraft 2 integration via PySC2 (Linux-friendly, headless)
 ├── clients/                # Backward-compat shim → games/tmnf/clients
 ├── rl/                     # Backward-compat shim + PPO/pretrain experiments
 ├── distributed/            # Coordinator, worker, protocol for distributed grid search
@@ -36,8 +41,12 @@ tmnf-ai/
 ## Running
 
 ```bash
-# Single experiment
+# Single experiment (TMNF — default)
 python main.py <experiment_name> [--no-interrupt] [--re-initialize]
+
+# Run on a different game
+python main.py <experiment_name> --game torcs
+python main.py <experiment_name> --game sc2
 
 # Grid search over param combinations
 python grid_search.py config/my_grid.yaml [--no-interrupt]
@@ -272,6 +281,52 @@ Daemon keepalive thread keeps `iface.running` alive. `on_registered` sets event 
 
 ---
 
+## StarCraft 2 (`games/sc2/`)
+
+**MVP scope** (issue #90): the 7 standard PySC2 minigames + a 1v1-vs-builtin-bot env stub. Fog-of-war + belief machinery comes in #91.
+
+### Setup
+
+1. Install the Blizzard StarCraft 2 binary. On Linux use the [headless build](https://github.com/Blizzard/s2client-proto#linux-packages); on Windows/Mac the regular client works.
+2. Set `SC2PATH` to the install root (Linux), or place the install in `~/StarCraftII/` (the PySC2 default).
+3. Download the [PySC2 maps](https://github.com/Blizzard/s2client-proto#downloads) (mini-games + ladder maps) and unzip them into `Maps/` under the install root.
+4. Install the optional sc2 dependency group:
+   ```bash
+   poetry install --with sc2
+   ```
+
+### Running
+
+```bash
+# Default minigame (MoveToBeacon)
+python main.py myrun --game sc2
+
+# Choose a different minigame: edit games/sc2/config/training_params.yaml
+# (or the per-experiment copy under experiments/) and set map_name.
+```
+
+The first run creates `experiments/sc2_<map>/<name>/` and copies both master configs in. Edit the experiment-local copies to tune without affecting other runs.
+
+### Config knobs
+
+| Key | Default | Notes |
+|---|---|---|
+| `map_name` | `MoveToBeacon` | Any of the 7 minigame names or a ladder map (e.g. `Simple64`). |
+| `agent_race` | `random` | `protoss` / `terran` / `zerg` / `random`. |
+| `bot_difficulty` | `very_easy` | Only for ladder maps. |
+| `step_mul` | `8` | Game ticks per env step (~0.5 s real-time). |
+| `screen_size`, `minimap_size` | `64` | Square feature-layer resolutions. |
+
+### Action space
+
+Continuous `Box([fn_idx, x, y, queue], shape=(4,))` with a 9-cell discrete grid in `games/sc2/actions.py`. `fn_idx` cell 4 (centre) selects the army; the other 8 cells emit `Move_screen` to one of the directional cells. Sufficient for `MoveToBeacon` / `CollectMineralShards`; extension to economy/build minigames is via richer reward shaping rather than a wider action set in this MVP.
+
+### Observation space
+
+13-dim flat vector for minigames (see `games/sc2/obs_spec.py::SC2_MINIGAME_OBS_SPEC`): player totals, selected-unit summary, screen player_relative pixel counts and centroids. Ladder maps add 8 more dims for economy + minimap visibility. Issue #91 will extend this with belief / staleness features for fog-of-war play.
+
+---
+
 ## Dependencies
 
 Managed by Poetry. Run `poetry install` from repo root.
@@ -279,3 +334,7 @@ Managed by Poetry. Run `poetry install` from repo root.
 `tminterface` and `pygbx` not on PyPI — install from source before `poetry install`.
 
 Core runtime deps: `numpy`, `scipy`, `gymnasium`, `pyyaml`, `matplotlib`, `opencv-python`, `mss`, `pywin32`, `tminterface`, `pygbx`.
+
+Optional groups:
+- `--with torcs` — `gym_torcs` for TORCS support.
+- `--with sc2` — `pysc2` for StarCraft 2 support.

--- a/games/sc2/__init__.py
+++ b/games/sc2/__init__.py
@@ -1,0 +1,15 @@
+"""StarCraft 2 game integration via PySC2.
+
+Implements the framework's abstract interfaces using DeepMind's PySC2 API.
+Two scopes are supported:
+
+1. **Minigames** (``map_name`` is one of MoveToBeacon, CollectMineralShards,
+   FindAndDefeatZerglings, DefeatRoaches, DefeatZerglingsAndBanelings,
+   CollectMineralsAndGas, BuildMarines).  Fully observable, short episodes,
+   small discrete action subset per map.
+
+2. **Ladder game stub** (``map_name`` is e.g. ``Simple64``).  Builds an
+   ``SC2Env`` against a built-in bot opponent so issue #91 can layer
+   fog-of-war belief machinery on top.  No learning is claimed at this
+   level — the env just runs without crashing.
+"""

--- a/games/sc2/actions.py
+++ b/games/sc2/actions.py
@@ -1,0 +1,143 @@
+"""StarCraft 2 action definitions.
+
+PySC2's full action space is parameterised: ``function_id`` + per-arg target
+coordinates.  That doesn't fit the existing ``Discrete(N)`` policies cleanly,
+so this MVP exposes a small flat discrete subset per minigame.  Continuous
+target coordinates are emitted for spatial actions (move-screen, attack-screen).
+
+Action representation
+---------------------
+Each row in ``DISCRETE_ACTIONS`` is a 4-vector ``[fn_idx, x, y, queue]`` where:
+
+  ``fn_idx``   — integer index into ``FUNCTION_IDS`` below.
+  ``x, y``     — normalised screen target coords in ``[0, 1]``.  Ignored for
+                 functions that don't take a screen-point arg.
+  ``queue``    — 0 or 1, whether to queue the order.
+
+The framework's discrete-action policies still see fixed-shape rows; the
+client (``games.sc2.client``) is responsible for translating each row into
+a real ``actions.FunctionCall`` at execution time.
+
+The 9-action grid below is sufficient for ``MoveToBeacon`` and
+``CollectMineralShards`` — both reduce to "select army, move to a screen
+cell".  Other minigames use the same grid plus a small extension elsewhere.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+# ---------------------------------------------------------------------------
+# Function-id table
+# ---------------------------------------------------------------------------
+# Indices are stable; the env client resolves them to PySC2 function ids at
+# call time so we don't need pysc2 imported at framework level.
+
+FUNCTION_IDS = {
+    0: "no_op",                         # actions.FUNCTIONS.no_op
+    1: "select_army",                   # actions.FUNCTIONS.select_army
+    2: "Move_screen",                   # actions.FUNCTIONS.Move_screen
+    3: "Attack_screen",                 # actions.FUNCTIONS.Attack_screen
+    4: "select_idle_worker",            # actions.FUNCTIONS.select_idle_worker
+    5: "Harvest_Gather_screen",         # actions.FUNCTIONS.Harvest_Gather_screen
+}
+
+
+# ---------------------------------------------------------------------------
+# Discrete action grid for minigame policies — 9 cells
+# ---------------------------------------------------------------------------
+# fn_idx 1 = select_army (instant), fn_idx 2 = Move_screen at one of 8
+# directional cells.  This is the minimum action set needed for MoveToBeacon
+# and is reused for the other minigames.
+#
+# Cells are arranged as a 3×3 grid over the screen.  The centre cell (4)
+# selects the army instead of moving — this gives the policy a way to issue
+# the prerequisite selection.
+
+_GRID = [
+    (0.20, 0.20),  # 0: top-left
+    (0.50, 0.20),  # 1: top
+    (0.80, 0.20),  # 2: top-right
+    (0.20, 0.50),  # 3: left
+    (0.50, 0.50),  # 4: centre  (select_army)
+    (0.80, 0.50),  # 5: right
+    (0.20, 0.80),  # 6: bottom-left
+    (0.50, 0.80),  # 7: bottom
+    (0.80, 0.80),  # 8: bottom-right
+]
+
+DISCRETE_ACTIONS = np.array(
+    [
+        [1, _GRID[i][0], _GRID[i][1], 0] if i == 4
+        else [2, _GRID[i][0], _GRID[i][1], 0]
+        for i in range(9)
+    ],
+    dtype=np.float32,
+)
+
+
+# ---------------------------------------------------------------------------
+# Probe actions — fixed action vectors for cold-start evaluation
+# ---------------------------------------------------------------------------
+# Each entry is (action_array, description_string).  Probes establish a
+# reward floor before random-restart hill-climbing kicks in.
+
+PROBE_ACTIONS: list[tuple[np.ndarray, str]] = [
+    (np.array([0, 0.5, 0.5, 0], dtype=np.float32), "no_op"),
+    (np.array([1, 0.5, 0.5, 0], dtype=np.float32), "select_army"),
+    (np.array([2, 0.5, 0.5, 0], dtype=np.float32), "move_centre"),
+    (np.array([2, 0.2, 0.2, 0], dtype=np.float32), "move_top_left"),
+    (np.array([2, 0.8, 0.8, 0], dtype=np.float32), "move_bottom_right"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Warmup action — forced for the first N steps of each episode
+# ---------------------------------------------------------------------------
+# select_army is a near-universal precondition; running it on step 0 means
+# subsequent moves can target individual units without first re-selecting.
+
+WARMUP_ACTION = np.array([1, 0.5, 0.5, 0], dtype=np.float32)
+
+
+def action_to_function_call(action: np.ndarray, screen_size: int):
+    """Translate a 4-vector action row into a PySC2 ``FunctionCall``.
+
+    Parameters
+    ----------
+    action :
+        4-vector ``[fn_idx, x, y, queue]`` produced by a policy.
+    screen_size :
+        Size of the screen feature layer (e.g. 64).  Used to denormalise
+        the coordinate args.
+
+    Returns
+    -------
+    pysc2.lib.actions.FunctionCall
+
+    Notes
+    -----
+    Imports PySC2 lazily so that callers without PySC2 installed (unit
+    tests, framework code) can import this module freely.
+    """
+    from pysc2.lib import actions  # type: ignore[import-untyped]
+
+    fn_idx = int(action[0])
+    x_norm = float(np.clip(action[1], 0.0, 1.0))
+    y_norm = float(np.clip(action[2], 0.0, 1.0))
+    queue = int(round(float(action[3])))
+    sx = int(x_norm * (screen_size - 1))
+    sy = int(y_norm * (screen_size - 1))
+
+    name = FUNCTION_IDS.get(fn_idx, "no_op")
+    fn = getattr(actions.FUNCTIONS, name, actions.FUNCTIONS.no_op)
+    fn_id = int(fn.id)
+
+    if name == "no_op" or name == "select_army" or name == "select_idle_worker":
+        # No spatial args; queue may not apply for instant actions.
+        if name == "select_army" or name == "select_idle_worker":
+            return actions.FunctionCall(fn_id, [[0]])
+        return actions.FunctionCall(fn_id, [])
+    # Spatial actions: [queued, target_screen]
+    return actions.FunctionCall(fn_id, [[queue], [sx, sy]])

--- a/games/sc2/actions.py
+++ b/games/sc2/actions.py
@@ -126,7 +126,7 @@ def action_to_function_call(action: np.ndarray, screen_size: int):
     fn_idx = int(action[0])
     x_norm = float(np.clip(action[1], 0.0, 1.0))
     y_norm = float(np.clip(action[2], 0.0, 1.0))
-    queue = int(round(float(action[3])))
+    queue = int(np.clip(round(float(action[3])), 0, 1))
     sx = int(x_norm * (screen_size - 1))
     sy = int(y_norm * (screen_size - 1))
 

--- a/games/sc2/analytics.py
+++ b/games/sc2/analytics.py
@@ -1,0 +1,81 @@
+"""SC2-specific analytics entry point.
+
+SC2 minigames don't have throttle / steering / centerline concepts, so
+this module is intentionally thin — it delegates to the framework's
+generic reward-trajectory and probe/cold-start/greedy plots and writes
+a minimal Markdown summary.
+
+Entry point called by main.py:
+    save_experiment_results(data: ExperimentData, results_dir: str) -> None
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+import matplotlib
+if 'matplotlib.pyplot' not in sys.modules:
+    matplotlib.use('Agg')
+
+from framework.analytics import (
+    ExperimentData,
+    plot_probe_rewards,
+    plot_cold_start_rewards,
+    plot_greedy_rewards,
+    plot_reward_trajectory,
+    _probe_table_md,
+    _cold_start_table_md,
+    _greedy_table_md,
+    _timings_md,
+    _summary_md,
+    save_grid_summary as _framework_save_grid_summary,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def save_experiment_results(data: ExperimentData, results_dir: str) -> None:
+    """Generate generic plots and write a results.md report to *results_dir*."""
+    os.makedirs(results_dir, exist_ok=True)
+
+    sections = [
+        f"# Experiment: {data.experiment_name}\n\n**Game:** StarCraft 2\n\n",
+        _timings_md(data),
+        _summary_md(data),
+    ]
+
+    if data.probe_results:
+        plot_probe_rewards(data, results_dir)
+        sections.append(_probe_table_md(data))
+        sections.append("\n![Probe rewards](probe_rewards.png)\n\n")
+
+    if data.cold_start_restarts:
+        plot_cold_start_rewards(data, results_dir)
+        sections.append(_cold_start_table_md(data))
+        sections.append("\n![Cold-start best rewards](cold_start_best_rewards.png)\n\n")
+
+    if data.greedy_sims:
+        plot_greedy_rewards(data, results_dir)
+        sections.append(_greedy_table_md(data))
+        sections.append("\n![Greedy rewards](greedy_rewards.png)\n\n")
+
+    plot_reward_trajectory(data, results_dir)
+    sections.append("\n![Reward trajectory](reward_trajectory.png)\n\n")
+
+    report_path = os.path.join(results_dir, "results.md")
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.writelines(sections)
+
+    n = len(os.listdir(results_dir))
+    logger.info("Saved %d file(s) to %s/ (report: results.md)", n, results_dir)
+
+
+def save_grid_summary(
+    runs: list[tuple[str, ExperimentData]],
+    varied_keys: list[str],
+    summary_dir: str,
+    base_name: str,
+) -> None:
+    """Grid search cross-experiment summary using framework defaults."""
+    _framework_save_grid_summary(runs, varied_keys, summary_dir, base_name)

--- a/games/sc2/client.py
+++ b/games/sc2/client.py
@@ -73,7 +73,6 @@ class SC2Client:
             LADDER_OBS_NAMES if self._is_ladder else OBS_NAMES
         )
         self._cumulative_score: float = 0.0
-        self._first_visible_mask: np.ndarray | None = None
         self._explored_mask: np.ndarray | None = None
 
     # ------------------------------------------------------------------

--- a/games/sc2/client.py
+++ b/games/sc2/client.py
@@ -74,6 +74,7 @@ class SC2Client:
         )
         self._cumulative_score: float = 0.0
         self._explored_mask: np.ndarray | None = None
+        self._available_actions: set[int] | None = None
 
     # ------------------------------------------------------------------
     # Public interface
@@ -86,6 +87,7 @@ class SC2Client:
         timesteps = self._sc2_env.reset()
         self._cumulative_score = 0.0
         self._explored_mask = None
+        self._available_actions = None
         return self._timestep_to_obs_info(timesteps[0])
 
     def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, dict]:
@@ -171,12 +173,22 @@ class SC2Client:
         Falls back to ``no_op`` if the requested function is not currently
         available (PySC2 enforces preconditions like "have units selected").
         """
-        try:
-            from pysc2.lib import actions as pysc2_actions  # type: ignore[import-untyped]
-        except ImportError:
-            raise
+        from pysc2.lib import actions as pysc2_actions  # type: ignore[import-untyped]
 
         fn_call = action_to_function_call(action, self._screen_size)
+
+        if (
+            self._available_actions is not None
+            and int(fn_call.function) not in self._available_actions
+        ):
+            logger.debug(
+                "Function %d not in available_actions; substituting no_op.",
+                int(fn_call.function),
+            )
+            return pysc2_actions.FunctionCall(
+                int(pysc2_actions.FUNCTIONS.no_op.id), []
+            )
+
         return fn_call
 
     # ------------------------------------------------------------------
@@ -255,7 +267,7 @@ class SC2Client:
                 mm_self_count = float((player_relative_mm == 1).sum())
                 mm_enemy_count = float((player_relative_mm == 4).sum())
             if visible_mm is not None:
-                visible_frac = float((visible_mm > 0).sum()) / max(visible_mm.size, 1)
+                visible_frac = float((visible_mm == 2).sum()) / max(visible_mm.size, 1)
                 if self._explored_mask is None:
                     self._explored_mask = (visible_mm > 0).astype(bool)
                 else:
@@ -281,6 +293,21 @@ class SC2Client:
             cumulative = prev_score + float(getattr(timestep, "reward", 0.0) or 0.0)
         self._cumulative_score = cumulative
 
+        # Track available actions for precondition checking in _action_to_call.
+        avail_arr = self._safe_array(ob, "available_actions")
+        if avail_arr is not None:
+            self._available_actions = set(avail_arr.tolist())
+
+        # player_outcome is only meaningful for ladder maps where PySC2 emits
+        # a terminal +1 / -1 / 0.  For minigames timestep.reward is a per-step
+        # score delta, not a win/loss signal, so we leave it as None.
+        if timestep.last() and self._is_ladder:
+            player_outcome: float | None = float(
+                getattr(timestep, "reward", 0.0) or 0.0
+            )
+        else:
+            player_outcome = None
+
         info = {
             "score": cumulative,
             "prev_score": prev_score,
@@ -291,8 +318,7 @@ class SC2Client:
             "food_used": food_used,
             "food_cap": food_cap,
             "army_count": army_count,
-            "player_outcome": float(getattr(timestep, "reward", 0.0) or 0.0)
-                              if timestep.last() else None,
+            "player_outcome": player_outcome,
             "is_last": bool(timestep.last()),
         }
         return flat, info

--- a/games/sc2/client.py
+++ b/games/sc2/client.py
@@ -1,0 +1,383 @@
+"""Thin wrapper around ``pysc2.env.sc2_env.SC2Env``.
+
+Provides ``reset()`` / ``step()`` / ``close()`` returning the flat
+``np.ndarray`` observation expected by :class:`games.sc2.env.SC2Env`,
+plus an info dict with the raw scalars the reward calculator needs.
+
+PySC2 import is lazy: importing this module does not pull pysc2 in, so
+unit tests can mock the client without installing the SC2 binary.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+
+from games.sc2.actions import action_to_function_call
+from games.sc2.obs_spec import (
+    LADDER_OBS_NAMES,
+    OBS_NAMES,
+    SC2_LADDER_OBS_SPEC,
+    SC2_MINIGAME_OBS_SPEC,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SC2Client:
+    """Manages a ``pysc2.env.sc2_env.SC2Env`` session.
+
+    Parameters
+    ----------
+    map_name :
+        PySC2 map name (e.g. ``MoveToBeacon`` or ``Simple64``).
+    step_mul :
+        Game-tick multiplier per env step (default 8 ≈ 0.5 sec real-time).
+    screen_size :
+        Square feature-screen resolution (default 64).
+    minimap_size :
+        Square feature-minimap resolution (default 64).
+    agent_race :
+        Race string (``"random"``, ``"protoss"``, ``"terran"``, ``"zerg"``).
+    bot_difficulty :
+        Bot difficulty for 1v1 maps; ignored for minigames.
+    visualize :
+        If True, render the PySC2 visualizer window.
+    """
+
+    def __init__(
+        self,
+        map_name: str,
+        step_mul: int = 8,
+        screen_size: int = 64,
+        minimap_size: int = 64,
+        agent_race: str = "random",
+        bot_difficulty: str = "very_easy",
+        visualize: bool = False,
+    ) -> None:
+        self._map_name = map_name
+        self._step_mul = step_mul
+        self._screen_size = screen_size
+        self._minimap_size = minimap_size
+        self._agent_race = agent_race
+        self._bot_difficulty = bot_difficulty
+        self._visualize = visualize
+        self._sc2_env: Any = None
+        self._is_ladder = self._detect_ladder(map_name)
+        self._spec = (
+            SC2_LADDER_OBS_SPEC if self._is_ladder else SC2_MINIGAME_OBS_SPEC
+        )
+        self._obs_names = (
+            LADDER_OBS_NAMES if self._is_ladder else OBS_NAMES
+        )
+        self._cumulative_score: float = 0.0
+        self._first_visible_mask: np.ndarray | None = None
+        self._explored_mask: np.ndarray | None = None
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def reset(self) -> tuple[np.ndarray, dict]:
+        """Initialise the SC2 env and return the first observation + info."""
+        if self._sc2_env is None:
+            self._sc2_env = self._make_sc2_env()
+        timesteps = self._sc2_env.reset()
+        self._cumulative_score = 0.0
+        self._explored_mask = None
+        return self._timestep_to_obs_info(timesteps[0])
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, dict]:
+        """Apply an action and return ``(obs, score, done, info)``.
+
+        The middle return value is the raw PySC2 reward signal — for
+        minigames this is the score increment; for ladder maps it is the
+        terminal +1 / -1 / 0.  The reward calculator computes the actual
+        training reward in :class:`games.sc2.env.SC2Env`.
+        """
+        fn_call = self._action_to_call(action)
+        timesteps = self._sc2_env.step([fn_call])
+        timestep = timesteps[0]
+        obs, info = self._timestep_to_obs_info(timestep)
+        done = bool(timestep.last())
+        score = float(getattr(timestep, "reward", 0.0) or 0.0)
+        return obs, score, done, info
+
+    def close(self) -> None:
+        if self._sc2_env is not None:
+            self._sc2_env.close()
+            self._sc2_env = None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _detect_ladder(map_name: str) -> bool:
+        from games.sc2.obs_spec import MINIGAME_NAMES
+        return map_name not in MINIGAME_NAMES
+
+    def _make_sc2_env(self) -> Any:
+        try:
+            from pysc2.env import sc2_env  # type: ignore[import-untyped]
+            from pysc2.lib import features  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise ImportError(
+                "pysc2 is required for the StarCraft 2 game integration.  "
+                "Install it with:  poetry install --with sc2  "
+                "(and download the Blizzard SC2 binary + maps separately — "
+                "see CLAUDE.md for setup instructions)."
+            ) from exc
+
+        agents = [sc2_env.Agent(self._race(sc2_env), "rl_agent")]
+        if self._is_ladder:
+            agents.append(
+                sc2_env.Bot(
+                    self._race(sc2_env),
+                    self._difficulty(sc2_env),
+                )
+            )
+
+        return sc2_env.SC2Env(
+            map_name=self._map_name,
+            players=agents,
+            agent_interface_format=features.AgentInterfaceFormat(
+                feature_dimensions=features.Dimensions(
+                    screen=self._screen_size,
+                    minimap=self._minimap_size,
+                ),
+                use_feature_units=True,
+            ),
+            step_mul=self._step_mul,
+            game_steps_per_episode=0,
+            visualize=self._visualize,
+            disable_fog=False,
+        )
+
+    def _race(self, sc2_env_mod: Any) -> Any:
+        return getattr(sc2_env_mod.Race, self._agent_race, sc2_env_mod.Race.random)
+
+    def _difficulty(self, sc2_env_mod: Any) -> Any:
+        return getattr(
+            sc2_env_mod.Difficulty,
+            self._bot_difficulty,
+            sc2_env_mod.Difficulty.very_easy,
+        )
+
+    def _action_to_call(self, action: np.ndarray) -> Any:
+        """Translate a 4-vector action to a PySC2 ``FunctionCall``.
+
+        Falls back to ``no_op`` if the requested function is not currently
+        available (PySC2 enforces preconditions like "have units selected").
+        """
+        try:
+            from pysc2.lib import actions as pysc2_actions  # type: ignore[import-untyped]
+        except ImportError:
+            raise
+
+        fn_call = action_to_function_call(action, self._screen_size)
+        return fn_call
+
+    # ------------------------------------------------------------------
+    # Observation flattening
+    # ------------------------------------------------------------------
+
+    def _timestep_to_obs_info(self, timestep: Any) -> tuple[np.ndarray, dict]:
+        """Convert a PySC2 TimeStep into ``(flat_obs, info)``.
+
+        Tolerates missing fields gracefully so the same code path works for
+        minigames (no minimap visibility tracking) and ladder maps (with
+        fog of war).
+        """
+        ob = timestep.observation
+        player = self._safe_player(ob)
+
+        minerals   = float(player.get("minerals", 0))
+        vespene    = float(player.get("vespene", 0))
+        food_used  = float(player.get("food_used", 0))
+        food_cap   = float(player.get("food_cap", 0))
+        army_count = float(player.get("army_count", 0))
+        idle_workers = float(player.get("idle_worker_count", 0))
+        warp_gates = float(player.get("warp_gate_count", 0))
+        larva      = float(player.get("larva_count", 0))
+
+        # Selected-unit summary.
+        selected = self._safe_array(ob, "single_select")
+        if selected is None or selected.size == 0:
+            multi = self._safe_array(ob, "multi_select")
+            if multi is not None and multi.size > 0:
+                selected = multi
+        if selected is not None and selected.size > 0:
+            sel_count = float(selected.shape[0]) if selected.ndim >= 2 else 1.0
+            # Column index 2 in PySC2 single/multi select = current health.
+            try:
+                hp_col = selected[:, 2] if selected.ndim >= 2 else selected[2:3]
+                sel_avg_hp = float(np.mean(hp_col))
+            except (IndexError, ValueError):
+                sel_avg_hp = 0.0
+        else:
+            sel_count = 0.0
+            sel_avg_hp = 0.0
+
+        # Spatial summaries from the screen feature layer.
+        screen_self_count, screen_enemy_count = 0.0, 0.0
+        screen_self_cx, screen_self_cy = 0.0, 0.0
+        screen_enemy_cx, screen_enemy_cy = 0.0, 0.0
+        feat_screen = self._safe_array(ob, "feature_screen")
+        player_relative_screen = self._extract_player_relative(feat_screen, screen=True)
+        if player_relative_screen is not None:
+            self_mask = player_relative_screen == 1
+            enemy_mask = player_relative_screen == 4
+            screen_self_count = float(self_mask.sum())
+            screen_enemy_count = float(enemy_mask.sum())
+            screen_self_cx, screen_self_cy = self._centroid(self_mask)
+            screen_enemy_cx, screen_enemy_cy = self._centroid(enemy_mask)
+
+        minigame_features = [
+            minerals, vespene, food_used, food_cap, army_count,
+            sel_count, sel_avg_hp,
+            screen_self_count, screen_enemy_count,
+            screen_self_cx, screen_self_cy,
+            screen_enemy_cx, screen_enemy_cy,
+        ]
+
+        if not self._is_ladder:
+            flat = np.array(minigame_features, dtype=np.float32)
+        else:
+            # Ladder extras: minimap-level stats.
+            mmap = self._safe_array(ob, "feature_minimap")
+            player_relative_mm = self._extract_player_relative(mmap, screen=False)
+            visible_mm = self._extract_visibility(mmap)
+            mm_self_count, mm_enemy_count = 0.0, 0.0
+            visible_frac, explored_frac = 0.0, 0.0
+            if player_relative_mm is not None:
+                mm_self_count = float((player_relative_mm == 1).sum())
+                mm_enemy_count = float((player_relative_mm == 4).sum())
+            if visible_mm is not None:
+                visible_frac = float((visible_mm > 0).sum()) / max(visible_mm.size, 1)
+                if self._explored_mask is None:
+                    self._explored_mask = (visible_mm > 0).astype(bool)
+                else:
+                    self._explored_mask |= (visible_mm > 0)
+                explored_frac = float(self._explored_mask.sum()) / max(self._explored_mask.size, 1)
+            game_loop_arr = self._safe_array(ob, "game_loop")
+            game_loop = float(game_loop_arr[0]) if game_loop_arr is not None and game_loop_arr.size > 0 else 0.0
+
+            ladder_features = minigame_features + [
+                idle_workers, warp_gates, larva,
+                mm_self_count, mm_enemy_count,
+                visible_frac, explored_frac,
+                game_loop,
+            ]
+            flat = np.array(ladder_features, dtype=np.float32)
+
+        # Build the info dict — score deltas + reward inputs.
+        prev_score = self._cumulative_score
+        score_arr = self._safe_array(ob, "score_cumulative")
+        if score_arr is not None and score_arr.size > 0:
+            cumulative = float(score_arr[0])
+        else:
+            cumulative = prev_score + float(getattr(timestep, "reward", 0.0) or 0.0)
+        self._cumulative_score = cumulative
+
+        info = {
+            "score": cumulative,
+            "prev_score": prev_score,
+            "minerals": minerals,
+            "vespene": vespene,
+            "prev_minerals": 0.0,   # filled in by env on subsequent steps
+            "prev_vespene": 0.0,
+            "food_used": food_used,
+            "food_cap": food_cap,
+            "army_count": army_count,
+            "player_outcome": float(getattr(timestep, "reward", 0.0) or 0.0)
+                              if timestep.last() else None,
+            "is_last": bool(timestep.last()),
+        }
+        return flat, info
+
+    # ------------------------------------------------------------------
+    # PySC2 observation helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _safe_player(ob: Any) -> dict:
+        """PySC2 ``ob['player']`` is a NamedNumpyArray indexed by feature name."""
+        player = ob.get("player") if hasattr(ob, "get") else None
+        if player is None:
+            return {}
+        # NamedNumpyArray: support both attribute access and dict-like access.
+        result = {}
+        keys = (
+            "minerals", "vespene", "food_used", "food_cap",
+            "army_count", "idle_worker_count", "warp_gate_count", "larva_count",
+        )
+        for k in keys:
+            try:
+                v = player[k]
+            except (KeyError, IndexError, TypeError):
+                v = getattr(player, k, 0)
+            result[k] = float(v) if v is not None else 0.0
+        return result
+
+    @staticmethod
+    def _safe_array(ob: Any, key: str) -> np.ndarray | None:
+        """Look up a key in the timestep observation, return None if missing."""
+        try:
+            value = ob[key] if hasattr(ob, "__getitem__") else None
+        except (KeyError, IndexError, TypeError):
+            value = None
+        if value is None:
+            value = getattr(ob, key, None)
+        if value is None:
+            return None
+        if not isinstance(value, np.ndarray):
+            try:
+                value = np.asarray(value)
+            except (TypeError, ValueError):
+                return None
+        return value
+
+    @staticmethod
+    def _extract_player_relative(feat: np.ndarray | None, screen: bool) -> np.ndarray | None:
+        """PySC2 feature_screen / feature_minimap layers are indexable by name.
+
+        We dig out the ``player_relative`` channel (1 = self, 4 = enemy).
+        Returns None if the feature is unavailable.
+        """
+        if feat is None:
+            return None
+        # NamedNumpyArray-style access supports string indexing.
+        try:
+            return np.asarray(feat["player_relative"])
+        except (KeyError, IndexError, TypeError, ValueError):
+            pass
+        # Fall back to the canonical channel index.
+        # PySC2's SCREEN_FEATURES.player_relative.index = 5
+        # PySC2's MINIMAP_FEATURES.player_relative.index = 5
+        if feat.ndim == 3 and feat.shape[0] > 5:
+            return np.asarray(feat[5])
+        return None
+
+    @staticmethod
+    def _extract_visibility(feat: np.ndarray | None) -> np.ndarray | None:
+        """Extract minimap ``visibility_map`` (0=hidden, 1=fogged, 2=visible)."""
+        if feat is None:
+            return None
+        try:
+            return np.asarray(feat["visibility_map"])
+        except (KeyError, IndexError, TypeError, ValueError):
+            pass
+        # Canonical index 1.
+        if feat.ndim == 3 and feat.shape[0] > 1:
+            return np.asarray(feat[1])
+        return None
+
+    @staticmethod
+    def _centroid(mask: np.ndarray) -> tuple[float, float]:
+        if mask.sum() == 0:
+            return 0.0, 0.0
+        ys, xs = np.where(mask)
+        return float(np.mean(xs)), float(np.mean(ys))

--- a/games/sc2/config/reward_config.yaml
+++ b/games/sc2/config/reward_config.yaml
@@ -1,0 +1,30 @@
+# Reward configuration for SC2 RL training.
+# Edit these values freely — no code changes required.
+# See games/sc2/reward.py for full documentation of each parameter.
+#
+# Defaults below are tuned for MoveToBeacon (score increments by 1 per beacon
+# touched).  Other minigames may want different weights:
+#   - CollectMineralShards / CollectMineralsAndGas → score_weight=1.0,
+#       optionally economy_weight≈0.001 (already double-counts via score)
+#   - DefeatRoaches / DefeatZerglingsAndBanelings   → score_weight=0.05
+#       (raw kill score is large), idle_penalty=0
+#   - BuildMarines                                  → score_weight=1.0,
+#       idle_penalty=-0.05 (push away from doing nothing)
+#   - 1v1 ladder (Simple64)                         → score_weight=0.0,
+#       win_bonus=100, loss_penalty=-100, economy_weight=0.001
+
+# --- Primary signal ---
+score_weight: 1.0
+
+# --- Terminal outcome (ladder maps) ---
+win_bonus: 100.0
+loss_penalty: -100.0
+
+# --- Time cost ---
+step_penalty: -0.001
+
+# --- Idle penalty (BuildMarines / economy maps) ---
+idle_penalty: 0.0
+
+# --- Economy delta (mineral + vespene) ---
+economy_weight: 0.0

--- a/games/sc2/config/training_params.yaml
+++ b/games/sc2/config/training_params.yaml
@@ -1,0 +1,29 @@
+# StarCraft 2 training parameters.
+# Mirrors the TMNF / TORCS config structure with SC2-specific defaults.
+
+game: sc2
+map_name: MoveToBeacon       # PySC2 map; one of MINIGAME_NAMES or a ladder map
+agent_race: random           # protoss | terran | zerg | random
+bot_difficulty: very_easy    # only used on ladder maps; ignored for minigames
+step_mul: 8                  # game ticks per env step (~0.5 s real-time at default speed)
+screen_size: 64              # square feature-screen resolution
+minimap_size: 64             # square feature-minimap resolution
+
+speed: 1.0                   # SC2 has no in-engine speed multiplier; kept for framework compatibility
+in_game_episode_s: 120.0     # wall-clock seconds before truncation
+n_sims: 100                  # greedy simulations / generations after cold-start
+mutation_scale: 0.05         # std-dev of Gaussian noise applied to each perturbed weight
+mutation_share: 1.0          # fraction of weights perturbed per mutation (1.0 = all)
+adaptive_mutation: true      # apply 1/5th success rule to adapt mutation_scale during greedy phase
+probe_s: 30.0                # in-game seconds for each probe action run
+cold_restarts: 10            # max random restarts during cold-start search
+cold_sims: 5                 # hill-climb sims per cold-start restart
+n_lidar_rays: 0              # not applicable for SC2
+patience: 0                  # stop greedy loop if no improvement for this many sims (0 = run all)
+
+# Policy algorithm for the greedy training phase.
+policy_type: genetic
+
+policy_params:
+  population_size: 20
+  elite_k: 3

--- a/games/sc2/env.py
+++ b/games/sc2/env.py
@@ -87,6 +87,7 @@ class SC2Env(BaseGameEnv):
         self._is_ladder = map_name not in MINIGAME_NAMES
         self._reward_config = reward_config or SC2RewardConfig()
         self._max_episode_time_s = max_episode_time_s
+        self._step_mul = step_mul
         self._reward_calc = SC2RewardCalculator(self._reward_config)
 
         spec = get_spec(map_name)
@@ -168,6 +169,7 @@ class SC2Env(BaseGameEnv):
             finished=finished,
             elapsed_s=self._elapsed_s,
             info=info,
+            n_ticks=self._step_mul,
         )
 
         terminated = finished

--- a/games/sc2/env.py
+++ b/games/sc2/env.py
@@ -1,0 +1,253 @@
+"""SC2Env — Gymnasium environment wrapping PySC2 for RL training.
+
+Observation space
+-----------------
+Either ``SC2_MINIGAME_OBS_SPEC`` (13 dims) or ``SC2_LADDER_OBS_SPEC`` (21
+dims) depending on the map.  See :mod:`games.sc2.obs_spec`.
+
+Action space
+------------
+``Box(low=[0, 0, 0, 0], high=[N_FUNCS-1, 1, 1, 1], shape=(4,), dtype=float32)``
+
+  [0] fn_idx — integer in ``[0, len(FUNCTION_IDS)-1]`` (cast to int at exec)
+  [1] x      — normalised screen target x in ``[0, 1]``
+  [2] y      — normalised screen target y in ``[0, 1]``
+  [3] queue  — 0 or 1 (queue the order)
+
+The discrete-action policies use :data:`games.sc2.actions.DISCRETE_ACTIONS`
+which is a 9×4 grid in this Box space.
+
+Episode lifecycle
+-----------------
+``reset()`` → first PySC2 timestep → flat obs, info
+``step()``  → apply FunctionCall, read next timestep, compute reward
+Terminated when PySC2 marks ``timestep.last()``.
+Truncated when wall-clock elapsed > ``max_episode_time_s``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from gymnasium import spaces
+
+from framework.base_env import BaseGameEnv
+from games.sc2.actions import FUNCTION_IDS
+from games.sc2.client import SC2Client
+from games.sc2.obs_spec import MINIGAME_NAMES, get_spec
+from games.sc2.reward import SC2RewardCalculator, SC2RewardConfig
+
+logger = logging.getLogger(__name__)
+
+
+class SC2Env(BaseGameEnv):
+    """Gymnasium environment for StarCraft 2 reinforcement learning.
+
+    Parameters
+    ----------
+    map_name :
+        PySC2 map name (e.g. ``MoveToBeacon``, ``Simple64``).
+    reward_config :
+        :class:`SC2RewardConfig` instance.  If None, uses Python defaults.
+    max_episode_time_s :
+        Wall-clock seconds before the episode is truncated.
+    step_mul :
+        Game-tick multiplier per env step.
+    screen_size, minimap_size :
+        Square feature-layer resolutions.
+    agent_race :
+        Race string (``"random"``, ``"protoss"``, ``"terran"``, ``"zerg"``).
+    bot_difficulty :
+        Bot difficulty for 1v1 maps; ignored for minigames.
+    visualize :
+        If True, render the PySC2 visualizer.
+    """
+
+    metadata = {"render_modes": []}
+
+    def __init__(
+        self,
+        map_name: str = "MoveToBeacon",
+        reward_config: SC2RewardConfig | None = None,
+        max_episode_time_s: float = 120.0,
+        step_mul: int = 8,
+        screen_size: int = 64,
+        minimap_size: int = 64,
+        agent_race: str = "random",
+        bot_difficulty: str = "very_easy",
+        visualize: bool = False,
+    ) -> None:
+        super().__init__()
+
+        self._map_name = map_name
+        self._is_ladder = map_name not in MINIGAME_NAMES
+        self._reward_config = reward_config or SC2RewardConfig()
+        self._max_episode_time_s = max_episode_time_s
+        self._reward_calc = SC2RewardCalculator(self._reward_config)
+
+        spec = get_spec(map_name)
+        self.observation_space = spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(spec.dim,),
+            dtype=np.float32,
+        )
+        n_funcs = max(FUNCTION_IDS) + 1
+        self.action_space = spaces.Box(
+            low=np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            high=np.array([float(n_funcs - 1), 1.0, 1.0, 1.0], dtype=np.float32),
+            dtype=np.float32,
+        )
+
+        self._client = SC2Client(
+            map_name=map_name,
+            step_mul=step_mul,
+            screen_size=screen_size,
+            minimap_size=minimap_size,
+            agent_race=agent_race,
+            bot_difficulty=bot_difficulty,
+            visualize=visualize,
+        )
+
+        # Episode tracking
+        self._prev_obs: np.ndarray | None = None
+        self._prev_minerals: float = 0.0
+        self._prev_vespene: float = 0.0
+        self._prev_score: float = 0.0
+        self._elapsed_s: float = 0.0
+        self._episode_start_s: float = 0.0
+        self._step_count: int = 0
+
+    # ------------------------------------------------------------------
+    # Gymnasium interface
+    # ------------------------------------------------------------------
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[np.ndarray, dict]:
+        super().reset(seed=seed)
+
+        obs, info = self._client.reset()
+
+        self._prev_obs = obs
+        self._prev_minerals = info.get("minerals", 0.0)
+        self._prev_vespene = info.get("vespene", 0.0)
+        self._prev_score = info.get("score", 0.0)
+        self._elapsed_s = 0.0
+        self._episode_start_s = time.monotonic()
+        self._step_count = 0
+        self._reward_calc.reset()
+
+        return obs, info
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, bool, dict]:
+        obs, _raw_reward, done, info = self._client.step(action)
+
+        self._step_count += 1
+        self._elapsed_s = time.monotonic() - self._episode_start_s
+
+        # Override the prev-* entries the client cannot know about.
+        info["prev_minerals"] = self._prev_minerals
+        info["prev_vespene"] = self._prev_vespene
+        info["prev_score"] = self._prev_score
+        info["elapsed_s"] = self._elapsed_s
+
+        time_over = self._elapsed_s > self._max_episode_time_s
+        finished = done
+
+        reward = self._reward_calc.compute(
+            prev_state=None,
+            curr_state=None,
+            finished=finished,
+            elapsed_s=self._elapsed_s,
+            info=info,
+        )
+
+        terminated = finished
+        truncated = time_over and not terminated
+
+        if finished:
+            outcome = info.get("player_outcome")
+            if outcome is not None and outcome > 0:
+                info["termination_reason"] = "win"
+            elif outcome is not None and outcome < 0:
+                info["termination_reason"] = "loss"
+            else:
+                info["termination_reason"] = "finish"
+        elif time_over:
+            info["termination_reason"] = "timeout"
+        else:
+            info["termination_reason"] = None
+
+        self._prev_obs = obs
+        self._prev_minerals = info.get("minerals", 0.0)
+        self._prev_vespene = info.get("vespene", 0.0)
+        self._prev_score = info.get("score", 0.0)
+
+        return obs, reward, terminated, truncated, info
+
+    def close(self) -> None:
+        self._client.close()
+
+    # ------------------------------------------------------------------
+    # BaseGameEnv API
+    # ------------------------------------------------------------------
+
+    def _build_obs(self, step: Any) -> np.ndarray:
+        """Not used directly — obs comes from the client's reset/step."""
+        return np.zeros(self.observation_space.shape, dtype=np.float32)
+
+    def _get_game_info(self) -> dict:
+        return {
+            "map_name": self._map_name,
+            "is_ladder": self._is_ladder,
+            "step_count": self._step_count,
+            "elapsed_s": self._elapsed_s,
+        }
+
+    def get_episode_time_limit(self) -> float:
+        return self._max_episode_time_s
+
+    def set_episode_time_limit(self, seconds: float) -> None:
+        self._max_episode_time_s = seconds
+
+
+def make_env(
+    experiment_dir: str | Path,
+    map_name: str = "MoveToBeacon",
+    max_episode_time_s: float = 120.0,
+    step_mul: int = 8,
+    screen_size: int = 64,
+    minimap_size: int = 64,
+    agent_race: str = "random",
+    bot_difficulty: str = "very_easy",
+    visualize: bool = False,
+) -> SC2Env:
+    """Factory that wires up an :class:`SC2Env` from an experiment directory.
+
+    Loads ``reward_config.yaml`` from *experiment_dir* if it exists.
+    """
+    experiment_dir = Path(experiment_dir)
+    reward_cfg_path = experiment_dir / "reward_config.yaml"
+    if reward_cfg_path.exists():
+        reward_config = SC2RewardConfig.from_yaml(str(reward_cfg_path))
+    else:
+        reward_config = SC2RewardConfig()
+    return SC2Env(
+        map_name=map_name,
+        reward_config=reward_config,
+        max_episode_time_s=max_episode_time_s,
+        step_mul=step_mul,
+        screen_size=screen_size,
+        minimap_size=minimap_size,
+        agent_race=agent_race,
+        bot_difficulty=bot_difficulty,
+        visualize=visualize,
+    )

--- a/games/sc2/obs_spec.py
+++ b/games/sc2/obs_spec.py
@@ -1,0 +1,114 @@
+"""StarCraft 2 observation space definition.
+
+The PySC2 API exposes a rich observation: structured ``player`` totals, two
+spatial feature-layer stacks (minimap and screen), and per-unit feature lists.
+This game integration starts with a flat, fixed-size structured-only vector
+so the existing framework policies (linear, MLP, evolutionary) can consume
+SC2 observations without architectural changes.
+
+Two specs are defined:
+
+``SC2_MINIGAME_OBS_SPEC``
+    Compact 13-dim spec covering player totals plus a few spatial summary
+    statistics.  Designed for the 7 standard PySC2 minigames where the
+    relevant signal is small-scale unit positioning.
+
+``SC2_LADDER_OBS_SPEC``
+    21-dim extension adding economy and supply features used by the 1v1
+    ladder env stub.  Issue #91 (belief framework) will further extend this
+    with per-region staleness / belief features.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from framework.obs_spec import ObsDim, ObsSpec
+
+
+# ---------------------------------------------------------------------------
+# Minigame spec — 13 dims
+# ---------------------------------------------------------------------------
+# The 7 standard PySC2 minigames give scalar score directly; the structured
+# observation here exists so policies can condition on the immediate state.
+
+_MINIGAME_DIMS: list[ObsDim] = [
+    # Player totals (PySC2 obs.observation["player"] vector).
+    ObsDim("minerals",         1000.0,  "Current mineral count"),
+    ObsDim("vespene",          1000.0,  "Current vespene count"),
+    ObsDim("food_used",         200.0,  "Supply used"),
+    ObsDim("food_cap",          200.0,  "Supply cap"),
+    ObsDim("army_count",        100.0,  "Total army units"),
+    # Selected-unit summary (cached from feature_screen.selected when present).
+    ObsDim("selected_count",     50.0,  "Number of units currently selected"),
+    ObsDim("selected_avg_hp",   100.0,  "Mean HP of selected units"),
+    # Spatial summary stats over the screen feature layers.
+    ObsDim("screen_self_count", 200.0,  "Friendly unit pixel count on screen"),
+    ObsDim("screen_enemy_count",200.0,  "Enemy unit pixel count on screen"),
+    ObsDim("screen_self_cx",     64.0,  "Friendly unit centroid x (screen)"),
+    ObsDim("screen_self_cy",     64.0,  "Friendly unit centroid y (screen)"),
+    ObsDim("screen_enemy_cx",    64.0,  "Enemy unit centroid x (screen)"),
+    ObsDim("screen_enemy_cy",    64.0,  "Enemy unit centroid y (screen)"),
+]
+
+#: The canonical observation spec for PySC2 minigames.
+SC2_MINIGAME_OBS_SPEC: ObsSpec = ObsSpec(_MINIGAME_DIMS)
+
+
+# ---------------------------------------------------------------------------
+# Ladder game spec — extends minigame spec with economy + minimap summaries
+# ---------------------------------------------------------------------------
+
+_LADDER_EXTRA_DIMS: list[ObsDim] = [
+    ObsDim("idle_worker_count",  50.0,  "Idle worker count"),
+    ObsDim("warp_gate_count",    20.0,  "Warp gate count"),
+    ObsDim("larva_count",        20.0,  "Larva count"),
+    # Minimap-level summaries — distinct from screen stats above.
+    ObsDim("minimap_self_count",200.0,  "Friendly pixel count on minimap"),
+    ObsDim("minimap_enemy_count",200.0, "Enemy pixel count on minimap (visible only)"),
+    ObsDim("minimap_visible_frac",1.0,  "Fraction of minimap currently visible"),
+    ObsDim("minimap_explored_frac",1.0, "Fraction of minimap ever explored"),
+    ObsDim("game_loop",        20000.0, "Current game loop tick"),
+]
+
+#: Observation spec for the 1v1 ladder game stub.
+SC2_LADDER_OBS_SPEC: ObsSpec = ObsSpec(_MINIGAME_DIMS + _LADDER_EXTRA_DIMS)
+
+
+# ---------------------------------------------------------------------------
+# Derived constants — mirror the style used by games.tmnf / games.torcs.
+# ---------------------------------------------------------------------------
+
+#: Default spec — minigames are the MVP.
+SC2_OBS_SPEC: ObsSpec = SC2_MINIGAME_OBS_SPEC
+
+BASE_OBS_DIM: int = SC2_OBS_SPEC.dim
+OBS_NAMES: list[str] = SC2_OBS_SPEC.names
+OBS_SCALES: np.ndarray = SC2_OBS_SPEC.scales
+OBS_SPEC: list[ObsDim] = list(SC2_OBS_SPEC.dims)
+
+LADDER_OBS_DIM: int = SC2_LADDER_OBS_SPEC.dim
+LADDER_OBS_NAMES: list[str] = SC2_LADDER_OBS_SPEC.names
+
+
+def get_spec(map_name: str) -> ObsSpec:
+    """Return the appropriate ObsSpec for the given map.
+
+    Minigame names map to ``SC2_MINIGAME_OBS_SPEC``.  Anything else is
+    treated as a ladder map and gets ``SC2_LADDER_OBS_SPEC``.
+    """
+    if map_name in MINIGAME_NAMES:
+        return SC2_MINIGAME_OBS_SPEC
+    return SC2_LADDER_OBS_SPEC
+
+
+#: The 7 standard PySC2 minigame map names.
+MINIGAME_NAMES: tuple[str, ...] = (
+    "MoveToBeacon",
+    "CollectMineralShards",
+    "FindAndDefeatZerglings",
+    "DefeatRoaches",
+    "DefeatZerglingsAndBanelings",
+    "CollectMineralsAndGas",
+    "BuildMarines",
+)

--- a/games/sc2/reward.py
+++ b/games/sc2/reward.py
@@ -1,0 +1,132 @@
+"""StarCraft 2 reward calculator.
+
+For minigames the canonical signal is the cumulative ``score`` returned by
+PySC2 itself — so the calculator's main job is to compute the score *delta*
+each step and add small shaping terms.  For the ladder game stub the same
+signal is used as a placeholder; richer reward shaping (kill credit, mineral
+income, supply lead) is left for the follow-up issue that adds learning.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, fields
+from typing import Any
+
+import yaml
+
+from framework.base_reward import RewardCalculatorBase
+
+
+@dataclass
+class SC2RewardConfig:
+    """Reward weights for the SC2 environment.
+
+    Python defaults match a sensible baseline for ``MoveToBeacon``.  Other
+    minigames will typically want a different ``score_weight`` because the
+    environment-provided score scales differ (e.g. mineral count vs.
+    beacon-touch count).
+
+    Parameters
+    ----------
+    score_weight :
+        Coefficient on the ``score`` delta returned by PySC2 each step.
+    win_bonus :
+        One-shot bonus when the player reward signals a win (>0 from PySC2).
+    loss_penalty :
+        One-shot penalty when the player reward signals a loss (<0).
+    step_penalty :
+        Tiny negative reward every tick — discourages indefinite no-op.
+    idle_penalty :
+        Per-step penalty when ``army_count == 0 and food_used <= food_cap``;
+        used by ``BuildMarines`` to discourage doing nothing.
+    economy_weight :
+        Coefficient on (minerals + vespene) delta.  Useful for economy
+        minigames.  Set to 0 for pure-combat minigames.
+    """
+
+    score_weight:    float = 1.0
+    win_bonus:       float = 100.0
+    loss_penalty:    float = -100.0
+    step_penalty:    float = -0.001
+    idle_penalty:    float = 0.0
+    economy_weight:  float = 0.0
+
+    @classmethod
+    def from_yaml(cls, path: str) -> SC2RewardConfig:
+        with open(path) as f:
+            data = yaml.safe_load(f) or {}
+        valid_keys = {f.name for f in fields(cls)}
+        unknown = set(data.keys()) - valid_keys
+        if unknown:
+            raise ValueError(
+                f"{path}: unknown reward config keys: {sorted(unknown)}\n"
+                f"Valid keys: {sorted(valid_keys)}"
+            )
+        return cls(**data)
+
+
+class SC2RewardCalculator(RewardCalculatorBase):
+    """Reward computation for the SC2 environment.
+
+    Stateless — episode-state derivatives (``prev_score``) are passed in via
+    the ``info`` dict produced by :class:`games.sc2.env.SC2Env`.
+
+    Expected keys in ``info``:
+        ``score``         — current cumulative environment score
+        ``prev_score``    — previous step's environment score
+        ``minerals``, ``vespene`` — current totals
+        ``prev_minerals``, ``prev_vespene`` — previous totals
+        ``army_count``, ``food_used``, ``food_cap``
+        ``player_outcome`` — None / +1 / -1 (only set on the final step)
+    """
+
+    def __init__(self, config: SC2RewardConfig) -> None:
+        self.config = config
+
+    def compute(
+        self,
+        prev_state: Any,
+        curr_state: Any,
+        finished: bool,
+        elapsed_s: float,
+        info: dict,
+        n_ticks: int = 1,
+    ) -> float:
+        cfg = self.config
+        reward = 0.0
+
+        # Score delta — primary signal for minigames.
+        prev_score = info.get("prev_score", 0.0)
+        curr_score = info.get("score", 0.0)
+        reward += cfg.score_weight * (curr_score - prev_score)
+
+        # Economy delta (optional — typically 0 for pure-combat minigames).
+        if cfg.economy_weight != 0.0:
+            prev_min = info.get("prev_minerals", 0.0)
+            curr_min = info.get("minerals", 0.0)
+            prev_vesp = info.get("prev_vespene", 0.0)
+            curr_vesp = info.get("vespene", 0.0)
+            reward += cfg.economy_weight * (
+                (curr_min - prev_min) + (curr_vesp - prev_vesp)
+            )
+
+        # Idle penalty: nothing built and supply slack — encourages building.
+        if cfg.idle_penalty != 0.0:
+            army = info.get("army_count", 0.0)
+            food_used = info.get("food_used", 0.0)
+            food_cap = info.get("food_cap", 0.0)
+            if army == 0 and food_used < food_cap:
+                reward += cfg.idle_penalty * n_ticks
+
+        # Time cost.
+        reward += cfg.step_penalty * n_ticks
+
+        # Terminal win/loss bonus (only set when the env signals an outcome).
+        outcome = info.get("player_outcome")
+        if finished and outcome is not None:
+            if outcome > 0:
+                reward += cfg.win_bonus
+            elif outcome < 0:
+                reward += cfg.loss_penalty
+
+        return reward

--- a/games/sc2/reward.py
+++ b/games/sc2/reward.py
@@ -37,7 +37,7 @@ class SC2RewardConfig:
     step_penalty :
         Tiny negative reward every tick — discourages indefinite no-op.
     idle_penalty :
-        Per-step penalty when ``army_count == 0 and food_used <= food_cap``;
+        Per-step penalty when ``army_count == 0 and food_used < food_cap``;
         used by ``BuildMarines`` to discourage doing nothing.
     economy_weight :
         Coefficient on (minerals + vespene) delta.  Useful for economy

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ def main() -> None:
         help="Experiment name — files stored in experiments/<track>/<name>/",
     )
     parser.add_argument(
-        "--game", default="tmnf", choices=["tmnf", "torcs"],
+        "--game", default="tmnf", choices=["tmnf", "torcs", "sc2"],
         help="Game to train on (default: tmnf)",
     )
     parser.add_argument(
@@ -58,6 +58,8 @@ def main() -> None:
 
     if args.game == "torcs":
         _run_torcs(args)
+    elif args.game == "sc2":
+        _run_sc2(args)
     else:
         _run_tmnf(args)
 
@@ -309,6 +311,87 @@ def _run_torcs(args: argparse.Namespace) -> None:
 
     save_experiment_results(data, results_dir=f"{experiment_dir}/results")
     logger.info("TORCS training complete. Results saved to %s", experiment_dir)
+
+
+# ======================================================================
+# StarCraft 2 entry point
+# ======================================================================
+
+def _run_sc2(args: argparse.Namespace) -> None:
+    from games.sc2.obs_spec import get_spec
+    from games.sc2.actions import DISCRETE_ACTIONS, PROBE_ACTIONS, WARMUP_ACTION
+    from games.sc2.env import make_env
+    from games.sc2.analytics import save_experiment_results
+
+    # Read SC2 master config.
+    with open("games/sc2/config/training_params.yaml") as f:
+        master_p = yaml.safe_load(f)
+
+    map_name = master_p.get("map_name", "MoveToBeacon")
+    experiment_dir       = f"experiments/sc2_{map_name}/{args.experiment}"
+    weights_file         = f"{experiment_dir}/policy_weights.yaml"
+    reward_cfg_file      = f"{experiment_dir}/reward_config.yaml"
+    training_params_file = f"{experiment_dir}/training_params.yaml"
+
+    os.makedirs(experiment_dir, exist_ok=True)
+    if not os.path.exists(reward_cfg_file):
+        shutil.copy("games/sc2/config/reward_config.yaml", reward_cfg_file)
+        logger.info("Copied SC2 reward config → %s", reward_cfg_file)
+    if not os.path.exists(training_params_file):
+        shutil.copy("games/sc2/config/training_params.yaml", training_params_file)
+        logger.info("Copied SC2 training params → %s", training_params_file)
+
+    with open(training_params_file) as f:
+        p = yaml.safe_load(f)
+
+    # Pick obs spec by map. Re-read map_name from per-experiment config so
+    # users can change maps without touching the master config.
+    map_name      = p.get("map_name", map_name)
+    obs_spec      = get_spec(map_name)
+    policy_type   = p.get("policy_type", "genetic")
+    policy_params = p.get("policy_params") or {}
+
+    data = train_rl(
+        experiment_name     = args.experiment,
+        make_env_fn         = lambda: make_env(
+            experiment_dir     = experiment_dir,
+            map_name           = map_name,
+            max_episode_time_s = p["in_game_episode_s"],
+            step_mul           = p.get("step_mul", 8),
+            screen_size        = p.get("screen_size", 64),
+            minimap_size       = p.get("minimap_size", 64),
+            agent_race         = p.get("agent_race", "random"),
+            bot_difficulty     = p.get("bot_difficulty", "very_easy"),
+        ),
+        obs_spec            = obs_spec,
+        head_names          = ["fn_idx", "x", "y", "queue"],
+        discrete_actions    = DISCRETE_ACTIONS,
+        speed               = p.get("speed", 1.0),
+        n_sims              = p["n_sims"],
+        in_game_episode_s   = p["in_game_episode_s"],
+        weights_file        = weights_file,
+        reward_config_file  = reward_cfg_file,
+        mutation_scale      = p["mutation_scale"],
+        mutation_share      = p.get("mutation_share", 1.0),
+        probe_actions       = PROBE_ACTIONS,
+        probe_in_game_s     = p["probe_s"],
+        cold_start_restarts = p["cold_restarts"],
+        cold_start_sims     = p["cold_sims"],
+        warmup_action       = WARMUP_ACTION,
+        warmup_steps        = 5,
+        training_params     = p,
+        no_interrupt        = args.no_interrupt,
+        re_initialize       = args.re_initialize,
+        do_pretrain         = p.get("do_pretrain", False),
+        policy_type         = policy_type,
+        policy_params       = policy_params,
+        track               = f"sc2_{map_name}",
+        adaptive_mutation   = p.get("adaptive_mutation", True),
+        patience            = p.get("patience", 0),
+    )
+
+    save_experiment_results(data, results_dir=f"{experiment_dir}/results")
+    logger.info("SC2 training complete. Results saved to %s", experiment_dir)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,18 @@ numpy = ">=1.26"
 gymnasium = ">=0.29"
 pyyaml = ">=6.0"
 
+[tool.poetry.group.sc2]
+optional = true
+
+[tool.poetry.group.sc2.dependencies]
+# PySC2 brings in absl-py and the SC2 protocol stack; keep it optional so
+# Windows-only TMNF setups don't pull it in. Requires a separate Blizzard
+# SC2 binary install — see CLAUDE.md.
+numpy = ">=1.26"
+gymnasium = ">=0.29"
+pyyaml = ">=6.0"
+pysc2 = ">=4.0"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_sc2_actions.py
+++ b/tests/test_sc2_actions.py
@@ -1,0 +1,67 @@
+"""Tests for the SC2 action definitions."""
+import unittest
+
+import numpy as np
+
+from games.sc2.actions import (
+    DISCRETE_ACTIONS,
+    FUNCTION_IDS,
+    PROBE_ACTIONS,
+    WARMUP_ACTION,
+)
+
+
+class TestSC2Actions(unittest.TestCase):
+
+    def test_discrete_actions_shape(self):
+        # 9 cells × 4-dim action vector [fn_idx, x, y, queue].
+        self.assertEqual(DISCRETE_ACTIONS.shape, (9, 4))
+
+    def test_discrete_actions_dtype(self):
+        self.assertEqual(DISCRETE_ACTIONS.dtype, np.float32)
+
+    def test_discrete_actions_x_y_in_unit_square(self):
+        xs = DISCRETE_ACTIONS[:, 1]
+        ys = DISCRETE_ACTIONS[:, 2]
+        self.assertTrue(np.all((xs >= 0.0) & (xs <= 1.0)))
+        self.assertTrue(np.all((ys >= 0.0) & (ys <= 1.0)))
+
+    def test_centre_cell_is_select_army(self):
+        """Cell index 4 is the 3×3 grid centre and selects the army."""
+        self.assertEqual(int(DISCRETE_ACTIONS[4, 0]), 1)  # select_army
+
+    def test_other_cells_are_move_screen(self):
+        for i in range(9):
+            if i == 4:
+                continue
+            self.assertEqual(int(DISCRETE_ACTIONS[i, 0]), 2)  # Move_screen
+
+    def test_probe_actions_count(self):
+        self.assertEqual(len(PROBE_ACTIONS), 5)
+
+    def test_probe_actions_shape(self):
+        for action, name in PROBE_ACTIONS:
+            self.assertEqual(action.shape, (4,))
+            self.assertIsInstance(name, str)
+
+    def test_warmup_action_shape(self):
+        self.assertEqual(WARMUP_ACTION.shape, (4,))
+
+    def test_warmup_action_is_select_army(self):
+        self.assertEqual(int(WARMUP_ACTION[0]), 1)
+
+    def test_function_ids_table_is_complete(self):
+        # Indices used by DISCRETE_ACTIONS / PROBE_ACTIONS / WARMUP_ACTION must
+        # exist in the FUNCTION_IDS lookup so the client can resolve them.
+        used = set()
+        for row in DISCRETE_ACTIONS:
+            used.add(int(row[0]))
+        for action, _ in PROBE_ACTIONS:
+            used.add(int(action[0]))
+        used.add(int(WARMUP_ACTION[0]))
+        for fn_idx in used:
+            self.assertIn(fn_idx, FUNCTION_IDS, f"missing fn_idx={fn_idx}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sc2_client.py
+++ b/tests/test_sc2_client.py
@@ -1,0 +1,178 @@
+"""Tests for the SC2 client's PySC2 timestep flattening.
+
+We don't want a hard PySC2 dependency in CI, so these tests construct fake
+TimeStep-shaped objects (NamedTuples / dicts) and pass them through the
+client's flattening path.
+"""
+import unittest
+from collections import namedtuple
+
+import numpy as np
+
+from games.sc2.client import SC2Client
+from games.sc2.obs_spec import BASE_OBS_DIM, LADDER_OBS_DIM
+
+
+# Minimal stand-in for pysc2.lib.named_array.NamedNumpyArray indexed by name.
+class _NamedArr:
+    def __init__(self, mapping: dict[str, float]):
+        self._mapping = mapping
+
+    def __getitem__(self, key: str) -> float:
+        return self._mapping[key]
+
+    def get(self, key: str, default=None):
+        return self._mapping.get(key, default)
+
+
+# Stand-in for pysc2.env.environment.TimeStep.
+_TimeStep = namedtuple("TimeStep", ["observation", "reward", "step_type"])
+
+
+def _last_step_type():
+    """Sentinel object whose .last() check uses the wrapper's logic."""
+    return 2  # PySC2 uses StepType.LAST = 2
+
+
+class _FakeTimeStep:
+    def __init__(self, observation, reward=0.0, last=False):
+        self.observation = observation
+        self.reward = reward
+        self._last = last
+
+    def last(self) -> bool:
+        return self._last
+
+
+class TestSC2ClientMinigameFlatten(unittest.TestCase):
+
+    def setUp(self):
+        self.client = SC2Client(map_name="MoveToBeacon")
+
+    def test_minigame_flat_obs_shape(self):
+        observation = {
+            "player": _NamedArr({
+                "minerals": 50, "vespene": 0, "food_used": 1, "food_cap": 15,
+                "army_count": 0, "idle_worker_count": 0,
+                "warp_gate_count": 0, "larva_count": 0,
+            }),
+            "single_select": np.zeros((0, 7), dtype=np.int32),
+            "multi_select": np.zeros((0, 7), dtype=np.int32),
+            "feature_screen": np.zeros((17, 64, 64), dtype=np.int32),
+            "score_cumulative": np.array([0]),
+        }
+        ts = _FakeTimeStep(observation)
+        flat, info = self.client._timestep_to_obs_info(ts)
+        self.assertEqual(flat.shape, (BASE_OBS_DIM,))
+        self.assertEqual(flat.dtype, np.float32)
+
+    def test_score_delta_threading(self):
+        """score becomes prev_score on the second call."""
+        ob = {
+            "player": _NamedArr({
+                "minerals": 0, "vespene": 0, "food_used": 0, "food_cap": 0,
+                "army_count": 0, "idle_worker_count": 0,
+                "warp_gate_count": 0, "larva_count": 0,
+            }),
+            "feature_screen": np.zeros((17, 64, 64), dtype=np.int32),
+            "score_cumulative": np.array([7]),
+        }
+        ts = _FakeTimeStep(ob)
+        _, info = self.client._timestep_to_obs_info(ts)
+        self.assertEqual(info["score"], 7.0)
+        self.assertEqual(info["prev_score"], 0.0)
+
+        ob["score_cumulative"] = np.array([12])
+        _, info2 = self.client._timestep_to_obs_info(_FakeTimeStep(ob))
+        self.assertEqual(info2["score"], 12.0)
+        self.assertEqual(info2["prev_score"], 7.0)
+
+    def test_player_relative_centroid(self):
+        """A non-empty player_relative layer should yield centroid coords."""
+        screen = np.zeros((17, 64, 64), dtype=np.int32)
+        # Place a single friendly pixel at (10, 20) — channel 5 = player_relative.
+        screen[5, 20, 10] = 1  # row=20 → y, col=10 → x
+        ob = {
+            "player": _NamedArr({
+                "minerals": 0, "vespene": 0, "food_used": 0, "food_cap": 0,
+                "army_count": 0, "idle_worker_count": 0,
+                "warp_gate_count": 0, "larva_count": 0,
+            }),
+            "feature_screen": screen,
+            "score_cumulative": np.array([0]),
+        }
+        flat, _ = self.client._timestep_to_obs_info(_FakeTimeStep(ob))
+        # Indices 7=screen_self_count, 9=screen_self_cx, 10=screen_self_cy.
+        self.assertEqual(flat[7], 1.0)
+        self.assertAlmostEqual(flat[9], 10.0)
+        self.assertAlmostEqual(flat[10], 20.0)
+
+    def test_terminal_outcome_recorded(self):
+        ob = {
+            "player": _NamedArr({
+                "minerals": 0, "vespene": 0, "food_used": 0, "food_cap": 0,
+                "army_count": 0, "idle_worker_count": 0,
+                "warp_gate_count": 0, "larva_count": 0,
+            }),
+            "feature_screen": np.zeros((17, 64, 64), dtype=np.int32),
+            "score_cumulative": np.array([0]),
+        }
+        ts = _FakeTimeStep(ob, reward=1.0, last=True)
+        _, info = self.client._timestep_to_obs_info(ts)
+        self.assertEqual(info["player_outcome"], 1.0)
+        self.assertTrue(info["is_last"])
+
+
+class TestSC2ClientLadderFlatten(unittest.TestCase):
+
+    def setUp(self):
+        self.client = SC2Client(map_name="Simple64")
+
+    def test_ladder_flat_obs_shape(self):
+        ob = {
+            "player": _NamedArr({
+                "minerals": 50, "vespene": 0, "food_used": 12, "food_cap": 15,
+                "army_count": 1, "idle_worker_count": 2,
+                "warp_gate_count": 0, "larva_count": 3,
+            }),
+            "feature_screen": np.zeros((17, 64, 64), dtype=np.int32),
+            "feature_minimap": np.zeros((11, 64, 64), dtype=np.int32),
+            "score_cumulative": np.array([0]),
+            "game_loop": np.array([100]),
+        }
+        flat, _ = self.client._timestep_to_obs_info(_FakeTimeStep(ob))
+        self.assertEqual(flat.shape, (LADDER_OBS_DIM,))
+
+    def test_visibility_tracking(self):
+        """Explored fraction should be monotonically non-decreasing."""
+        mmap = np.zeros((11, 64, 64), dtype=np.int32)
+        # Channel 1 = visibility_map; mark a quadrant visible.
+        mmap[1, :32, :32] = 2
+        ob = {
+            "player": _NamedArr({
+                "minerals": 0, "vespene": 0, "food_used": 0, "food_cap": 0,
+                "army_count": 0, "idle_worker_count": 0,
+                "warp_gate_count": 0, "larva_count": 0,
+            }),
+            "feature_screen": np.zeros((17, 64, 64), dtype=np.int32),
+            "feature_minimap": mmap,
+            "score_cumulative": np.array([0]),
+            "game_loop": np.array([0]),
+        }
+        flat1, _ = self.client._timestep_to_obs_info(_FakeTimeStep(ob))
+        # Now zero visibility but explored mask should persist.
+        ob["feature_minimap"] = np.zeros((11, 64, 64), dtype=np.int32)
+        flat2, _ = self.client._timestep_to_obs_info(_FakeTimeStep(ob))
+
+        # Index 19 = minimap_visible_frac, 20 = minimap_explored_frac
+        # (offset by 13 from minigame dims).
+        self.assertGreater(flat1[18], 0.0)  # visible_frac > 0 first call
+        self.assertEqual(flat2[18], 0.0)    # visible_frac = 0 second call
+        # Explored remains > 0 in both calls.
+        self.assertGreater(flat1[19], 0.0)
+        self.assertGreater(flat2[19], 0.0)
+        self.assertGreaterEqual(flat2[19], flat1[19])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sc2_client.py
+++ b/tests/test_sc2_client.py
@@ -108,6 +108,8 @@ class TestSC2ClientMinigameFlatten(unittest.TestCase):
         self.assertAlmostEqual(flat[10], 20.0)
 
     def test_terminal_outcome_recorded(self):
+        """For minigames, player_outcome is always None (timestep.reward is
+        the per-step score delta, not a terminal win/loss signal)."""
         ob = {
             "player": _NamedArr({
                 "minerals": 0, "vespene": 0, "food_used": 0, "food_cap": 0,
@@ -119,7 +121,7 @@ class TestSC2ClientMinigameFlatten(unittest.TestCase):
         }
         ts = _FakeTimeStep(ob, reward=1.0, last=True)
         _, info = self.client._timestep_to_obs_info(ts)
-        self.assertEqual(info["player_outcome"], 1.0)
+        self.assertIsNone(info["player_outcome"])
         self.assertTrue(info["is_last"])
 
 
@@ -146,7 +148,7 @@ class TestSC2ClientLadderFlatten(unittest.TestCase):
     def test_visibility_tracking(self):
         """Explored fraction should be monotonically non-decreasing."""
         mmap = np.zeros((11, 64, 64), dtype=np.int32)
-        # Channel 1 = visibility_map; mark a quadrant visible.
+        # Channel 1 = visibility_map; mark a quadrant visible (value 2).
         mmap[1, :32, :32] = 2
         ob = {
             "player": _NamedArr({
@@ -164,7 +166,7 @@ class TestSC2ClientLadderFlatten(unittest.TestCase):
         ob["feature_minimap"] = np.zeros((11, 64, 64), dtype=np.int32)
         flat2, _ = self.client._timestep_to_obs_info(_FakeTimeStep(ob))
 
-        # Index 19 = minimap_visible_frac, 20 = minimap_explored_frac
+        # Index 18 = minimap_visible_frac, 19 = minimap_explored_frac
         # (offset by 13 from minigame dims).
         self.assertGreater(flat1[18], 0.0)  # visible_frac > 0 first call
         self.assertEqual(flat2[18], 0.0)    # visible_frac = 0 second call
@@ -172,6 +174,67 @@ class TestSC2ClientLadderFlatten(unittest.TestCase):
         self.assertGreater(flat1[19], 0.0)
         self.assertGreater(flat2[19], 0.0)
         self.assertGreaterEqual(flat2[19], flat1[19])
+
+    def test_visibility_fogged_not_counted_as_visible(self):
+        """visible_frac uses == 2; fogged tiles (value 1) must not be counted."""
+        mmap = np.zeros((11, 64, 64), dtype=np.int32)
+        # Mark top-left quadrant as fogged (1) and bottom-right as visible (2).
+        mmap[1, :32, :32] = 1   # fogged — explored but not currently visible
+        mmap[1, 32:, 32:] = 2   # fully visible
+        ob = {
+            "player": _NamedArr({
+                "minerals": 0, "vespene": 0, "food_used": 0, "food_cap": 0,
+                "army_count": 0, "idle_worker_count": 0,
+                "warp_gate_count": 0, "larva_count": 0,
+            }),
+            "feature_screen": np.zeros((17, 64, 64), dtype=np.int32),
+            "feature_minimap": mmap,
+            "score_cumulative": np.array([0]),
+            "game_loop": np.array([0]),
+        }
+        flat, _ = self.client._timestep_to_obs_info(_FakeTimeStep(ob))
+        # visible_frac should only count the 32×32 visible quadrant.
+        expected_visible = (32 * 32) / (64 * 64)
+        self.assertAlmostEqual(float(flat[18]), expected_visible, places=5)
+        # explored_frac counts both fogged (1) and visible (2).
+        expected_explored = (32 * 32 + 32 * 32) / (64 * 64)
+        self.assertAlmostEqual(float(flat[19]), expected_explored, places=5)
+
+    def test_ladder_terminal_outcome_set(self):
+        """For ladder maps, player_outcome is set from timestep.reward on last step."""
+        ob = {
+            "player": _NamedArr({
+                "minerals": 0, "vespene": 0, "food_used": 0, "food_cap": 0,
+                "army_count": 0, "idle_worker_count": 0,
+                "warp_gate_count": 0, "larva_count": 0,
+            }),
+            "feature_screen": np.zeros((17, 64, 64), dtype=np.int32),
+            "feature_minimap": np.zeros((11, 64, 64), dtype=np.int32),
+            "score_cumulative": np.array([0]),
+            "game_loop": np.array([0]),
+        }
+        # Simulate a win (reward=1) on the terminal step.
+        ts = _FakeTimeStep(ob, reward=1.0, last=True)
+        _, info = self.client._timestep_to_obs_info(ts)
+        self.assertEqual(info["player_outcome"], 1.0)
+        self.assertTrue(info["is_last"])
+
+    def test_ladder_non_terminal_outcome_is_none(self):
+        """player_outcome is None on non-terminal ladder steps."""
+        ob = {
+            "player": _NamedArr({
+                "minerals": 0, "vespene": 0, "food_used": 0, "food_cap": 0,
+                "army_count": 0, "idle_worker_count": 0,
+                "warp_gate_count": 0, "larva_count": 0,
+            }),
+            "feature_screen": np.zeros((17, 64, 64), dtype=np.int32),
+            "feature_minimap": np.zeros((11, 64, 64), dtype=np.int32),
+            "score_cumulative": np.array([0]),
+            "game_loop": np.array([0]),
+        }
+        ts = _FakeTimeStep(ob, reward=0.0, last=False)
+        _, info = self.client._timestep_to_obs_info(ts)
+        self.assertIsNone(info["player_outcome"])
 
 
 if __name__ == "__main__":

--- a/tests/test_sc2_env.py
+++ b/tests/test_sc2_env.py
@@ -1,0 +1,202 @@
+"""Tests for the SC2 environment wrapper.
+
+These tests validate the env's spaces, episode logic, and termination
+without requiring PySC2 to be installed (the client is mocked).
+"""
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from games.sc2.env import SC2Env
+from games.sc2.obs_spec import BASE_OBS_DIM, LADDER_OBS_DIM
+from games.sc2.reward import SC2RewardConfig
+
+
+class TestSC2EnvSpaces(unittest.TestCase):
+
+    def setUp(self):
+        with patch("games.sc2.env.SC2Client"):
+            self.env = SC2Env(map_name="MoveToBeacon")
+
+    def test_minigame_observation_space(self):
+        self.assertEqual(self.env.observation_space.shape, (BASE_OBS_DIM,))
+
+    def test_action_space_shape(self):
+        self.assertEqual(self.env.action_space.shape, (4,))
+
+    def test_action_space_bounds(self):
+        # fn_idx range, then x/y/queue in [0,1].
+        self.assertEqual(float(self.env.action_space.low[0]), 0.0)
+        np.testing.assert_array_equal(
+            self.env.action_space.high[1:], [1.0, 1.0, 1.0]
+        )
+
+
+class TestSC2EnvLadderSpaces(unittest.TestCase):
+
+    def test_ladder_obs_space(self):
+        with patch("games.sc2.env.SC2Client"):
+            env = SC2Env(map_name="Simple64")
+        self.assertEqual(env.observation_space.shape, (LADDER_OBS_DIM,))
+
+
+class TestSC2EnvEpisodeTime(unittest.TestCase):
+
+    def setUp(self):
+        with patch("games.sc2.env.SC2Client"):
+            self.env = SC2Env(map_name="MoveToBeacon", max_episode_time_s=60.0)
+
+    def test_get_episode_time_limit(self):
+        self.assertEqual(self.env.get_episode_time_limit(), 60.0)
+
+    def test_set_episode_time_limit(self):
+        self.env.set_episode_time_limit(30.0)
+        self.assertEqual(self.env.get_episode_time_limit(), 30.0)
+
+
+class TestSC2EnvStepLogic(unittest.TestCase):
+    """Test step/reset with mocked client."""
+
+    def setUp(self):
+        patcher = patch("games.sc2.env.SC2Client")
+        self.mock_client_cls = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        self.mock_client = self.mock_client_cls.return_value
+        self.mock_client.reset.return_value = (
+            np.zeros(BASE_OBS_DIM, dtype=np.float32),
+            {"score": 0.0, "minerals": 50.0, "vespene": 0.0,
+             "food_used": 1.0, "food_cap": 15.0, "army_count": 0.0},
+        )
+        self.mock_client.step.return_value = (
+            np.zeros(BASE_OBS_DIM, dtype=np.float32),
+            0.0,
+            False,
+            {"score": 1.0, "minerals": 50.0, "vespene": 0.0,
+             "food_used": 1.0, "food_cap": 15.0, "army_count": 0.0},
+        )
+        self.env = SC2Env(map_name="MoveToBeacon")
+
+    def test_reset_returns_obs_and_info(self):
+        obs, info = self.env.reset()
+        self.assertEqual(obs.shape, (BASE_OBS_DIM,))
+        self.assertIsInstance(info, dict)
+        self.assertIn("score", info)
+
+    def test_step_returns_five_tuple(self):
+        self.env.reset()
+        action = np.array([1, 0.5, 0.5, 0], dtype=np.float32)
+        result = self.env.step(action)
+        self.assertEqual(len(result), 5)
+        obs, reward, terminated, truncated, info = result
+        self.assertEqual(obs.shape, (BASE_OBS_DIM,))
+        self.assertIsInstance(reward, float)
+        self.assertIsInstance(terminated, bool)
+        self.assertIsInstance(truncated, bool)
+        self.assertIsInstance(info, dict)
+
+    def test_score_delta_reward(self):
+        """With default reward config (score_weight=1.0), a +1 score delta
+        should produce a reward close to +1 (minus tiny step_penalty)."""
+        self.env.reset()
+        _, reward, _, _, _ = self.env.step(np.zeros(4, dtype=np.float32))
+        # score went 0 -> 1, default step_penalty -0.001 → reward ≈ 0.999.
+        self.assertAlmostEqual(reward, 1.0 - 0.001, places=5)
+
+    def test_done_terminates(self):
+        """When the client signals done, terminated should be True."""
+        self.mock_client.step.return_value = (
+            np.zeros(BASE_OBS_DIM, dtype=np.float32),
+            1.0,
+            True,
+            {"score": 5.0, "minerals": 0.0, "vespene": 0.0,
+             "food_used": 0.0, "food_cap": 0.0, "army_count": 0.0,
+             "player_outcome": 1.0, "is_last": True},
+        )
+        self.env.reset()
+        _, _, terminated, truncated, info = self.env.step(np.zeros(4, dtype=np.float32))
+        self.assertTrue(terminated)
+        self.assertFalse(truncated)
+        self.assertEqual(info["termination_reason"], "win")
+
+    def test_loss_outcome(self):
+        self.mock_client.step.return_value = (
+            np.zeros(BASE_OBS_DIM, dtype=np.float32),
+            -1.0,
+            True,
+            {"score": 0.0, "minerals": 0.0, "vespene": 0.0,
+             "food_used": 0.0, "food_cap": 0.0, "army_count": 0.0,
+             "player_outcome": -1.0, "is_last": True},
+        )
+        self.env.reset()
+        _, _, terminated, _, info = self.env.step(np.zeros(4, dtype=np.float32))
+        self.assertTrue(terminated)
+        self.assertEqual(info["termination_reason"], "loss")
+
+    def test_close_calls_client_close(self):
+        self.env.close()
+        self.mock_client.close.assert_called_once()
+
+    def test_info_contains_required_keys(self):
+        """Reward calculator depends on these keys from info."""
+        self.env.reset()
+        _, _, _, _, info = self.env.step(np.zeros(4, dtype=np.float32))
+        for key in ("score", "prev_score", "minerals", "prev_minerals",
+                     "vespene", "prev_vespene", "elapsed_s",
+                     "termination_reason"):
+            self.assertIn(key, info, f"missing key {key}")
+
+    def test_prev_score_threaded_through(self):
+        """prev_score in step N+1 should equal score from step N."""
+        # Step 1 returns score=10
+        self.mock_client.step.return_value = (
+            np.zeros(BASE_OBS_DIM, dtype=np.float32),
+            0.0,
+            False,
+            {"score": 10.0, "minerals": 0.0, "vespene": 0.0,
+             "food_used": 1.0, "food_cap": 15.0, "army_count": 0.0},
+        )
+        self.env.reset()
+        _, _, _, _, info1 = self.env.step(np.zeros(4, dtype=np.float32))
+        self.assertEqual(info1["prev_score"], 0.0)
+        self.assertEqual(info1["score"], 10.0)
+        # Step 2 returns score=15.
+        self.mock_client.step.return_value = (
+            np.zeros(BASE_OBS_DIM, dtype=np.float32),
+            0.0,
+            False,
+            {"score": 15.0, "minerals": 0.0, "vespene": 0.0,
+             "food_used": 1.0, "food_cap": 15.0, "army_count": 0.0},
+        )
+        _, _, _, _, info2 = self.env.step(np.zeros(4, dtype=np.float32))
+        self.assertEqual(info2["prev_score"], 10.0)
+        self.assertEqual(info2["score"], 15.0)
+
+
+class TestSC2EnvCustomReward(unittest.TestCase):
+
+    def test_custom_reward_config(self):
+        with patch("games.sc2.env.SC2Client") as mock_cls:
+            mock_cls.return_value.reset.return_value = (
+                np.zeros(BASE_OBS_DIM, dtype=np.float32),
+                {"score": 0.0, "minerals": 0.0, "vespene": 0.0,
+                 "food_used": 0.0, "food_cap": 0.0, "army_count": 0.0},
+            )
+            mock_cls.return_value.step.return_value = (
+                np.zeros(BASE_OBS_DIM, dtype=np.float32),
+                0.0,
+                False,
+                {"score": 5.0, "minerals": 0.0, "vespene": 0.0,
+                 "food_used": 0.0, "food_cap": 0.0, "army_count": 0.0},
+            )
+            cfg = SC2RewardConfig(score_weight=10.0, step_penalty=0.0)
+            env = SC2Env(map_name="MoveToBeacon", reward_config=cfg)
+            env.reset()
+            _, reward, _, _, _ = env.step(np.zeros(4, dtype=np.float32))
+            # 5 * 10 = 50.
+            self.assertAlmostEqual(reward, 50.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sc2_env.py
+++ b/tests/test_sc2_env.py
@@ -98,11 +98,12 @@ class TestSC2EnvStepLogic(unittest.TestCase):
 
     def test_score_delta_reward(self):
         """With default reward config (score_weight=1.0), a +1 score delta
-        should produce a reward close to +1 (minus tiny step_penalty)."""
+        should produce a reward close to +1 minus step_penalty scaled by
+        step_mul (default 8)."""
         self.env.reset()
         _, reward, _, _, _ = self.env.step(np.zeros(4, dtype=np.float32))
-        # score went 0 -> 1, default step_penalty -0.001 → reward ≈ 0.999.
-        self.assertAlmostEqual(reward, 1.0 - 0.001, places=5)
+        # score went 0 -> 1, default step_penalty -0.001 × 8 ticks → reward ≈ 0.992.
+        self.assertAlmostEqual(reward, 1.0 - 0.001 * 8, places=5)
 
     def test_done_terminates(self):
         """When the client signals done, terminated should be True."""

--- a/tests/test_sc2_obs_spec.py
+++ b/tests/test_sc2_obs_spec.py
@@ -1,0 +1,50 @@
+"""Tests for the SC2 observation spec."""
+import unittest
+
+from games.sc2.obs_spec import (
+    BASE_OBS_DIM,
+    LADDER_OBS_DIM,
+    MINIGAME_NAMES,
+    OBS_NAMES,
+    SC2_LADDER_OBS_SPEC,
+    SC2_MINIGAME_OBS_SPEC,
+    SC2_OBS_SPEC,
+    get_spec,
+)
+
+
+class TestSC2ObsSpec(unittest.TestCase):
+
+    def test_minigame_spec_dim(self):
+        self.assertEqual(BASE_OBS_DIM, 13)
+        self.assertEqual(SC2_MINIGAME_OBS_SPEC.dim, 13)
+
+    def test_ladder_spec_dim(self):
+        self.assertEqual(LADDER_OBS_DIM, 21)
+        self.assertEqual(SC2_LADDER_OBS_SPEC.dim, 21)
+
+    def test_ladder_extends_minigame(self):
+        """Ladder spec must contain all minigame names as a prefix."""
+        for i, name in enumerate(SC2_MINIGAME_OBS_SPEC.names):
+            self.assertEqual(SC2_LADDER_OBS_SPEC.names[i], name)
+
+    def test_default_spec_is_minigame(self):
+        self.assertIs(SC2_OBS_SPEC, SC2_MINIGAME_OBS_SPEC)
+
+    def test_get_spec_for_minigame(self):
+        for name in MINIGAME_NAMES:
+            self.assertIs(get_spec(name), SC2_MINIGAME_OBS_SPEC)
+
+    def test_get_spec_for_ladder_map(self):
+        self.assertIs(get_spec("Simple64"), SC2_LADDER_OBS_SPEC)
+        self.assertIs(get_spec("AbyssalReef"), SC2_LADDER_OBS_SPEC)
+
+    def test_minigame_count(self):
+        self.assertEqual(len(MINIGAME_NAMES), 7)
+
+    def test_obs_names_match_dims(self):
+        self.assertEqual(len(OBS_NAMES), BASE_OBS_DIM)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sc2_reward.py
+++ b/tests/test_sc2_reward.py
@@ -1,0 +1,179 @@
+"""Tests for the SC2 reward calculator."""
+import os
+import tempfile
+import unittest
+
+from games.sc2.reward import SC2RewardCalculator, SC2RewardConfig
+
+
+def _write_yaml(content: str) -> str:
+    f = tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False)
+    f.write(content)
+    f.close()
+    return f.name
+
+
+class TestSC2RewardConfig(unittest.TestCase):
+
+    def test_defaults(self):
+        cfg = SC2RewardConfig()
+        self.assertEqual(cfg.score_weight, 1.0)
+        self.assertEqual(cfg.win_bonus, 100.0)
+        self.assertEqual(cfg.loss_penalty, -100.0)
+        self.assertLess(cfg.step_penalty, 0.0)
+
+    def test_from_yaml(self):
+        path = _write_yaml("score_weight: 0.5\nwin_bonus: 50.0\n")
+        try:
+            cfg = SC2RewardConfig.from_yaml(path)
+            self.assertEqual(cfg.score_weight, 0.5)
+            self.assertEqual(cfg.win_bonus, 50.0)
+            # Untouched fields keep defaults.
+            self.assertEqual(cfg.loss_penalty, -100.0)
+        finally:
+            os.unlink(path)
+
+    def test_from_yaml_unknown_key_raises(self):
+        path = _write_yaml("unknown_key: 1.0\n")
+        try:
+            with self.assertRaises(ValueError) as ctx:
+                SC2RewardConfig.from_yaml(path)
+            self.assertIn("unknown_key", str(ctx.exception))
+        finally:
+            os.unlink(path)
+
+    def test_from_yaml_loads_bundled_config(self):
+        cfg_path = os.path.join(
+            os.path.dirname(__file__),
+            "..", "games", "sc2", "config", "reward_config.yaml",
+        )
+        cfg = SC2RewardConfig.from_yaml(cfg_path)
+        self.assertIsInstance(cfg.score_weight, float)
+
+
+class TestSC2RewardCalculator(unittest.TestCase):
+
+    def _make_calc(self, **kwargs) -> SC2RewardCalculator:
+        return SC2RewardCalculator(SC2RewardConfig(**kwargs))
+
+    def test_score_delta_reward(self):
+        calc = self._make_calc(
+            score_weight=2.0, step_penalty=0.0,
+            win_bonus=0.0, loss_penalty=0.0, economy_weight=0.0,
+        )
+        r = calc.compute(
+            prev_state=None, curr_state=None, finished=False,
+            elapsed_s=1.0,
+            info={"prev_score": 5.0, "score": 8.0},
+        )
+        self.assertAlmostEqual(r, 6.0)  # (8 - 5) * 2.0
+
+    def test_step_penalty_only(self):
+        calc = self._make_calc(
+            score_weight=0.0, step_penalty=-0.5, economy_weight=0.0,
+        )
+        r = calc.compute(
+            prev_state=None, curr_state=None, finished=False,
+            elapsed_s=1.0,
+            info={"prev_score": 0.0, "score": 0.0},
+        )
+        self.assertAlmostEqual(r, -0.5)
+
+    def test_step_penalty_scales_with_n_ticks(self):
+        calc = self._make_calc(
+            score_weight=0.0, step_penalty=-0.5, economy_weight=0.0,
+        )
+        r = calc.compute(
+            prev_state=None, curr_state=None, finished=False,
+            elapsed_s=1.0,
+            info={"prev_score": 0.0, "score": 0.0},
+            n_ticks=4,
+        )
+        self.assertAlmostEqual(r, -2.0)
+
+    def test_win_bonus(self):
+        calc = self._make_calc(
+            score_weight=0.0, step_penalty=0.0,
+            win_bonus=200.0, loss_penalty=-200.0, economy_weight=0.0,
+        )
+        r = calc.compute(
+            prev_state=None, curr_state=None, finished=True,
+            elapsed_s=60.0,
+            info={"prev_score": 0.0, "score": 0.0, "player_outcome": 1.0},
+        )
+        self.assertAlmostEqual(r, 200.0)
+
+    def test_loss_penalty(self):
+        calc = self._make_calc(
+            score_weight=0.0, step_penalty=0.0,
+            win_bonus=200.0, loss_penalty=-200.0, economy_weight=0.0,
+        )
+        r = calc.compute(
+            prev_state=None, curr_state=None, finished=True,
+            elapsed_s=60.0,
+            info={"prev_score": 0.0, "score": 0.0, "player_outcome": -1.0},
+        )
+        self.assertAlmostEqual(r, -200.0)
+
+    def test_no_outcome_no_bonus(self):
+        """Game ends without explicit outcome (e.g. minigame timeout) → no win/loss."""
+        calc = self._make_calc(
+            score_weight=0.0, step_penalty=0.0,
+            win_bonus=200.0, loss_penalty=-200.0, economy_weight=0.0,
+        )
+        r = calc.compute(
+            prev_state=None, curr_state=None, finished=True,
+            elapsed_s=60.0,
+            info={"prev_score": 0.0, "score": 0.0, "player_outcome": None},
+        )
+        self.assertAlmostEqual(r, 0.0)
+
+    def test_economy_weight(self):
+        calc = self._make_calc(
+            score_weight=0.0, step_penalty=0.0, economy_weight=0.01,
+        )
+        r = calc.compute(
+            prev_state=None, curr_state=None, finished=False,
+            elapsed_s=1.0,
+            info={
+                "prev_score": 0.0, "score": 0.0,
+                "prev_minerals": 100.0, "minerals": 200.0,
+                "prev_vespene": 0.0, "vespene": 50.0,
+            },
+        )
+        # delta = (200-100) + (50-0) = 150; reward = 0.01 * 150 = 1.5
+        self.assertAlmostEqual(r, 1.5)
+
+    def test_idle_penalty_when_idle(self):
+        calc = self._make_calc(
+            score_weight=0.0, step_penalty=0.0,
+            idle_penalty=-1.0, economy_weight=0.0,
+        )
+        r = calc.compute(
+            prev_state=None, curr_state=None, finished=False,
+            elapsed_s=1.0,
+            info={
+                "prev_score": 0.0, "score": 0.0,
+                "army_count": 0, "food_used": 5, "food_cap": 10,
+            },
+        )
+        self.assertAlmostEqual(r, -1.0)
+
+    def test_idle_penalty_not_applied_when_busy(self):
+        calc = self._make_calc(
+            score_weight=0.0, step_penalty=0.0,
+            idle_penalty=-1.0, economy_weight=0.0,
+        )
+        r = calc.compute(
+            prev_state=None, curr_state=None, finished=False,
+            elapsed_s=1.0,
+            info={
+                "prev_score": 0.0, "score": 0.0,
+                "army_count": 5, "food_used": 5, "food_cap": 10,
+            },
+        )
+        self.assertAlmostEqual(r, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds games/sc2/ as the third game alongside games/tmnf/ and games/torcs/.
Mirrors the TORCS package layout: SC2Env(BaseGameEnv), SC2RewardCalculator,
ObsSpec, discrete-action grid, and an SC2Client that lazily imports pysc2 so
unit tests run without PySC2 installed.

Scope (issue #90 MVP):
- 7 standard PySC2 minigames via map_name in training_params.yaml
- 1v1 vs builtin-bot env shell (Phase B); no learner is claimed
- Discrete 9-cell action grid (select_army + 8 directional Move_screen)
- 13-dim minigame obs spec, 21-dim ladder spec for fog-of-war work in #91

Wires SC2 into main.py via --game sc2 and adds a [sc2] poetry group.
52 new tests covering obs_spec, actions, reward, env, and client flattening
all pass; existing 304 tests unaffected.

Closes #90.

https://claude.ai/code/session_01JB98wQdveJjLx7y81qyHW4