### PR TITLE
Scale episode time limit during neural network policy optimization

### DIFF
--- a/framework/training.py
+++ b/framework/training.py
@@ -456,6 +456,7 @@ def _greedy_loop(
 
     if isinstance(best_policy, NeuralNetPolicy):
         # Single-candidate hill-climbing for neural_net
+        full_episode_time_s = env.get_episode_time_limit()
         no_improve_streak = 0
         early_stopped     = False
         early_stop_sim    = None
@@ -463,6 +464,10 @@ def _greedy_loop(
             for sim in range(1, n_sims + 1):
                 candidate = best_policy.mutated(scale=current_scale)
                 logger.info("--- Sim %d/%d ---", sim, n_sims)
+                if full_episode_time_s is not None:
+                    env.set_episode_time_limit(
+                        _scaled_episode_time(sim, n_sims, full_episode_time_s)
+                    )
                 obs, _ = env.reset()
                 reward, info, tc, total_steps, trace = _run_episode(
                     env, candidate, obs,


### PR DESCRIPTION
## Summary
Added dynamic episode time limit scaling during the greedy loop optimization of neural network policies. This allows episodes to run with progressively adjusted time limits based on the simulation progress.

## Key Changes
- Retrieve the full episode time limit from the environment at the start of neural network policy optimization
- Scale the episode time limit for each simulation based on its progress through the total number of simulations
- Apply the scaled time limit to the environment before each episode reset

## Implementation Details
- The time limit scaling only occurs when `full_episode_time_s` is not `None`, ensuring backward compatibility with environments that don't define time limits
- The `_scaled_episode_time()` helper function is used to compute the appropriate time limit for each simulation iteration
- This change enables more efficient exploration during policy optimization by potentially reducing episode duration in early simulations while allowing full-length episodes in later stages

https://claude.ai/code/session_01GwhCxwW1jUnt9i7BbzLKHm