### PR TITLE
Add contribution guide, PR template, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,106 @@
+name: Bug report
+description: Something is broken — a crash, wrong output, regression, or unexpected behaviour.
+title: "[bug]: <one-line summary>"
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more concrete you can
+        be (commands run, full traceback, config files), the faster this
+        gets fixed.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What happened?
+      description: A clear, concise description of the bug.
+      placeholder: "When I run `python main.py X --game sc2`, it crashes after the first episode with …"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+      placeholder: "Training should continue through n_sims generations."
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction steps
+      description: The exact commands and config that trigger the bug. Paste your `training_params.yaml` and `reward_config.yaml` if relevant.
+      value: |
+        1. `python main.py …`
+        2. …
+        3. See error
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / traceback
+      description: Full stack trace, or the last ~50 lines of output. Wrap long pastes in `<details>` to keep the issue readable.
+      render: shell
+
+  - type: dropdown
+    id: game
+    attributes:
+      label: Affected game
+      description: Which game integration is involved? Pick "framework" for game-agnostic bugs.
+      multiple: true
+      options:
+        - framework (game-agnostic)
+        - tmnf
+        - torcs
+        - sc2
+        - beamng
+        - assetto
+        - car_racing
+        - distributed / coordinator / worker
+        - analytics
+        - infrastructure (terraform / azure)
+        - other
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "Windows 11 24H2 / Ubuntu 22.04 / macOS 14.5"
+    validations:
+      required: true
+
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.11.9"
+    validations:
+      required: true
+
+  - type: input
+    id: commit
+    attributes:
+      label: Commit / branch
+      description: Output of `git rev-parse --short HEAD` (and branch name).
+      placeholder: "abc1234 on main"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I searched existing open and closed issues and didn't find a duplicate.
+          required: true
+        - label: I included the full command, traceback, and (where relevant) my config files.
+          required: true
+        - label: This is reproducible on the latest `main` (or I've explained why I can't test main).
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/espenhk/gamer-ai/discussions
+    about: For open-ended questions, design discussions, or "is this a good idea?" threads, please use GitHub Discussions instead of an issue.
+  - name: Read the contribution guide first
+    url: https://github.com/espenhk/gamer-ai/blob/main/CONTRIBUTING.md
+    about: How to set up the project, run tests, and propose changes.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,75 @@
+name: Feature request
+description: Suggest an enhancement, new policy, new analytics view, or other non-game improvement.
+title: "[feature]: <one-line summary>"
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for new features, new policies, new analytics
+        views, infrastructure changes, or developer-experience
+        improvements. **For proposing a new game integration, please use
+        the dedicated "New game integration" template instead** — it asks
+        the questions we need to scope the work.
+
+        For open-ended "is this a good idea?" discussions, prefer
+        [GitHub Discussions](https://github.com/espenhk/gamer-ai/discussions).
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the gap or pain point. Focus on the user-facing problem, not the solution.
+      placeholder: "When training SC2 ladder runs, I have no way to … which means …"
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How would you fix it? Sketch the API, config knobs, or UI changes.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why you discarded them.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area of the codebase
+      multiple: true
+      options:
+        - framework (game-agnostic training loop, policies, analytics)
+        - new policy / algorithm
+        - analytics / plotting
+        - grid search / distributed
+        - infrastructure (terraform / azure / CI)
+        - tooling / DX (pre-commit, lint, docs)
+        - tmnf
+        - torcs
+        - sc2
+        - beamng
+        - assetto
+        - car_racing
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Additional context
+      description: Links, papers, screenshots, related issues, anything else.
+
+  - type: checkboxes
+    id: willing
+    attributes:
+      label: Would you like to implement this?
+      options:
+        - label: I'd like to take this on myself (please assign me / mark "good first issue" if it fits).
+          required: false

--- a/.github/ISSUE_TEMPLATE/game_support.yml
+++ b/.github/ISSUE_TEMPLATE/game_support.yml
@@ -1,0 +1,116 @@
+name: New game integration
+description: Propose adding support for a new game / simulator.
+title: "[game]: add <game name> integration"
+labels: ["game-support", "enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for proposals to add a **new entry under
+        `games/<name>/`**. Before opening, please skim
+        [CONTRIBUTING.md → "Adding a new game"](https://github.com/espenhk/gamer-ai/blob/main/CONTRIBUTING.md#adding-a-new-game)
+        so we share vocabulary on the adapter / env / reward split.
+
+  - type: input
+    id: game
+    attributes:
+      label: Game / simulator name
+      placeholder: "Rocket League (via RLGym)"
+    validations:
+      required: true
+
+  - type: input
+    id: link
+    attributes:
+      label: Primary upstream link
+      description: Game website, Steam page, or open-source repo we'd integrate against.
+      placeholder: "https://rlgym.org"
+    validations:
+      required: true
+
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is this a good fit?
+      description: |
+        One paragraph each:
+        - What kind of task does this give us (racing, RTS, FPS, control, …)?
+        - Does it fill a gap in our current game roster?
+        - Is there a known RL benchmark / paper that uses it?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Required runtime platforms
+      multiple: true
+      options:
+        - Linux
+        - Windows
+        - macOS
+        - Headless server (no GPU window)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: openness
+    attributes:
+      label: License / openness
+      options:
+        - Open-source (free to redistribute)
+        - Free but proprietary (e.g. free download, no redistribution)
+        - Paid commercial (user must buy / own)
+        - Unclear
+    validations:
+      required: true
+
+  - type: textarea
+    id: interface
+    attributes:
+      label: How does the agent talk to the game?
+      description: TCP API, shared memory, screen capture, Gymnasium env, native Python bindings, IPC, replay file, …?
+      placeholder: "RLGym exposes a Gymnasium-compatible `make()` that wraps Bakkesmod+RLGym sockets."
+    validations:
+      required: true
+
+  - type: textarea
+    id: obs_action
+    attributes:
+      label: Proposed observation + action spaces
+      description: A sketch is fine — full schema goes in the PR. List the obs features and whether the action is continuous (Box) or discrete.
+      placeholder: |
+        Observation (~22 floats): car xyz, velocity, ball xyz, ball velocity, …
+        Action: Box([-1,-1,0,0,0,0,0], [1,1,1,1,1,1,1]) — throttle, steer, pitch, yaw, roll, jump, boost.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reward
+    attributes:
+      label: Reward signal
+      description: What does success look like? Sparse (win/lose only), dense (per-step score delta), or both? Note any quirks (e.g. team-based, multi-agent).
+    validations:
+      required: true
+
+  - type: textarea
+    id: complexity
+    attributes:
+      label: Expected complexity
+      description: |
+        Rough estimate — adapter + env + reward + obs_spec + tests is the bare minimum. Does this need:
+        - new policy types (e.g. spatial CNN, multi-agent)?
+        - new observation features in `framework/obs_spec.py`?
+        - custom analytics?
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-flight checks
+      options:
+        - label: I checked the [game support roadmap issues](https://github.com/espenhk/gamer-ai/issues?q=is%3Aissue+label%3Agame-support) and this isn't already proposed.
+          required: true
+        - label: I (or someone I know) actually owns / can run the game required for development.
+          required: false
+        - label: I'd be willing to implement at least the adapter + env skeleton if scoped.
+          required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -39,8 +39,12 @@ Closes #
      more useful than "looks good". Paste commands you ran. -->
 
 ```
-# e.g.
-poetry run python -m pytest tests/
+# e.g. — same unit-test command CI runs:
+PYTHONPATH=. poetry run python -m pytest tests/ \
+    --ignore=tests/test_env_termination.py \
+    --ignore=tests/test_grid_search.py \
+    --ignore=tests/integration/
+
 python main.py smoke_test --game car_racing --no-interrupt
 ```
 
@@ -55,7 +59,7 @@ python main.py smoke_test --game car_racing --no-interrupt
 ### Tests
 
 - [ ] Added or updated unit tests for new logic (`tests/`)
-- [ ] `poetry run python -m pytest tests/` passes locally
+- [ ] Cross-platform unit tests pass locally (`PYTHONPATH=. poetry run python -m pytest tests/ --ignore=tests/test_env_termination.py --ignore=tests/test_grid_search.py --ignore=tests/integration/`) — same command the `Tests / test` CI job runs
 - [ ] For game-specific changes: ran at least one short end-to-end training run (`python main.py …`) and confirmed it doesn't crash
 - [ ] For integration-test-eligible changes (CarRacing / SC2): integration tests are green or there is a clear reason they're skipped
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,85 @@
+<!--
+Thanks for sending a PR! A few quick things before you click "Create":
+
+  - Keep the title short (≤ 70 chars). Use the body for detail.
+  - Link the issue this PR closes (e.g. "Closes #123").
+  - Tick the checklist below honestly — unchecked boxes are fine, they
+    just tell the reviewer what's still missing.
+-->
+
+## Summary
+
+<!-- 1–3 bullet points: what changed and why. Focus on the "why". -->
+
+-
+-
+
+## Related issues
+
+<!-- "Closes #123", "Refs #456". Use "Closes" so the issue auto-closes on merge. -->
+
+Closes #
+
+## Type of change
+
+<!-- Tick whichever apply. -->
+
+- [ ] Bug fix
+- [ ] New feature (no breaking change)
+- [ ] Breaking change (existing behaviour or API changes)
+- [ ] New game integration (`games/<name>/`)
+- [ ] New policy / algorithm
+- [ ] Documentation only
+- [ ] Refactor / internal cleanup
+- [ ] Infrastructure / CI
+
+## How was this tested?
+
+<!-- Be specific. "Ran the training loop for N sims on game X" is much
+     more useful than "looks good". Paste commands you ran. -->
+
+```
+# e.g.
+poetry run python -m pytest tests/
+python main.py smoke_test --game car_racing --no-interrupt
+```
+
+## Checklist
+
+### Code quality
+
+- [ ] Changes are scoped to the issue — no unrelated refactors mixed in
+- [ ] New / changed code follows the surrounding style (no `print` debug noise, no dead code, no commented-out blocks)
+- [ ] No accidentally-committed secrets, `.env` files, large binaries, or experiment output under `experiments/`
+
+### Tests
+
+- [ ] Added or updated unit tests for new logic (`tests/`)
+- [ ] `poetry run python -m pytest tests/` passes locally
+- [ ] For game-specific changes: ran at least one short end-to-end training run (`python main.py …`) and confirmed it doesn't crash
+- [ ] For integration-test-eligible changes (CarRacing / SC2): integration tests are green or there is a clear reason they're skipped
+
+### Documentation
+
+- [ ] Updated `README.md` if user-visible behaviour, install steps, or CLI flags changed
+- [ ] Updated `CLAUDE.md` if architecture, config knobs, or training-loop semantics changed
+- [ ] Updated the relevant `games/<name>/README.md` for per-game changes
+- [ ] Updated `tests/README.md` if tests were added, removed, or substantially changed (required by the repo's test-suite contract)
+- [ ] New config keys appear in the relevant `config/*.yaml` master file with a sensible default
+
+### Review
+
+- [ ] Self-reviewed the diff at least once before requesting review
+- [ ] Happy for an AI code review (e.g. `/ultrareview` or an automated reviewer) to run on this PR
+- [ ] Marked the PR as draft if it isn't ready for human review yet
+
+## Screenshots / plots (optional)
+
+<!-- For training-loop, reward, or analytics changes: drop in the
+     before/after plots from experiments/<...>/results/. -->
+
+## Notes for the reviewer
+
+<!-- Anything that would save the reviewer time: known limitations,
+     follow-up work, parts of the diff that look weird but are
+     intentional, etc. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,13 +90,20 @@ tests need.
 
 ### Smoke test
 
+Run the same command CI runs so you don't get blocked by tests that need
+optional binaries (TMInterface, SC2, Box2D):
+
 ```bash
-poetry run python -m pytest tests/
+PYTHONPATH=. poetry run python -m pytest tests/ \
+    --ignore=tests/test_env_termination.py \
+    --ignore=tests/test_grid_search.py \
+    --ignore=tests/integration/
 ```
 
-You should get a green run in well under a minute. If a handful of tests
-are skipped, that's normal — some integration suites require optional
-binaries (SC2, Box2D).
+You should get a green run in well under a minute. The ignored top-level
+files import `tminterface` (Windows-only); `tests/integration/` needs
+either `gymnasium[box2d]` or the SC2 binary. On a fully-provisioned
+Windows dev box you can drop the `--ignore` flags to run the full suite.
 
 ---
 
@@ -107,8 +114,9 @@ Practically:
 
 | Command | What it runs |
 |---|---|
-| `poetry run python -m pytest tests/` | Full unit-test suite, excluding integration. |
-| `poetry run python -m pytest tests/integration/ -m integration` | Integration tests (need `gymnasium[box2d]` for CarRacing, the SC2 binary for SC2). |
+| `PYTHONPATH=. poetry run python -m pytest tests/ --ignore=tests/test_env_termination.py --ignore=tests/test_grid_search.py --ignore=tests/integration/` | Cross-platform unit-test suite — same set of files the `Tests / test` CI job runs. The two ignored top-level files import `tminterface` (Windows-only); `tests/integration/` needs optional binaries. |
+| `poetry run python -m pytest tests/` | Full suite. Only green if you've installed the `tmnf` group on Windows **and** the integration extras (`gymnasium[box2d]`, SC2 binary). Skip this unless you're on a fully-provisioned dev box. |
+| `poetry run python -m pytest tests/integration/ -m integration` | Integration tests on their own (need `gymnasium[box2d]` for CarRacing, the SC2 binary for SC2). |
 | `poetry run python -m pytest tests/test_<area>.py -v` | Focus a single area. |
 | `python main.py smoke --game car_racing --no-interrupt` | End-to-end smoke run that doesn't need any external binary. Great for spot-checking framework changes. |
 
@@ -280,8 +288,16 @@ PR review *will* push back if any of these are out of date.
    `add-rocket-league-game`, `fix-sc2-replay-overwrite`, etc.
 2. **Make small, focused commits**. A bug fix and an unrelated refactor
    should be two PRs.
-3. **Run `poetry run python -m pytest tests/` locally** before opening
-   the PR.
+3. **Run the unit tests locally** before opening the PR, using the same
+   command CI runs so you get the same result:
+   ```bash
+   PYTHONPATH=. poetry run python -m pytest tests/ \
+       --ignore=tests/test_env_termination.py \
+       --ignore=tests/test_grid_search.py \
+       --ignore=tests/integration/
+   ```
+   If you're on a fully-provisioned Windows dev box with `tminterface`
+   installed, drop the `--ignore` flags to run the full suite.
 4. **Open the PR against `main`**. The
    [PR template](.github/PULL_REQUEST_TEMPLATE.md) has a checklist —
    tick what applies, leave the rest unticked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,331 @@
+# Contributing to gamer-ai
+
+Thanks for thinking about contributing! `gamer-ai` started as a Trackmania
+Nations Forever experiment and has grown into a small multi-game RL
+framework — TMNF, TORCS, StarCraft 2, BeamNG, Assetto Corsa, and
+Gymnasium's CarRacing all share the same training loop today, and the
+explicit goal is to keep adding games.
+
+This document covers:
+
+- [Code of conduct](#code-of-conduct)
+- [Ways to contribute](#ways-to-contribute)
+- [Getting set up](#getting-set-up)
+- [Running tests](#running-tests)
+- [Project layout (the short version)](#project-layout-the-short-version)
+- [Adding a new game](#adding-a-new-game)
+- [Adding a new policy / algorithm](#adding-a-new-policy--algorithm)
+- [Coding conventions](#coding-conventions)
+- [Documentation conventions](#documentation-conventions)
+- [Submitting a pull request](#submitting-a-pull-request)
+- [Reporting bugs and proposing features](#reporting-bugs-and-proposing-features)
+- [License](#license)
+
+---
+
+## Code of conduct
+
+Be kind, be specific, assume good faith. We're a small project — disagreements
+should be technical, not personal. Harassment, personal attacks, or
+discriminatory language are not welcome and will get you removed from the
+project.
+
+---
+
+## Ways to contribute
+
+You don't have to write code to help:
+
+- **Try a game integration** that already exists, file bugs about the
+  rough edges, and share your training plots.
+- **Improve documentation** — every `README.md` (root + `games/<name>/`)
+  is fair game, and "this section confused me" is a real bug.
+- **Propose a new game** via the
+  [New game integration](.github/ISSUE_TEMPLATE/game_support.yml) issue
+  template. Even if you can't implement it, a well-scoped proposal is
+  often the hardest part.
+- **Pick up a "good first issue"** — these are tagged in the
+  [issue tracker](https://github.com/espenhk/gamer-ai/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22).
+- **Tighten the framework** — e.g. add a new policy, a new analytics view,
+  or improve the distributed coordinator.
+- **Write tests** for areas the `tests/README.md` "what isn't tested"
+  paragraphs admit are thin.
+
+---
+
+## Getting set up
+
+### Prerequisites
+
+- **Python 3.11+** and **Poetry** (≥ 1.7).
+- A working `git`.
+- Platform notes:
+  - **TMNF** training is Windows-only (TMInterface attaches to the live
+    game process). You can still work on the framework or other games
+    from Linux / macOS.
+  - **TORCS / SC2 / CarRacing** all work on Linux. SC2 has a headless
+    Linux binary; CarRacing needs no external binary at all.
+  - **BeamNG / Assetto Corsa** are Windows-only games but their Python
+    wrappers can be imported (and unit-tested) anywhere.
+
+### Clone and install
+
+```bash
+git clone https://github.com/espenhk/gamer-ai.git
+cd gamer-ai
+
+# Cross-platform dev install — enough to run the unit tests on any OS:
+poetry install --with tmnf-test
+
+# Add the game-specific groups you'll actually use:
+poetry install --with tmnf-test,sc2          # Linux/macOS SC2 work
+poetry install --with tmnf-test,torcs        # TORCS work
+poetry install --with tmnf,tmnf-test         # full TMNF on Windows
+```
+
+If `poetry install --with tmnf` fails on Linux with `pywin32` / `mss` /
+`tminterface` errors, that's expected — install `tmnf-test` instead. The
+`tmnf-test` group pulls only the cross-platform dependencies the unit
+tests need.
+
+### Smoke test
+
+```bash
+poetry run python -m pytest tests/
+```
+
+You should get a green run in well under a minute. If a handful of tests
+are skipped, that's normal — some integration suites require optional
+binaries (SC2, Box2D).
+
+---
+
+## Running tests
+
+The CI pipelines under `.github/workflows/` are the source of truth.
+Practically:
+
+| Command | What it runs |
+|---|---|
+| `poetry run python -m pytest tests/` | Full unit-test suite, excluding integration. |
+| `poetry run python -m pytest tests/integration/ -m integration` | Integration tests (need `gymnasium[box2d]` for CarRacing, the SC2 binary for SC2). |
+| `poetry run python -m pytest tests/test_<area>.py -v` | Focus a single area. |
+| `python main.py smoke --game car_racing --no-interrupt` | End-to-end smoke run that doesn't need any external binary. Great for spot-checking framework changes. |
+
+### Test-suite contract
+
+`tests/README.md` documents every test (one line each, grouped by area)
+plus per-area "what is and isn't tested" paragraphs. **When you add,
+remove, or substantially change tests, update `tests/README.md` in the
+same PR.** This is checked in review.
+
+---
+
+## Project layout (the short version)
+
+```
+gamer-ai/
+├── main.py                 # Entry point — python main.py <experiment> [--game <name>]
+├── framework/              # Game-agnostic training loop, base env, base policies, analytics
+├── games/
+│   ├── tmnf/               # Trackmania Nations Forever (primary)
+│   ├── torcs/              # TORCS (open-source racing)
+│   ├── sc2/                # StarCraft 2 (PySC2)
+│   ├── beamng/             # BeamNG.drive
+│   ├── assetto_corsa/      # Assetto Corsa
+│   └── car_racing/         # Gymnasium CarRacing-v2 (no binary)
+├── distributed/            # HTTP coordinator + worker for multi-machine grid search
+├── infrastructure/         # Terraform stack for Azure worker VMs
+├── config/                 # Master training_params.yaml / reward_config.yaml templates
+├── tests/                  # Pytest suite — see tests/README.md
+├── README.md               # User-facing setup + run guide
+├── CLAUDE.md               # Architecture-level docs (the source of truth for design)
+└── CONTRIBUTING.md         # This file
+```
+
+The deep dive lives in `CLAUDE.md` (architecture, observation specs,
+policy taxonomy, reward knobs, threading model). When user-visible
+behaviour changes, update `README.md`; when architecture changes,
+update `CLAUDE.md`.
+
+---
+
+## Adding a new game
+
+A new game lives entirely under `games/<name>/` and plugs into the
+framework through a single `GameAdapter`. The pattern is the same for
+every game in the repo — `games/car_racing/` is the smallest reference
+implementation; copy it as a starting point.
+
+### What you need to implement
+
+| File | Role |
+|---|---|
+| `games/<name>/adapter.py` | Implements `framework.game_adapter.GameAdapter`. Wires the game-specific objects below into the framework. Must expose `make_adapter()`. |
+| `games/<name>/env.py` | `gymnasium.Env` subclass. Resets the game, steps it, returns `(obs, reward, terminated, truncated, info)`. |
+| `games/<name>/obs_spec.py` | Module-level constant describing the flat observation vector (names + scales). Used for normalisation, analytics labels, and weight-file migration. |
+| `games/<name>/actions.py` | `DISCRETE_ACTIONS` — the list of discrete action tuples that tabular policies can pick from. |
+| `games/<name>/reward.py` | `RewardCalculator` + `RewardConfig` for the game. |
+| `games/<name>/analytics.py` | `save_experiment_results(...)` — at minimum produce a `results.md` and a reward-over-time plot. |
+| `games/<name>/config/training_params.yaml` | Master training params copied into each new experiment. |
+| `games/<name>/config/reward_config.yaml` | Master reward weights copied into each new experiment. |
+| `games/<name>/README.md` | Per-game user-facing README — install, run, obs/action/reward tables. |
+
+Then register the adapter in `framework/game_adapter.GAME_ADAPTERS` and
+add `<name>` to the `--game` choices in `main.py`.
+
+### Step-by-step
+
+1. **Open a [new-game-integration issue](.github/ISSUE_TEMPLATE/game_support.yml)
+   first** so we can agree on scope before code lands. The template asks
+   the questions we need: licensing, platform, obs/action sketch, reward.
+2. **Copy `games/car_racing/` to `games/<name>/`** and rename the
+   `CarRacingAdapter` class. Strip out anything that doesn't apply.
+3. **Stand up `env.py`** so `env.reset()` / `env.step(action)` work
+   against the real game. Keep imports of the game's SDK *inside*
+   functions / methods, not at module top — Linux CI imports the
+   module to run lazy unit tests, and a hard import of a Windows-only
+   SDK breaks that. (See `games/assetto_corsa/clients/ac_client.py`
+   for the pattern.)
+4. **Pin the observation spec** in `obs_spec.py`. Every feature gets a
+   name and a scale; the framework divides the raw value by the scale
+   before handing it to a policy. Aim for normalised values roughly in
+   `[-1, 1]`.
+5. **Write `reward.py`** with a `RewardCalculator(reward_cfg, ...)` that
+   exposes a `compute(state, prev_state)` (or similar) method. Default
+   knobs go in `reward_config.yaml`.
+6. **Hook up `adapter.py`** — fill in `experiment_dir`, `build_game_spec`,
+   `build_probe`, `build_warmup`, `build_extras` as needed.
+7. **Register** in `framework/game_adapter.py` and `main.py`.
+8. **Add tests** under `tests/test_<name>_<area>.py`. The minimum set is:
+   - `test_<name>_obs_spec.py` — round-trip a state through your obs
+     extractor and check shapes / scales.
+   - `test_<name>_reward.py` — feed canned state deltas through the
+     reward calc and assert the expected signs.
+   - `test_<name>_env.py` — instantiate `make_env()` with a mock client
+     and step it a few times.
+   - Update `tests/README.md` to describe each new test.
+9. **Add a section** to your new `games/<name>/README.md` and link it
+   from the root `README.md`'s `--game` table.
+10. **Optionally** add an integration job to
+    `.github/workflows/integration-tests.yml` if the game has a free,
+    headless way to run end-to-end.
+
+### What "done" looks like
+
+- `python main.py smoke --game <name> --no-interrupt` finishes a short
+  run without crashing.
+- `poetry run python -m pytest tests/test_<name>_*.py -v` is green.
+- Reward-over-time plot under
+  `experiments/<name>/smoke/results/` shows non-trivial learning (even a
+  flat curve is fine for the smoke run — we're checking the pipe, not
+  the algorithm).
+
+---
+
+## Adding a new policy / algorithm
+
+Policies live in `framework/policies.py` (game-agnostic) or under
+`games/<name>/` (game-specific, e.g. `sc2_genetic`). Every policy
+inherits from `BasePolicy` and implements:
+
+- `act(obs)` — pick an action given a normalised observation vector.
+- `update(...)` — for trainable policies; no-op for hand-coded baselines.
+- `save(path)` / `load(path)` — YAML for linear / tabular policies,
+  numpy `.npz` for neural / LSTM / CNN.
+
+Add the new `policy_type` string to `CLAUDE.md`'s policy table, update
+the `README.md` policy table if it's game-agnostic, and ship at least
+one test under `tests/test_<policy>_policy.py`.
+
+---
+
+## Coding conventions
+
+- **Python 3.11+**, `from __future__ import annotations`, type hints on
+  public functions.
+- **Numpy-first**: pure numpy is preferred for new tabular / linear /
+  small-network policies — keeps installs lean and CI fast.
+- **No `print` for diagnostics** — use `logging.getLogger(__name__)`.
+- **No dead code, no commented-out blocks, no TODO without an issue
+  number**.
+- **Comments**: write the *why*, not the *what*. Don't restate the code
+  in prose. Only add a comment when a future reader would otherwise be
+  surprised.
+- **Imports**: heavy / OS-specific imports go inside the function that
+  needs them, so cross-platform CI can import the module without
+  pulling in `pywin32` / `tminterface` / `pysc2`.
+
+---
+
+## Documentation conventions
+
+When you change code, ask which of these need to follow:
+
+| Change | Update |
+|---|---|
+| New / changed CLI flag, config key, or install step | `README.md` + relevant `games/<name>/README.md` |
+| New training-loop semantics, observation features, or policy | `CLAUDE.md` |
+| New / removed / substantially-changed tests | `tests/README.md` |
+| New game | New `games/<name>/README.md` + entry in root `README.md` `--game` table |
+| New infrastructure / terraform change | `infrastructure/README.md` |
+
+PR review *will* push back if any of these are out of date.
+
+---
+
+## Submitting a pull request
+
+1. **Branch off `main`** with a descriptive name —
+   `add-rocket-league-game`, `fix-sc2-replay-overwrite`, etc.
+2. **Make small, focused commits**. A bug fix and an unrelated refactor
+   should be two PRs.
+3. **Run `poetry run python -m pytest tests/` locally** before opening
+   the PR.
+4. **Open the PR against `main`**. The
+   [PR template](.github/PULL_REQUEST_TEMPLATE.md) has a checklist —
+   tick what applies, leave the rest unticked.
+5. **CI gates**:
+   - `Tests / test` (the unit-test workflow) runs on every PR.
+   - `Integration Tests / car-racing` / `sc2` run after an approving
+     review, and only if files in their watched paths changed.
+6. **Welcome AI review**. The PR template includes a checkbox asking
+   if you're happy for an automated reviewer (e.g. `/ultrareview`) to
+   run on the PR. This is opt-in.
+7. **Address review comments** in new commits (don't force-push over an
+   in-progress review unless asked — it makes re-review harder).
+8. **Squash on merge** — keep `main` linear.
+
+### What the reviewer is looking for
+
+- The change does what the issue / PR description says, and nothing
+  more.
+- New code has tests, and `tests/README.md` reflects them.
+- Docs match the new behaviour.
+- No accidental commits of secrets, large binaries, or experiment
+  outputs.
+
+---
+
+## Reporting bugs and proposing features
+
+Use the issue templates — they ask for the information we actually need:
+
+- [Bug report](.github/ISSUE_TEMPLATE/bug_report.yml) — for crashes,
+  regressions, wrong outputs.
+- [Feature request](.github/ISSUE_TEMPLATE/feature_request.yml) — for
+  framework / policy / analytics / DX improvements.
+- [New game integration](.github/ISSUE_TEMPLATE/game_support.yml) — for
+  proposing a new entry under `games/<name>/`.
+
+For open-ended "should we do X?" threads, prefer
+[GitHub Discussions](https://github.com/espenhk/gamer-ai/discussions)
+over an issue.
+
+---
+
+## License
+
+By contributing you agree your contributions will be licensed under the
+MIT License, the same license that covers the rest of the project (see
+[LICENSE](LICENSE)).

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A reinforcement-learning agent that drives Trackmania Nations Forever autonomously. It offers a menu of training algorithms — hill-climbing, neural-net mutate-and-keep, tabular Q-learning, MCTS, a genetic algorithm, and CMA-ES — all trained live against TMInterface against the reference track A03. See [`CLAUDE.md`](CLAUDE.md) for the full architecture documentation.
 
+> **Contributing?** Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) — it covers setup, the test contract, the walkthrough for adding a new game, and the PR review flow. New game proposals go through the [New game integration issue template](.github/ISSUE_TEMPLATE/game_support.yml).
+
 --- [TMNF — Trackmania Nations Forever RL](#tmnf--trackmania-nations-forever-rl)
 - [Prerequisites](#prerequisites)
 - [Installation](#installation)


### PR DESCRIPTION
## Summary

- Adds `CONTRIBUTING.md` with setup, the unit/integration test contract, and a step-by-step "Adding a new game" walkthrough grounded in the existing `GameAdapter` + env + reward + obs_spec split that `games/car_racing/` already demonstrates.
- Adds `.github/PULL_REQUEST_TEMPLATE.md` — checklist covers documentation updates (`README.md` / `CLAUDE.md` / per-game READMEs / `tests/README.md`), test runs, and opt-in AI code review.
- Adds three structured issue forms under `.github/ISSUE_TEMPLATE/`: bug report, feature request, and a dedicated **new-game-integration** template that captures licensing, platform, observation/action sketch, and reward signal up front.
- Points the root README at `CONTRIBUTING.md` so contributors find it first.

## Related issues

The accompanying issues filed against this branch's work:

- Game support proposals: Rocket League (RLGym), MineRL / Minecraft, Gymnasium classic-control + MuJoCo, Atari / retro via stable-retro, iRacing.
- Contribution scaffolding: `games/_template/` skeleton, framework-protocol docs, pre-commit config, triage labels + good-first-issue backlog.

## Test plan

- [x] `git status` clean, branch pushed to `claude/add-contribution-templates-e3IHE`
- [ ] Issue templates render correctly on the GitHub "New issue" page (visual check after merge)
- [ ] PR template appears on the next PR opened against this branch (this PR is the first sanity check)
- [ ] `CONTRIBUTING.md` table of contents anchors resolve in GitHub's rendered view

## Notes for the reviewer

- The new-game template asks for licensing / platform / obs+action / reward up front because those are the four questions that have repeatedly stalled past game-integration discussions.
- The PR template's "AI review" checkbox is opt-in — leaving it unchecked is fine and signals "human review only".
- I did **not** add a `.pre-commit-config.yaml` here; that's its own issue and PR so the diff stays focused.
- I did **not** rename `pyproject.toml`'s `name` from `espenhk/tmnf-ai` to `gamer-ai`; that's a separate cosmetic change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpbRoEaQBN4YsiytbLWaw5)_