### PR TITLE
Add SC2 CNN policy with isotropic evolutionary strategy

### DIFF
--- a/games/sc2/adapter.py
+++ b/games/sc2/adapter.py
@@ -58,6 +58,9 @@ class SC2Adapter:
         map_name = self._map_name(training_params, track_override)
         obs_spec = get_spec(map_name)
 
+        screen_layers   = training_params.get("screen_layers") or []
+        minimap_layers  = training_params.get("minimap_layers") or []
+
         def _make_env():
             from games.sc2.env import make_env
             return make_env(
@@ -69,6 +72,8 @@ class SC2Adapter:
                 minimap_size=training_params.get("minimap_size", 64),
                 agent_race=training_params.get("agent_race", "random"),
                 bot_difficulty=training_params.get("bot_difficulty", "very_easy"),
+                screen_layers=screen_layers,
+                minimap_layers=minimap_layers,
             )
 
         return GameSpec(
@@ -249,6 +254,41 @@ class SC2Adapter:
                         )
             return policy
 
+        screen_layers_extras  = training_params.get("screen_layers") or []
+        minimap_layers_extras = training_params.get("minimap_layers") or []
+
+        def _make_sc2_cnn():
+            from games.sc2.cnn_policy import SC2CNNEvolutionPolicy
+            n_channels = len(screen_layers_extras) + len(minimap_layers_extras)
+            if n_channels == 0:
+                raise ValueError(
+                    "sc2_cnn requires at least one spatial layer.  "
+                    "Set screen_layers in training_params.yaml."
+                )
+            pop_size = policy_params.get("population_size", 20)
+            sigma    = policy_params.get("initial_sigma", 0.01)
+            policy   = SC2CNNEvolutionPolicy(
+                n_channels      = n_channels,
+                obs_spec        = obs_spec,
+                population_size = pop_size,
+                initial_sigma   = sigma,
+                eval_episodes   = policy_params.get("eval_episodes", 1),
+            )
+            champion_path = weights_file.replace(".yaml", ".npz")
+            if os.path.exists(champion_path) and not re_initialize:
+                try:
+                    policy.load_champion(champion_path)
+                    if os.path.exists(trainer_state_file):
+                        policy.load_trainer_state(trainer_state_file)
+                        logger.info("[SC2CNNEvolutionPolicy] loaded trainer state from %s",
+                                    trainer_state_file)
+                except (ValueError, KeyError) as exc:
+                    logger.warning(
+                        "[SC2CNNEvolutionPolicy] could not load saved state — %s; "
+                        "starting from random.", exc,
+                    )
+            return policy
+
         return PolicyExtras(
             factories={
                 "sc2_genetic": _make_sc2_genetic,
@@ -256,6 +296,7 @@ class SC2Adapter:
                 "cmaes": _make_cmaes,
                 "reinforce": _make_reinforce,
                 "lstm": _make_lstm,
+                "sc2_cnn": _make_sc2_cnn,
             },
             loop_dispatch={
                 "sc2_genetic": "genetic",
@@ -263,6 +304,7 @@ class SC2Adapter:
                 "cmaes": "cmaes",
                 "reinforce": "q_learning",
                 "lstm": "cmaes",
+                "sc2_cnn": "cmaes",
             },
         )
 

--- a/games/sc2/adapter.py
+++ b/games/sc2/adapter.py
@@ -58,8 +58,17 @@ class SC2Adapter:
         map_name = self._map_name(training_params, track_override)
         obs_spec = get_spec(map_name)
 
-        screen_layers   = training_params.get("screen_layers") or []
-        minimap_layers  = training_params.get("minimap_layers") or []
+        policy_type = training_params.get("policy_type", "sc2_genetic")
+        # Spatial obs (dict observation space) is only supported by sc2_cnn.
+        # All other SC2 policies operate on flat np.ndarray observations; if
+        # the user accidentally left non-empty screen_layers in their config
+        # we silently ignore them to avoid crashing those policies.
+        if policy_type == "sc2_cnn":
+            screen_layers  = training_params.get("screen_layers") or []
+            minimap_layers = training_params.get("minimap_layers") or []
+        else:
+            screen_layers  = []
+            minimap_layers = []
 
         def _make_env():
             from games.sc2.env import make_env

--- a/games/sc2/client.py
+++ b/games/sc2/client.py
@@ -25,6 +25,29 @@ from games.sc2.obs_spec import (
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Spatial feature layer normalisation scales
+# ---------------------------------------------------------------------------
+# Values taken from PySC2 feature layer documentation.  Unknown layers default
+# to 1.0 (no normalisation), so 0–max values map to ~[0, 1].
+_LAYER_SCALE: dict[str, float] = {
+    "player_relative":    4.0,
+    "selected":           1.0,
+    "unit_type":       1917.0,
+    "height_map":       255.0,
+    "unit_hit_points":  255.0,
+    "unit_shields":     255.0,
+    "unit_density":      16.0,
+    "unit_density_aa":  255.0,
+    "effects":           16.0,
+    "visibility_map":     2.0,
+    "unit_energy":      255.0,
+    "creep":              1.0,
+    "power":              1.0,
+    "pathable":           1.0,
+    "buildable":          1.0,
+}
+
 
 class SC2Client:
     """Manages a ``pysc2.env.sc2_env.SC2Env`` session.
@@ -56,6 +79,8 @@ class SC2Client:
         agent_race: str = "random",
         bot_difficulty: str = "very_easy",
         visualize: bool = False,
+        screen_layers: list[str] | None = None,
+        minimap_layers: list[str] | None = None,
     ) -> None:
         self._map_name = map_name
         self._step_mul = step_mul
@@ -64,6 +89,8 @@ class SC2Client:
         self._agent_race = agent_race
         self._bot_difficulty = bot_difficulty
         self._visualize = visualize
+        self._screen_layers: list[str] = list(screen_layers or [])
+        self._minimap_layers: list[str] = list(minimap_layers or [])
         self._sc2_env: Any = None
         self._is_ladder = self._detect_ladder(map_name)
         self._spec = (
@@ -321,6 +348,33 @@ class SC2Client:
             "player_outcome": player_outcome,
             "is_last": bool(timestep.last()),
         }
+
+        # Spatial obs: stack selected screen + minimap layers into (C, H, W).
+        if self._screen_layers or self._minimap_layers:
+            channels: list[np.ndarray] = []
+            for name in self._screen_layers:
+                layer = self._extract_named_layer(feat_screen, name)
+                scale = _LAYER_SCALE.get(name, 1.0)
+                if layer is not None:
+                    channels.append((layer / scale).astype(np.float32))
+                else:
+                    channels.append(
+                        np.zeros((self._screen_size, self._screen_size), dtype=np.float32)
+                    )
+            if self._minimap_layers:
+                feat_minimap = self._safe_array(ob, "feature_minimap")
+                for name in self._minimap_layers:
+                    layer = self._extract_named_layer(feat_minimap, name)
+                    scale = _LAYER_SCALE.get(name, 1.0)
+                    if layer is not None:
+                        channels.append((layer / scale).astype(np.float32))
+                    else:
+                        channels.append(
+                            np.zeros((self._minimap_size, self._minimap_size), dtype=np.float32)
+                        )
+            if channels:
+                info["spatial_obs"] = np.stack(channels, axis=0)
+
         return flat, info
 
     # ------------------------------------------------------------------
@@ -399,6 +453,16 @@ class SC2Client:
         if feat.ndim == 3 and feat.shape[0] > 1:
             return np.asarray(feat[1])
         return None
+
+    @staticmethod
+    def _extract_named_layer(feat: np.ndarray | None, name: str) -> np.ndarray | None:
+        """Extract a named feature layer from a PySC2 NamedNumpyArray."""
+        if feat is None:
+            return None
+        try:
+            return np.asarray(feat[name], dtype=np.float32)
+        except (KeyError, IndexError, TypeError, ValueError):
+            return None
 
     @staticmethod
     def _centroid(mask: np.ndarray) -> tuple[float, float]:

--- a/games/sc2/client.py
+++ b/games/sc2/client.py
@@ -367,10 +367,13 @@ class SC2Client:
                     layer = self._extract_named_layer(feat_minimap, name)
                     scale = _LAYER_SCALE.get(name, 1.0)
                     if layer is not None:
-                        channels.append((layer / scale).astype(np.float32))
+                        layer = (layer / scale).astype(np.float32)
+                        if layer.shape != (self._screen_size, self._screen_size):
+                            layer = self._resize_layer(layer, self._screen_size)
+                        channels.append(layer)
                     else:
                         channels.append(
-                            np.zeros((self._minimap_size, self._minimap_size), dtype=np.float32)
+                            np.zeros((self._screen_size, self._screen_size), dtype=np.float32)
                         )
             if channels:
                 info["spatial_obs"] = np.stack(channels, axis=0)
@@ -463,6 +466,32 @@ class SC2Client:
             return np.asarray(feat[name], dtype=np.float32)
         except (KeyError, IndexError, TypeError, ValueError):
             return None
+
+    @staticmethod
+    def _resize_layer(layer: np.ndarray, target_size: int) -> np.ndarray:
+        """Bilinear resize a 2-D feature layer to (target_size, target_size).
+
+        Used to bring minimap layers to the same resolution as screen layers
+        when ``minimap_size != screen_size``.
+        """
+        h, w = layer.shape
+        if h == target_size and w == target_size:
+            return layer
+        row_idx = np.linspace(0, h - 1, target_size)
+        col_idx = np.linspace(0, w - 1, target_size)
+        r0 = np.floor(row_idx).astype(int).clip(0, h - 2)
+        r1 = (r0 + 1).clip(0, h - 1)
+        c0 = np.floor(col_idx).astype(int).clip(0, w - 2)
+        c1 = (c0 + 1).clip(0, w - 1)
+        dr = (row_idx - r0).astype(np.float32)
+        dc = (col_idx - c0).astype(np.float32)
+        out = (
+            layer[np.ix_(r0, c0)] * np.outer(1 - dr, 1 - dc)
+            + layer[np.ix_(r0, c1)] * np.outer(1 - dr, dc)
+            + layer[np.ix_(r1, c0)] * np.outer(dr, 1 - dc)
+            + layer[np.ix_(r1, c1)] * np.outer(dr, dc)
+        )
+        return out.astype(np.float32)
 
     @staticmethod
     def _centroid(mask: np.ndarray) -> tuple[float, float]:

--- a/games/sc2/cnn_policy.py
+++ b/games/sc2/cnn_policy.py
@@ -1,0 +1,514 @@
+"""SC2 CNN policy evolved by isotropic evolutionary strategy.
+
+Architecture (per the issue spec)::
+
+    spatial (C, 64, 64)
+        │
+    Conv2d(C → 32, 3×3, relu)
+    Conv2d(32 → 64, 3×3, relu)
+    AdaptiveAvgPool2d(4×4)
+    Flatten → (1024,)
+        │
+    Concat with flat obs (obs_dim,)
+        │
+    FC(1024 + obs_dim → 256, relu)
+        │
+      ┌───┴────┐
+    fn_head   spatial_head
+      (6,)       (9,)
+
+Weights are evolved by the same isotropic ES used by
+:class:`games.sc2.policies.LSTMEvolutionPolicy` (sample_population /
+update_distribution interface, 1/5 success-rule sigma adaptation).
+No backprop — purely evolutionary.
+
+Usage with ``policy_type: sc2_cnn`` in training_params.yaml.  Requires
+``screen_layers`` (non-empty) so that ``SC2Env`` returns dict observations.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import numpy as np
+
+from framework.obs_spec import ObsSpec
+from framework.policies import BasePolicy
+from games.sc2.actions import DISCRETE_ACTIONS, FUNCTION_IDS
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_N_FUNCS           = len(FUNCTION_IDS)   # 6
+_N_SPATIAL_CELLS   = len(DISCRETE_ACTIONS)  # 9
+
+# Pre-build (x, y) coordinates for each grid cell from DISCRETE_ACTIONS.
+_GRID_XY: list[tuple[float, float]] = [
+    (float(DISCRETE_ACTIONS[i, 1]), float(DISCRETE_ACTIONS[i, 2]))
+    for i in range(_N_SPATIAL_CELLS)
+]
+
+
+# ---------------------------------------------------------------------------
+# Pure-numpy conv2d + adaptive avg pool helpers
+# ---------------------------------------------------------------------------
+
+def _conv2d_valid_relu(
+    x: np.ndarray,
+    W: np.ndarray,
+    b: np.ndarray,
+) -> np.ndarray:
+    """Valid 2-D convolution followed by ReLU — pure numpy.
+
+    Parameters
+    ----------
+    x : (C_in, H, W) float32
+    W : (C_out, C_in, k, k) float32
+    b : (C_out,) float32
+
+    Returns
+    -------
+    (C_out, H-k+1, W-k+1) float32
+    """
+    x = x.astype(np.float32)
+    C_in, H, W_in = x.shape
+    C_out, _, k, _ = W.shape
+    H_out = H - k + 1
+    W_out = W_in - k + 1
+    # im2col via stride tricks — avoids Python loops over spatial positions.
+    xc = np.lib.stride_tricks.as_strided(
+        x,
+        shape=(C_in, k, k, H_out, W_out),
+        strides=(x.strides[0], x.strides[1], x.strides[2],
+                 x.strides[1], x.strides[2]),
+    ).reshape(C_in * k * k, H_out * W_out)
+    out = (W.reshape(C_out, -1) @ xc + b[:, None]).reshape(C_out, H_out, W_out)
+    np.maximum(out, 0.0, out=out)  # in-place ReLU
+    return out
+
+
+def _adaptive_avg_pool(x: np.ndarray, out_h: int, out_w: int) -> np.ndarray:
+    """Adaptive average pooling from (C, H, W) to (C, out_h, out_w)."""
+    C, H, W = x.shape
+    result = np.empty((C, out_h, out_w), dtype=np.float32)
+    for i in range(out_h):
+        h0 = int(i * H / out_h)
+        h1 = int((i + 1) * H / out_h)
+        for j in range(out_w):
+            w0 = int(j * W / out_w)
+            w1 = int((j + 1) * W / out_w)
+            result[:, i, j] = x[:, h0:h1, w0:w1].mean(axis=(1, 2))
+    return result
+
+
+# ---------------------------------------------------------------------------
+# SC2CNNModel — the individual network evaluated each episode
+# ---------------------------------------------------------------------------
+
+class SC2CNNModel:
+    """CNN model that maps dict obs → SC2 action.
+
+    Callable as a policy individual during ES evaluation.  Holds all network
+    weights in plain numpy arrays so ``to_flat()`` / ``with_flat()`` give a
+    flat parameter vector for evolutionary perturbation.
+
+    Parameters
+    ----------
+    n_channels :
+        Number of spatial input channels (len(screen_layers) +
+        len(minimap_layers)).
+    obs_spec :
+        Flat observation spec — used for normalisation.
+    seed :
+        RNG seed for weight initialisation.
+    """
+
+    # Architecture hyperparams (fixed; matching the issue spec).
+    _CONV1_OUT = 32
+    _CONV2_OUT = 64
+    _POOL_H    = 4
+    _POOL_W    = 4
+    _KERNEL    = 3
+    _FC_DIM    = 256
+
+    def __init__(
+        self,
+        n_channels: int,
+        obs_spec: ObsSpec,
+        seed: int | None = None,
+    ) -> None:
+        self._n_channels = n_channels
+        self._obs_spec   = obs_spec
+        self._obs_dim    = obs_spec.dim
+        self._scales     = obs_spec.scales
+
+        self._pool_flat = self._CONV2_OUT * self._POOL_H * self._POOL_W  # 1024
+        fc_in           = self._pool_flat + self._obs_dim
+
+        rng = np.random.default_rng(seed)
+
+        def _he(shape: tuple) -> np.ndarray:
+            fan_in = int(np.prod(shape[1:]))
+            return rng.standard_normal(shape).astype(np.float32) * np.sqrt(2.0 / fan_in)
+
+        C = n_channels
+        k = self._KERNEL
+        self.W1 = _he((self._CONV1_OUT, C, k, k))
+        self.b1 = np.zeros(self._CONV1_OUT, dtype=np.float32)
+        self.W2 = _he((self._CONV2_OUT, self._CONV1_OUT, k, k))
+        self.b2 = np.zeros(self._CONV2_OUT, dtype=np.float32)
+        self.W3 = _he((self._FC_DIM, fc_in))
+        self.b3 = np.zeros(self._FC_DIM, dtype=np.float32)
+        self.W_fn = _he((_N_FUNCS, self._FC_DIM))
+        self.b_fn = np.zeros(_N_FUNCS, dtype=np.float32)
+        self.W_sp = _he((_N_SPATIAL_CELLS, self._FC_DIM))
+        self.b_sp = np.zeros(_N_SPATIAL_CELLS, dtype=np.float32)
+
+    @property
+    def flat_dim(self) -> int:
+        C = self._n_channels
+        k = self._KERNEL
+        fc_in = self._pool_flat + self._obs_dim
+        return (
+            self._CONV1_OUT * C * k * k + self._CONV1_OUT
+            + self._CONV2_OUT * self._CONV1_OUT * k * k + self._CONV2_OUT
+            + self._FC_DIM * fc_in + self._FC_DIM
+            + _N_FUNCS * self._FC_DIM + _N_FUNCS
+            + _N_SPATIAL_CELLS * self._FC_DIM + _N_SPATIAL_CELLS
+        )
+
+    def to_flat(self) -> np.ndarray:
+        return np.concatenate([
+            self.W1.ravel(), self.b1,
+            self.W2.ravel(), self.b2,
+            self.W3.ravel(), self.b3,
+            self.W_fn.ravel(), self.b_fn,
+            self.W_sp.ravel(), self.b_sp,
+        ]).astype(np.float32)
+
+    def with_flat(self, flat: np.ndarray) -> "SC2CNNModel":
+        flat = np.asarray(flat, dtype=np.float32)
+        if flat.shape[0] != self.flat_dim:
+            raise ValueError(
+                f"SC2CNNModel.with_flat: expected {self.flat_dim} params, "
+                f"got {flat.shape[0]}"
+            )
+        obj = object.__new__(SC2CNNModel)
+        obj._n_channels = self._n_channels
+        obj._obs_spec   = self._obs_spec
+        obj._obs_dim    = self._obs_dim
+        obj._scales     = self._scales
+        obj._pool_flat  = self._pool_flat
+
+        C, k = self._n_channels, self._KERNEL
+        fc_in = self._pool_flat + self._obs_dim
+        off = 0
+
+        def _take(shape: tuple) -> np.ndarray:
+            nonlocal off
+            n = int(np.prod(shape))
+            out = flat[off: off + n].reshape(shape).copy()
+            off += n
+            return out
+
+        obj.W1   = _take((self._CONV1_OUT, C, k, k))
+        obj.b1   = _take((self._CONV1_OUT,))
+        obj.W2   = _take((self._CONV2_OUT, self._CONV1_OUT, k, k))
+        obj.b2   = _take((self._CONV2_OUT,))
+        obj.W3   = _take((self._FC_DIM, fc_in))
+        obj.b3   = _take((self._FC_DIM,))
+        obj.W_fn = _take((_N_FUNCS, self._FC_DIM))
+        obj.b_fn = _take((_N_FUNCS,))
+        obj.W_sp = _take((_N_SPATIAL_CELLS, self._FC_DIM))
+        obj.b_sp = _take((_N_SPATIAL_CELLS,))
+        return obj
+
+    def forward(
+        self,
+        spatial: np.ndarray,
+        flat_obs: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Forward pass.
+
+        Parameters
+        ----------
+        spatial : (C, H, W) float32  — already normalised to ~[0, 1]
+        flat_obs : (obs_dim,) float32 — raw (un-normalised) flat observation
+
+        Returns
+        -------
+        fn_scores : (N_FUNCS,) logits
+        sp_scores : (N_SPATIAL_CELLS,) logits
+        """
+        x = _conv2d_valid_relu(spatial.astype(np.float32), self.W1, self.b1)
+        x = _conv2d_valid_relu(x, self.W2, self.b2)
+        x = _adaptive_avg_pool(x, self._POOL_H, self._POOL_W)
+        cnn_feat = x.ravel()                               # (pool_flat,)
+
+        norm_flat = (flat_obs.astype(np.float32) / self._scales)
+        combined  = np.concatenate([cnn_feat, norm_flat])  # (pool_flat + obs_dim,)
+        h         = np.maximum(0.0, self.W3 @ combined + self.b3)
+
+        fn_scores = self.W_fn @ h + self.b_fn
+        sp_scores = self.W_sp @ h + self.b_sp
+        return fn_scores, sp_scores
+
+    # ------------------------------------------------------------------
+    # Policy interface (used when this model is an ES individual)
+    # ------------------------------------------------------------------
+
+    def __call__(self, obs: dict | np.ndarray) -> np.ndarray:
+        if isinstance(obs, dict):
+            flat_obs   = obs["flat"]
+            spatial    = obs["spatial"]
+        else:
+            raise TypeError(
+                "SC2CNNModel expects a dict observation with keys "
+                "'flat' and 'spatial'.  Got: " + type(obs).__name__
+            )
+        fn_scores, sp_scores = self.forward(spatial, flat_obs)
+        fn_idx   = int(np.argmax(fn_scores))
+        cell_idx = int(np.argmax(sp_scores))
+        x, y     = _GRID_XY[cell_idx]
+        return np.array([fn_idx, x, y, 0.0], dtype=np.float32)
+
+    def on_episode_start(self) -> None:
+        pass
+
+    def on_episode_end(self) -> None:
+        pass
+
+    def update(
+        self,
+        obs: dict | np.ndarray,
+        action: np.ndarray | int,
+        reward: float,
+        next_obs: dict | np.ndarray,
+        done: bool,
+    ) -> None:
+        pass  # trained via outer evolutionary optimiser
+
+
+# ---------------------------------------------------------------------------
+# SC2CNNEvolutionPolicy — isotropic ES outer optimiser wrapping SC2CNNModel
+# ---------------------------------------------------------------------------
+
+class SC2CNNEvolutionPolicy(BasePolicy):
+    """Isotropic-ES outer optimiser for :class:`SC2CNNModel`.
+
+    Uses the ``_greedy_loop_cmaes`` interface:
+    ``sample_population()`` / ``update_distribution()``.
+    Step size is adapted via the 1/5 success rule (same as
+    :class:`games.sc2.policies.LSTMEvolutionPolicy`).
+
+    Parameters
+    ----------
+    n_channels :
+        Number of spatial input channels.
+    obs_spec :
+        Flat observation spec.
+    population_size :
+        λ — offspring evaluated per generation (default 20).
+    initial_sigma :
+        Starting perturbation scale (default 0.01; CNN weight space is
+        large, so a smaller sigma than the LSTM policy is appropriate).
+    eval_episodes :
+        Episodes per individual per generation (averaged for fitness).
+    seed :
+        RNG seed.
+    """
+
+    def __init__(
+        self,
+        n_channels: int,
+        obs_spec: ObsSpec,
+        population_size: int = 20,
+        initial_sigma: float = 0.01,
+        eval_episodes: int = 1,
+        seed: int | None = None,
+    ) -> None:
+        self._lam           = int(population_size)
+        self._sigma         = float(initial_sigma)
+        self._eval_episodes = max(1, int(eval_episodes))
+        self._obs_spec      = obs_spec
+        self._rng           = np.random.default_rng(seed)
+
+        self._template = SC2CNNModel(n_channels=n_channels, obs_spec=obs_spec, seed=seed)
+        self._flat_dim = self._template.flat_dim
+        self._mean     = self._template.to_flat().astype(np.float64)
+
+        mu = self._lam // 2
+        self._mu = mu
+        raw_w = np.array(
+            [np.log(mu + 0.5) - np.log(i + 1) for i in range(mu)],
+            dtype=np.float64,
+        )
+        self._recomb_w = raw_w / raw_w.sum()
+
+        self._pop: list[np.ndarray] = []
+        self._champion: SC2CNNModel | None        = None
+        self._champion_reward: float              = float("-inf")
+
+        logger.info(
+            "[SC2CNNEvolutionPolicy] n_channels=%d  obs_dim=%d  "
+            "flat_dim=%d  pop=%d  sigma=%.4f",
+            n_channels, obs_spec.dim, self._flat_dim,
+            self._lam, self._sigma,
+        )
+
+    # ------------------------------------------------------------------
+    # Properties expected by _greedy_loop_cmaes
+    # ------------------------------------------------------------------
+
+    @property
+    def population_size(self) -> int:
+        return self._lam
+
+    @property
+    def champion_reward(self) -> float:
+        return self._champion_reward
+
+    @property
+    def sigma(self) -> float:
+        return self._sigma
+
+    # ------------------------------------------------------------------
+    # ES interface
+    # ------------------------------------------------------------------
+
+    def sample_population(self) -> list[SC2CNNModel]:
+        self._pop = []
+        for _ in range(self._lam):
+            z = self._rng.standard_normal(self._flat_dim)
+            self._pop.append(self._mean + self._sigma * z)
+        return [self._template.with_flat(x.astype(np.float32)) for x in self._pop]
+
+    def update_distribution(self, rewards: list[float]) -> bool:
+        if len(rewards) != self._lam:
+            raise ValueError(f"Expected {self._lam} rewards, got {len(rewards)}")
+        if len(self._pop) != self._lam:
+            raise RuntimeError("update_distribution() called before sample_population().")
+
+        order     = np.argsort(rewards)[::-1]
+        prev_best = self._champion_reward
+        improved  = False
+
+        best_r = rewards[order[0]]
+        if best_r > self._champion_reward:
+            self._champion_reward = best_r
+            self._champion        = self._template.with_flat(
+                np.array(self._pop[order[0]], dtype=np.float32)
+            )
+            improved = True
+
+        # Weighted recombination of top-μ.
+        elite_xs   = np.stack([self._pop[order[i]] for i in range(self._mu)])
+        self._mean = np.einsum("i,ij->j", self._recomb_w, elite_xs)
+
+        # 1/5 success-rule sigma adaptation.
+        n_success    = sum(1 for r in rewards if r > prev_best)
+        success_rate = n_success / self._lam
+        self._sigma  = float(np.clip(
+            self._sigma * (1.2 if success_rate > 0.2 else 0.85),
+            1e-8, 1e2,
+        ))
+
+        return improved
+
+    # ------------------------------------------------------------------
+    # Policy interface (uses champion for inference)
+    # ------------------------------------------------------------------
+
+    def __call__(self, obs: dict | np.ndarray) -> np.ndarray:
+        if self._champion is None:
+            raise RuntimeError(
+                "SC2CNNEvolutionPolicy: no champion yet — call "
+                "sample_population() and update_distribution() first."
+            )
+        return self._champion(obs)
+
+    def on_episode_start(self) -> None:
+        pass
+
+    def on_episode_end(self) -> None:
+        pass
+
+    def update(
+        self,
+        obs: dict | np.ndarray,
+        action: np.ndarray | int,
+        reward: float,
+        next_obs: dict | np.ndarray,
+        done: bool,
+    ) -> None:
+        pass
+
+    # ------------------------------------------------------------------
+    # Persistence
+    # ------------------------------------------------------------------
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type":     "sc2_cnn",
+            "n_channels":      self._template._n_channels,
+            "obs_dim":         self._obs_spec.dim,
+            "population_size": self._lam,
+            "sigma":           float(self._sigma),
+            "eval_episodes":   self._eval_episodes,
+            "champion_reward": float(self._champion_reward),
+        }
+
+    def save(self, path: str) -> None:
+        """Save champion weights as a numpy .npz file."""
+        if self._champion is not None:
+            flat = self._champion.to_flat()
+            np.savez(
+                path.replace(".yaml", ".npz") if path.endswith(".yaml") else path,
+                flat=flat,
+                n_channels=np.int64(self._template._n_channels),
+                obs_dim=np.int64(self._obs_spec.dim),
+                flat_dim=np.int64(self._flat_dim),
+            )
+
+    def save_trainer_state(self, path: str) -> None:
+        np.savez(
+            path,
+            mean=self._mean,
+            sigma=np.float64(self._sigma),
+            flat_dim=np.int64(self._flat_dim),
+        )
+
+    def load_trainer_state(self, path: str) -> None:
+        with np.load(path) as data:
+            saved_flat_dim = int(data["flat_dim"])
+            if saved_flat_dim != self._flat_dim:
+                raise ValueError(
+                    f"SC2CNNEvolutionPolicy: trainer state flat_dim mismatch — "
+                    f"saved={saved_flat_dim}, current={self._flat_dim}. "
+                    f"Use --re-initialize to restart from scratch."
+                )
+            self._mean  = data["mean"].astype(np.float64)
+            self._sigma = float(data["sigma"])
+        logger.info(
+            "[SC2CNNEvolutionPolicy] trainer state loaded from %s (sigma=%.4f)",
+            path, self._sigma,
+        )
+
+    def load_champion(self, path: str) -> None:
+        """Load champion weights from a .npz file saved by :meth:`save`."""
+        with np.load(path) as data:
+            saved_flat_dim = int(data["flat_dim"])
+            if saved_flat_dim != self._flat_dim:
+                raise ValueError(
+                    f"SC2CNNEvolutionPolicy: champion flat_dim mismatch — "
+                    f"saved={saved_flat_dim}, current={self._flat_dim}. "
+                    f"Use --re-initialize to restart from scratch."
+                )
+            self._champion = self._template.with_flat(
+                data["flat"].astype(np.float32)
+            )
+            self._mean = data["flat"].astype(np.float64)
+        logger.info("[SC2CNNEvolutionPolicy] champion loaded from %s", path)

--- a/games/sc2/config/training_params.yaml
+++ b/games/sc2/config/training_params.yaml
@@ -35,8 +35,8 @@ patience: 0                  # stop greedy loop if no improvement for this many 
 # and x/y to screen corners — use sc2_genetic instead.
 policy_type: sc2_genetic
 
-screen_layers: [player_relative, selected]  # spatial feature layers to stack; [] disables CNN obs
-minimap_layers: []                          # optional minimap channels to append
+screen_layers: []                           # spatial feature layers for sc2_cnn policy; [] = disabled (required for sc2_genetic and other flat-obs policies)
+minimap_layers: []                          # optional minimap channels (sc2_cnn only; requires screen_size == minimap_size)
 
 policy_params:
   population_size: 30      # larger search space needs bigger population

--- a/games/sc2/config/training_params.yaml
+++ b/games/sc2/config/training_params.yaml
@@ -35,6 +35,9 @@ patience: 0                  # stop greedy loop if no improvement for this many 
 # and x/y to screen corners — use sc2_genetic instead.
 policy_type: sc2_genetic
 
+screen_layers: [player_relative, selected]  # spatial feature layers to stack; [] disables CNN obs
+minimap_layers: []                          # optional minimap channels to append
+
 policy_params:
   population_size: 30      # larger search space needs bigger population
   elite_k: 5

--- a/games/sc2/env.py
+++ b/games/sc2/env.py
@@ -65,6 +65,12 @@ class SC2Env(BaseGameEnv):
         Bot difficulty for 1v1 maps; ignored for minigames.
     visualize :
         If True, render the PySC2 visualizer.
+    screen_layers :
+        PySC2 feature_screen layer names to stack as spatial obs channels.
+        When non-empty the observation space becomes a ``Dict`` with keys
+        ``"flat"`` (the existing vector) and ``"spatial"`` (C × H × W).
+    minimap_layers :
+        PySC2 feature_minimap layer names appended after screen_layers.
     """
 
     metadata = {"render_modes": []}
@@ -80,6 +86,8 @@ class SC2Env(BaseGameEnv):
         agent_race: str = "random",
         bot_difficulty: str = "very_easy",
         visualize: bool = False,
+        screen_layers: list[str] | None = None,
+        minimap_layers: list[str] | None = None,
     ) -> None:
         super().__init__()
 
@@ -89,14 +97,32 @@ class SC2Env(BaseGameEnv):
         self._max_episode_time_s = max_episode_time_s
         self._step_mul = step_mul
         self._reward_calc = SC2RewardCalculator(self._reward_config)
+        self._screen_layers: list[str] = list(screen_layers or [])
+        self._minimap_layers: list[str] = list(minimap_layers or [])
+        self._use_spatial = bool(self._screen_layers or self._minimap_layers)
 
         spec = get_spec(map_name)
-        self.observation_space = spaces.Box(
+        flat_space = spaces.Box(
             low=-np.inf,
             high=np.inf,
             shape=(spec.dim,),
             dtype=np.float32,
         )
+        if self._use_spatial:
+            n_channels = len(self._screen_layers) + len(self._minimap_layers)
+            self.observation_space = spaces.Dict({
+                "flat": flat_space,
+                "spatial": spaces.Box(
+                    low=0.0, high=1.0,
+                    shape=(n_channels, screen_size, screen_size),
+                    dtype=np.float32,
+                ),
+            })
+            self._spatial_shape = (n_channels, screen_size, screen_size)
+        else:
+            self.observation_space = flat_space
+            self._spatial_shape = None
+
         n_funcs = max(FUNCTION_IDS) + 1
         self.action_space = spaces.Box(
             low=np.array([0.0, 0.0, 0.0, 0.0], dtype=np.float32),
@@ -112,6 +138,8 @@ class SC2Env(BaseGameEnv):
             agent_race=agent_race,
             bot_difficulty=bot_difficulty,
             visualize=visualize,
+            screen_layers=self._screen_layers,
+            minimap_layers=self._minimap_layers,
         )
 
         # Episode tracking
@@ -132,10 +160,11 @@ class SC2Env(BaseGameEnv):
         *,
         seed: int | None = None,
         options: dict[str, Any] | None = None,
-    ) -> tuple[np.ndarray, dict]:
+    ) -> tuple[np.ndarray | dict, dict]:
         super().reset(seed=seed)
 
-        obs, info = self._client.reset()
+        flat_obs, info = self._client.reset()
+        obs = self._make_obs(flat_obs, info)
 
         self._prev_obs = obs
         self._prev_minerals = info.get("minerals", 0.0)
@@ -148,8 +177,9 @@ class SC2Env(BaseGameEnv):
 
         return obs, info
 
-    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, bool, dict]:
-        obs, _raw_reward, done, info = self._client.step(action)
+    def step(self, action: np.ndarray) -> tuple[np.ndarray | dict, float, bool, bool, dict]:
+        flat_obs, _raw_reward, done, info = self._client.step(action)
+        obs = self._make_obs(flat_obs, info)
 
         self._step_count += 1
         self._elapsed_s = time.monotonic() - self._episode_start_s
@@ -199,11 +229,28 @@ class SC2Env(BaseGameEnv):
         self._client.close()
 
     # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _make_obs(self, flat_obs: np.ndarray, info: dict) -> np.ndarray | dict:
+        """Wrap flat_obs into a dict observation when spatial layers are active."""
+        if not self._use_spatial:
+            return flat_obs
+        spatial = info.get("spatial_obs")
+        if spatial is None:
+            spatial = np.zeros(self._spatial_shape, dtype=np.float32)
+        return {"flat": flat_obs, "spatial": spatial}
+
+    # ------------------------------------------------------------------
     # BaseGameEnv API
     # ------------------------------------------------------------------
 
     def _build_obs(self, step: Any) -> np.ndarray:
         """Not used directly — obs comes from the client's reset/step."""
+        if self._use_spatial:
+            return np.zeros(
+                self.observation_space["flat"].shape, dtype=np.float32
+            )
         return np.zeros(self.observation_space.shape, dtype=np.float32)
 
     def _get_game_info(self) -> dict:
@@ -231,6 +278,8 @@ def make_env(
     agent_race: str = "random",
     bot_difficulty: str = "very_easy",
     visualize: bool = False,
+    screen_layers: list[str] | None = None,
+    minimap_layers: list[str] | None = None,
 ) -> SC2Env:
     """Factory that wires up an :class:`SC2Env` from an experiment directory.
 
@@ -252,4 +301,6 @@ def make_env(
         agent_race=agent_race,
         bot_difficulty=bot_difficulty,
         visualize=visualize,
+        screen_layers=screen_layers,
+        minimap_layers=minimap_layers,
     )

--- a/tests/test_sc2_cnn_policy.py
+++ b/tests/test_sc2_cnn_policy.py
@@ -20,9 +20,8 @@ from games.sc2.obs_spec import SC2_MINIGAME_OBS_SPEC
 # Helpers
 # ---------------------------------------------------------------------------
 
-def _make_model(n_channels: int = 2, obs_dim: int | None = None) -> SC2CNNModel:
-    spec = SC2_MINIGAME_OBS_SPEC
-    return SC2CNNModel(n_channels=n_channels, obs_spec=spec, seed=0)
+def _make_model(n_channels: int = 2) -> SC2CNNModel:
+    return SC2CNNModel(n_channels=n_channels, obs_spec=SC2_MINIGAME_OBS_SPEC, seed=0)
 
 
 def _dict_obs(n_channels: int = 2, h: int = 64, w: int = 64) -> dict:
@@ -188,7 +187,7 @@ class TestSC2CNNEvolutionPolicy(unittest.TestCase):
         self.policy.update_distribution([100.0, 100.0, 100.0, 100.0])
         self.assertNotEqual(self.policy.sigma, sigma_before)
 
-    def test_trainer_state_roundtrip(self, tmp_path: str | None = None):
+    def test_trainer_state_roundtrip(self):
         import tempfile, os
         with tempfile.TemporaryDirectory() as d:
             state_path = os.path.join(d, "trainer_state.npz")

--- a/tests/test_sc2_cnn_policy.py
+++ b/tests/test_sc2_cnn_policy.py
@@ -1,0 +1,445 @@
+"""Tests for the SC2 CNN policy and spatial observation pipeline.
+
+All tests mock PySC2 / the SC2Client so they run without a game binary.
+"""
+import unittest
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from games.sc2.cnn_policy import (
+    SC2CNNModel,
+    SC2CNNEvolutionPolicy,
+    _conv2d_valid_relu,
+    _adaptive_avg_pool,
+)
+from games.sc2.obs_spec import SC2_MINIGAME_OBS_SPEC
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_model(n_channels: int = 2, obs_dim: int | None = None) -> SC2CNNModel:
+    spec = SC2_MINIGAME_OBS_SPEC
+    return SC2CNNModel(n_channels=n_channels, obs_spec=spec, seed=0)
+
+
+def _dict_obs(n_channels: int = 2, h: int = 64, w: int = 64) -> dict:
+    spec = SC2_MINIGAME_OBS_SPEC
+    return {
+        "flat":    np.zeros(spec.dim, dtype=np.float32),
+        "spatial": np.random.default_rng(0).random((n_channels, h, w)).astype(np.float32),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Conv2d + pool helpers
+# ---------------------------------------------------------------------------
+
+class TestConv2dValidRelu(unittest.TestCase):
+
+    def test_output_shape(self):
+        x = np.ones((2, 8, 8), dtype=np.float32)
+        W = np.ones((4, 2, 3, 3), dtype=np.float32) * 0.01
+        b = np.zeros(4, dtype=np.float32)
+        out = _conv2d_valid_relu(x, W, b)
+        self.assertEqual(out.shape, (4, 6, 6))
+
+    def test_relu_zeros_negative(self):
+        x = np.ones((1, 4, 4), dtype=np.float32)
+        W = -np.ones((1, 1, 3, 3), dtype=np.float32)
+        b = np.zeros(1, dtype=np.float32)
+        out = _conv2d_valid_relu(x, W, b)
+        # All pre-ReLU values are negative → output should be all zeros.
+        np.testing.assert_array_equal(out, 0.0)
+
+
+class TestAdaptiveAvgPool(unittest.TestCase):
+
+    def test_output_shape(self):
+        x = np.ones((32, 60, 60), dtype=np.float32)
+        out = _adaptive_avg_pool(x, 4, 4)
+        self.assertEqual(out.shape, (32, 4, 4))
+
+    def test_uniform_input_preserved(self):
+        x = np.full((8, 60, 60), 3.0, dtype=np.float32)
+        out = _adaptive_avg_pool(x, 4, 4)
+        np.testing.assert_allclose(out, 3.0, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# SC2CNNModel
+# ---------------------------------------------------------------------------
+
+class TestSC2CNNModelShape(unittest.TestCase):
+
+    def test_flat_dim_formula(self):
+        model = _make_model(n_channels=2)
+        self.assertEqual(model.to_flat().shape[0], model.flat_dim)
+
+    def test_flat_dim_varies_with_channels(self):
+        m1 = _make_model(n_channels=1)
+        m2 = _make_model(n_channels=4)
+        self.assertLess(m1.flat_dim, m2.flat_dim)
+
+    def test_forward_output_shapes(self):
+        model  = _make_model(n_channels=2)
+        obs    = _dict_obs(n_channels=2)
+        fn_sc, sp_sc = model.forward(obs["spatial"], obs["flat"])
+        self.assertEqual(fn_sc.shape, (6,))
+        self.assertEqual(sp_sc.shape, (9,))
+
+    def test_callable_returns_4vector(self):
+        model  = _make_model(n_channels=2)
+        obs    = _dict_obs(n_channels=2)
+        action = model(obs)
+        self.assertEqual(action.shape, (4,))
+        self.assertIsInstance(float(action[0]), float)
+
+    def test_with_flat_roundtrip(self):
+        model    = _make_model(n_channels=2)
+        flat     = model.to_flat()
+        restored = model.with_flat(flat)
+        np.testing.assert_array_equal(restored.to_flat(), flat)
+
+    def test_with_flat_wrong_size_raises(self):
+        model = _make_model(n_channels=2)
+        with self.assertRaises(ValueError):
+            model.with_flat(np.zeros(10, dtype=np.float32))
+
+    def test_non_dict_obs_raises(self):
+        model = _make_model(n_channels=2)
+        with self.assertRaises(TypeError):
+            model(np.zeros(13, dtype=np.float32))
+
+    def test_flat_concat_dimension(self):
+        """Flat obs and spatial features must be correctly concatenated."""
+        model = _make_model(n_channels=2)
+        obs   = _dict_obs(n_channels=2)
+        # Just check no shape error occurs in forward.
+        fn_sc, sp_sc = model.forward(obs["spatial"], obs["flat"])
+        self.assertEqual(fn_sc.shape[0], 6)
+        self.assertEqual(sp_sc.shape[0], 9)
+
+
+# ---------------------------------------------------------------------------
+# SC2CNNEvolutionPolicy
+# ---------------------------------------------------------------------------
+
+class TestSC2CNNEvolutionPolicy(unittest.TestCase):
+
+    def setUp(self):
+        self.obs_spec = SC2_MINIGAME_OBS_SPEC
+        self.policy = SC2CNNEvolutionPolicy(
+            n_channels=2,
+            obs_spec=self.obs_spec,
+            population_size=4,
+            initial_sigma=0.01,
+            seed=42,
+        )
+
+    def test_population_size(self):
+        self.assertEqual(self.policy.population_size, 4)
+
+    def test_sample_population_returns_correct_count(self):
+        pop = self.policy.sample_population()
+        self.assertEqual(len(pop), 4)
+        for ind in pop:
+            self.assertIsInstance(ind, SC2CNNModel)
+
+    def test_individuals_are_callable(self):
+        pop = self.policy.sample_population()
+        obs = _dict_obs(n_channels=2)
+        for ind in pop:
+            action = ind(obs)
+            self.assertEqual(action.shape, (4,))
+
+    def test_update_distribution_returns_bool(self):
+        self.policy.sample_population()
+        rewards = [1.0, 2.0, 0.5, 3.0]
+        improved = self.policy.update_distribution(rewards)
+        self.assertIsInstance(improved, bool)
+
+    def test_champion_improves_after_good_reward(self):
+        self.policy.sample_population()
+        self.policy.update_distribution([10.0, 1.0, 2.0, 3.0])
+        self.assertGreater(self.policy.champion_reward, float("-inf"))
+
+    def test_champion_callable_after_update(self):
+        self.policy.sample_population()
+        self.policy.update_distribution([1.0, 2.0, 3.0, 4.0])
+        obs    = _dict_obs(n_channels=2)
+        action = self.policy(obs)
+        self.assertEqual(action.shape, (4,))
+
+    def test_update_wrong_rewards_count_raises(self):
+        self.policy.sample_population()
+        with self.assertRaises(ValueError):
+            self.policy.update_distribution([1.0, 2.0])
+
+    def test_update_without_sample_raises(self):
+        with self.assertRaises(RuntimeError):
+            self.policy.update_distribution([1.0, 2.0, 3.0, 4.0])
+
+    def test_sigma_adapts(self):
+        sigma_before = self.policy.sigma
+        self.policy.sample_population()
+        self.policy.update_distribution([100.0, 100.0, 100.0, 100.0])
+        self.assertNotEqual(self.policy.sigma, sigma_before)
+
+    def test_trainer_state_roundtrip(self, tmp_path: str | None = None):
+        import tempfile, os
+        with tempfile.TemporaryDirectory() as d:
+            state_path = os.path.join(d, "trainer_state.npz")
+            self.policy.sample_population()
+            self.policy.update_distribution([1.0, 2.0, 3.0, 4.0])
+            self.policy.save_trainer_state(state_path)
+
+            policy2 = SC2CNNEvolutionPolicy(
+                n_channels=2, obs_spec=self.obs_spec,
+                population_size=4, initial_sigma=0.01, seed=0,
+            )
+            policy2.load_trainer_state(state_path)
+            np.testing.assert_array_almost_equal(
+                policy2._mean, self.policy._mean
+            )
+
+    def test_save_load_champion(self):
+        import tempfile, os
+        with tempfile.TemporaryDirectory() as d:
+            champ_path = os.path.join(d, "champion.npz")
+            self.policy.sample_population()
+            self.policy.update_distribution([1.0, 2.0, 3.0, 4.0])
+            self.policy.save(champ_path)
+
+            policy2 = SC2CNNEvolutionPolicy(
+                n_channels=2, obs_spec=self.obs_spec,
+                population_size=4, initial_sigma=0.01, seed=0,
+            )
+            policy2.load_champion(champ_path)
+            obs = _dict_obs(n_channels=2)
+            np.testing.assert_array_equal(
+                policy2(obs), self.policy(obs)
+            )
+
+
+# ---------------------------------------------------------------------------
+# SC2Env dict observation space
+# ---------------------------------------------------------------------------
+
+class TestSC2EnvDictObsSpace(unittest.TestCase):
+
+    def _make_env(self, screen_layers, minimap_layers=None):
+        from games.sc2.env import SC2Env
+        with patch("games.sc2.env.SC2Client"):
+            return SC2Env(
+                map_name="MoveToBeacon",
+                screen_layers=screen_layers,
+                minimap_layers=minimap_layers or [],
+            )
+
+    def test_flat_obs_space_when_no_layers(self):
+        from gymnasium import spaces
+        env = self._make_env([])
+        self.assertIsInstance(env.observation_space, spaces.Box)
+
+    def test_dict_obs_space_when_layers_given(self):
+        from gymnasium import spaces
+        env = self._make_env(["player_relative", "selected"])
+        self.assertIsInstance(env.observation_space, spaces.Dict)
+        self.assertIn("flat", env.observation_space.spaces)
+        self.assertIn("spatial", env.observation_space.spaces)
+
+    def test_spatial_shape_matches_channels(self):
+        env = self._make_env(["player_relative", "selected"])
+        spatial_space = env.observation_space["spatial"]
+        self.assertEqual(spatial_space.shape[0], 2)   # 2 channels
+        self.assertEqual(spatial_space.shape[1], 64)  # screen H
+        self.assertEqual(spatial_space.shape[2], 64)  # screen W
+
+    def test_reset_returns_dict_obs(self):
+        from games.sc2.env import SC2Env
+        from games.sc2.obs_spec import BASE_OBS_DIM
+
+        with patch("games.sc2.env.SC2Client") as mock_cls:
+            mock_client = mock_cls.return_value
+            mock_client.reset.return_value = (
+                np.zeros(BASE_OBS_DIM, dtype=np.float32),
+                {
+                    "score": 0.0, "minerals": 0.0, "vespene": 0.0,
+                    "food_used": 0.0, "food_cap": 0.0, "army_count": 0.0,
+                    "spatial_obs": np.zeros((2, 64, 64), dtype=np.float32),
+                },
+            )
+            env = SC2Env(
+                map_name="MoveToBeacon",
+                screen_layers=["player_relative", "selected"],
+            )
+            obs, info = env.reset()
+
+        self.assertIsInstance(obs, dict)
+        self.assertIn("flat", obs)
+        self.assertIn("spatial", obs)
+        self.assertEqual(obs["flat"].shape, (BASE_OBS_DIM,))
+        self.assertEqual(obs["spatial"].shape, (2, 64, 64))
+
+    def test_reset_fills_zeros_when_no_spatial_in_info(self):
+        from games.sc2.env import SC2Env
+        from games.sc2.obs_spec import BASE_OBS_DIM
+
+        with patch("games.sc2.env.SC2Client") as mock_cls:
+            mock_client = mock_cls.return_value
+            mock_client.reset.return_value = (
+                np.zeros(BASE_OBS_DIM, dtype=np.float32),
+                {
+                    "score": 0.0, "minerals": 0.0, "vespene": 0.0,
+                    "food_used": 0.0, "food_cap": 0.0, "army_count": 0.0,
+                    # no "spatial_obs" key
+                },
+            )
+            env = SC2Env(
+                map_name="MoveToBeacon",
+                screen_layers=["player_relative", "selected"],
+            )
+            obs, _ = env.reset()
+
+        self.assertIsInstance(obs, dict)
+        np.testing.assert_array_equal(obs["spatial"], 0.0)
+
+    def test_step_returns_dict_obs(self):
+        from games.sc2.env import SC2Env
+        from games.sc2.obs_spec import BASE_OBS_DIM
+
+        with patch("games.sc2.env.SC2Client") as mock_cls:
+            mock_client = mock_cls.return_value
+            mock_client.reset.return_value = (
+                np.zeros(BASE_OBS_DIM, dtype=np.float32),
+                {"score": 0.0, "minerals": 0.0, "vespene": 0.0,
+                 "food_used": 0.0, "food_cap": 0.0, "army_count": 0.0,
+                 "spatial_obs": np.zeros((2, 64, 64), dtype=np.float32)},
+            )
+            mock_client.step.return_value = (
+                np.zeros(BASE_OBS_DIM, dtype=np.float32),
+                0.0,
+                False,
+                {"score": 1.0, "minerals": 0.0, "vespene": 0.0,
+                 "food_used": 0.0, "food_cap": 0.0, "army_count": 0.0,
+                 "spatial_obs": np.ones((2, 64, 64), dtype=np.float32)},
+            )
+            env = SC2Env(
+                map_name="MoveToBeacon",
+                screen_layers=["player_relative", "selected"],
+            )
+            env.reset()
+            obs, reward, terminated, truncated, info = env.step(
+                np.zeros(4, dtype=np.float32)
+            )
+
+        self.assertIsInstance(obs, dict)
+        self.assertIn("spatial", obs)
+
+
+# ---------------------------------------------------------------------------
+# SC2Client spatial obs extraction
+# ---------------------------------------------------------------------------
+
+class TestSC2ClientSpatialObs(unittest.TestCase):
+
+    @staticmethod
+    def _fake_feature_screen(layer_data: dict) -> np.ndarray:
+        """Return an ndarray subclass that also supports string indexing.
+
+        ``_safe_array`` in SC2Client passes the result through
+        ``np.asarray()``, so the object must pass ``isinstance(x, np.ndarray)``
+        — hence the ndarray subclass approach.
+        """
+        h, w = next(iter(layer_data.values())).shape
+
+        class _FakeScreen(np.ndarray):
+            def __new__(cls, d):
+                # Backing storage is a zero float array — we only care about
+                # string-keyed access.
+                obj = np.zeros((len(d), h, w), dtype=np.float32).view(cls)
+                obj._layer_data = d
+                return obj
+
+            def __array_finalize__(self, obj):
+                self._layer_data = getattr(obj, "_layer_data", {})
+
+            def __getitem__(self, key):
+                if isinstance(key, str):
+                    return self._layer_data.get(key, np.zeros((h, w), dtype=np.float32))
+                return super().__getitem__(key)
+
+        return _FakeScreen(layer_data)
+
+    def _make_timestep(self, player_relative: np.ndarray) -> MagicMock:
+        """Build a minimal mock PySC2 TimeStep with a feature_screen layer."""
+        zeros = np.zeros_like(player_relative)
+        feat_screen = self._fake_feature_screen({
+            "player_relative": player_relative,
+            "selected":        zeros,
+        })
+
+        player_data = {
+            "minerals": 0, "vespene": 0, "food_used": 0, "food_cap": 10,
+            "army_count": 0, "idle_worker_count": 0,
+            "warp_gate_count": 0, "larva_count": 0,
+        }
+        player_mock = MagicMock()
+        player_mock.__getitem__.side_effect = player_data.__getitem__
+        player_mock.get.side_effect = player_data.get
+
+        ob = MagicMock()
+        ob_data = {
+            "feature_screen":    feat_screen,
+            "player":            player_mock,
+            "available_actions": np.array([0]),
+            "score_cumulative":  np.array([0.0]),
+            "single_select":     np.array([]),
+            "multi_select":      np.array([]),
+        }
+        ob.__getitem__.side_effect = ob_data.__getitem__
+        ob.get.side_effect = lambda k, d=None: ob_data.get(k, d)
+
+        ts = MagicMock()
+        ts.observation = ob
+        ts.last.return_value = False
+        ts.reward = 0.0
+        return ts
+
+    def test_spatial_obs_in_info(self):
+        from games.sc2.client import SC2Client
+        client = SC2Client(
+            map_name="MoveToBeacon",
+            screen_layers=["player_relative"],
+        )
+        pr = np.ones((64, 64), dtype=np.float32) * 2.0
+        ts = self._make_timestep(pr)
+        _, info = client._timestep_to_obs_info(ts)
+        self.assertIn("spatial_obs", info)
+        self.assertEqual(info["spatial_obs"].shape, (1, 64, 64))
+
+    def test_spatial_obs_normalised(self):
+        from games.sc2.client import SC2Client
+        client = SC2Client(
+            map_name="MoveToBeacon",
+            screen_layers=["player_relative"],
+        )
+        pr = np.full((64, 64), 4.0, dtype=np.float32)  # max value for player_relative
+        ts = self._make_timestep(pr)
+        _, info = client._timestep_to_obs_info(ts)
+        np.testing.assert_allclose(info["spatial_obs"], 1.0, atol=1e-5)
+
+    def test_no_spatial_obs_when_no_layers(self):
+        from games.sc2.client import SC2Client
+        client = SC2Client(map_name="MoveToBeacon")
+        pr = np.zeros((64, 64), dtype=np.float32)
+        ts = self._make_timestep(pr)
+        _, info = client._timestep_to_obs_info(ts)
+        self.assertNotIn("spatial_obs", info)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements a new CNN-based policy for StarCraft II that evolves network weights using isotropic evolutionary strategy (ES). This complements the existing LSTM evolutionary policy with a spatial-aware architecture designed for screen/minimap observations.

## Key Changes

### New CNN Policy Implementation (`games/sc2/cnn_policy.py`)
- **SC2CNNModel**: Pure-numpy CNN architecture with:
  - Two 3×3 convolutional layers (32 → 64 channels) with ReLU
  - Adaptive average pooling to 4×4
  - Concatenation with flat observations
  - Fully connected layer (256 units) feeding dual heads for function selection (6 outputs) and spatial cell selection (9 outputs)
  - No PyTorch/TensorFlow dependency — uses stride tricks for efficient convolution and custom pooling
  - Serializable weight format via `to_flat()` / `with_flat()` for evolutionary perturbation

- **SC2CNNEvolutionPolicy**: Isotropic ES optimizer with:
  - Population-based sampling with Gaussian perturbations
  - Weighted recombination of top-μ individuals
  - 1/5 success-rule sigma adaptation (same as LSTM policy)
  - Champion tracking and inference
  - Persistence via `save()` / `load_champion()` and trainer state checkpointing

### Spatial Observation Pipeline
- **SC2Client** (`games/sc2/client.py`):
  - Added `screen_layers` and `minimap_layers` parameters
  - New `_LAYER_SCALE` dictionary for normalizing feature layers (player_relative, selected, unit_type, etc.) to ~[0, 1]
  - `_timestep_to_obs_info()` now extracts and stacks selected layers into (C, H, W) spatial observations

- **SC2Env** (`games/sc2/env.py`):
  - Observation space becomes `Dict` with `"flat"` and `"spatial"` keys when layers are specified
  - Passes layer configuration to SC2Client
  - Maintains backward compatibility (flat-only when no layers given)

- **SC2Adapter** (`games/sc2/adapter.py`):
  - Routes `policy_type: sc2_cnn` to SC2CNNEvolutionPolicy factory
  - Validates that at least one spatial layer is configured
  - Reads `screen_layers` and `minimap_layers` from training_params.yaml

### Configuration
- **training_params.yaml**: Added example `screen_layers: [player_relative, selected]` and `minimap_layers: []`

### Testing (`tests/test_sc2_cnn_policy.py`)
- Comprehensive unit tests covering:
  - Conv2d and adaptive pooling helpers
  - Model shape inference and weight serialization
  - Forward pass correctness
  - ES population sampling and distribution updates
  - Sigma adaptation via 1/5 success rule
  - Champion persistence (save/load)
  - Dict observation space integration with SC2Env
  - Spatial layer extraction and normalization from mocked PySC2 timesteps

## Notable Implementation Details
- **Pure NumPy convolution**: Uses `np.lib.stride_tricks` for efficient im2col without explicit loops, enabling fast inference without external ML frameworks
- **He initialization**: Weights initialized with He scaling based on fan-in for stable training
- **Observation normalization**: Flat observations normalized by per-dimension scales; spatial layers normalized by layer-specific max values
- **No backprop**: Purely evolutionary — no gradient computation, suitable for discrete action spaces and non-differentiable reward signals
- **Backward compatible**: Existing flat-observation policies unaffected; spatial features opt-in via configuration

https://claude.ai/code/session_01VUiVNMQEQy4kkhMPwYhgxH