### PR TITLE
Extract core RL algorithms to framework/ for game-agnostic reuse

### DIFF
--- a/framework/cmaes.py
+++ b/framework/cmaes.py
@@ -1,0 +1,431 @@
+"""Generic (μ/μ_w, λ)-CMA-ES for reinforcement learning.
+
+CMAESDistribution — pure-math CMA-ES distribution (Hansen 2016).
+                    Operates on flat float64 parameter vectors; knows nothing
+                    about observation spaces or policy representations.
+
+CMAESPolicy       — wraps CMAESDistribution with a *policy_factory* callable
+                    that converts flat vectors to evaluable policy objects.
+                    Exposes the same interface as ``_greedy_loop_cmaes``
+                    expects: ``sample_population()``, ``update_distribution()``,
+                    ``save()``, ``save_trainer_state()``, ``load_trainer_state()``,
+                    ``champion_reward``, ``sigma``, ``population_size``,
+                    ``to_cfg()``.
+"""
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Callable, TypeVar
+
+import numpy as np
+
+from framework.obs_spec import ObsSpec
+from framework.policies import BasePolicy
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+# --------------------------------------------------------------------------- #
+# CMAESDistribution                                                            #
+# --------------------------------------------------------------------------- #
+
+class CMAESDistribution:
+    """(μ/μ_w, λ)-CMA-ES distribution over *n*-dimensional parameter vectors.
+
+    Implements step-size adaptation via CSA and full covariance adaptation via
+    the rank-1 + rank-μ update (Hansen 2016, Section 3).
+
+    Parameters
+    ----------
+    n :
+        Dimensionality of the parameter space.
+    population_size :
+        λ — offspring sampled per generation.
+    initial_sigma :
+        Starting step size σ₀.
+    seed :
+        Optional RNG seed for reproducibility.
+    """
+
+    def __init__(
+        self,
+        n: int,
+        *,
+        population_size: int = 20,
+        initial_sigma: float = 0.3,
+        seed: int | None = None,
+    ) -> None:
+        self._n   = int(n)
+        self._lam = int(population_size)
+
+        mu            = self._lam // 2
+        self._mu      = mu
+        raw_w         = np.array(
+            [np.log(mu + 0.5) - np.log(i + 1) for i in range(mu)],
+            dtype=np.float64,
+        )
+        self._weights = raw_w / raw_w.sum()
+        self._mu_eff  = 1.0 / float(np.sum(self._weights ** 2))
+
+        # Step-size adaptation constants (Hansen 2016, S3)
+        self._cs   = (self._mu_eff + 2) / (n + self._mu_eff + 5)
+        self._ds   = (
+            1 + 2 * max(0.0, float(np.sqrt((self._mu_eff - 1) / (n + 1))) - 1)
+            + self._cs
+        )
+        self._chin = float(
+            np.sqrt(n) * (1 - 1.0 / (4 * n) + 1.0 / (21 * n ** 2))
+        )
+
+        # Covariance adaptation constants
+        self._cc  = (4 + self._mu_eff / n) / (n + 4 + 2 * self._mu_eff / n)
+        self._c1  = 2.0 / ((n + 1.3) ** 2 + self._mu_eff)
+        self._cmu = min(
+            1.0 - self._c1,
+            2.0 * (self._mu_eff - 2 + 1.0 / self._mu_eff)
+            / ((n + 2) ** 2 + self._mu_eff),
+        )
+
+        self._rng = np.random.default_rng(seed)
+
+        # Distribution state (float64 for numerical stability)
+        self._mean     = self._rng.standard_normal(n).astype(np.float64)
+        self._sigma    = float(initial_sigma)
+        self._ps       = np.zeros(n, dtype=np.float64)
+        self._pc       = np.zeros(n, dtype=np.float64)
+        self._C        = np.eye(n, dtype=np.float64)
+        self._B        = np.eye(n, dtype=np.float64)
+        self._D        = np.ones(n, dtype=np.float64)
+        self._invsqrtC = np.eye(n, dtype=np.float64)
+        self._eigengen = 0
+        self._gen      = 0
+
+        self._pop_xs: list[np.ndarray] = []
+        self._pop_ys: list[np.ndarray] = []
+
+    def initialize_random(self) -> None:
+        """Set the search mean to zero (CMA-ES adapts scale via σ)."""
+        self._mean = np.zeros(self._n, dtype=np.float64)
+        logger.info("[CMAESDistribution] initialised with zero mean, sigma=%.3f", self._sigma)
+
+    def _update_eigen(self) -> None:
+        self._C = np.triu(self._C) + np.triu(self._C, 1).T
+        eigvals, self._B = np.linalg.eigh(self._C)
+        eigvals          = np.maximum(eigvals, 1e-20)
+        self._D          = np.sqrt(eigvals)
+        self._invsqrtC   = self._B @ np.diag(1.0 / self._D) @ self._B.T
+        self._eigengen   = self._gen
+
+    def sample(self) -> list[np.ndarray]:
+        """Sample λ offspring from N(mean, σ² · C). Returns flat parameter vectors."""
+        n = self._n
+        if self._gen - self._eigengen >= max(1, self._lam // max(1, 10 * n)):
+            self._update_eigen()
+
+        self._pop_xs = []
+        self._pop_ys = []
+        for _ in range(self._lam):
+            z = self._rng.standard_normal(n)
+            y = self._B @ (self._D * z)
+            x = self._mean + self._sigma * y
+            self._pop_xs.append(x)
+            self._pop_ys.append(y)
+        return list(self._pop_xs)
+
+    def update(self, rewards: list[float]) -> tuple[bool, int | None]:
+        """Apply (μ/μ_w, λ)-CMA-ES update.
+
+        Returns ``(improved, best_idx)`` where ``improved`` is True when the
+        best-seen reward increased and ``best_idx`` is the index of the best
+        offspring (or None if no improvement).
+        """
+        if len(rewards) != self._lam:
+            raise ValueError(f"Expected {self._lam} rewards, got {len(rewards)}")
+        if len(self._pop_xs) != self._lam or len(self._pop_ys) != self._lam:
+            raise RuntimeError(
+                "update() called before a matching sample(). "
+                f"Expected {self._lam} samples in _pop_xs/_pop_ys, "
+                f"got {len(self._pop_xs)}/{len(self._pop_ys)}. "
+                "Call sample() first."
+            )
+        n     = self._n
+        order = np.argsort(rewards)[::-1]
+
+        best_idx  = int(order[0])
+        best_r    = float(rewards[best_idx])
+
+        elite_ys  = np.stack([self._pop_ys[order[i]] for i in range(self._mu)])
+        step      = np.einsum("i,ij->j", self._weights, elite_ys)
+
+        self._mean = self._mean + self._sigma * step
+
+        ps_scale  = float(np.sqrt(self._cs * (2 - self._cs) * self._mu_eff))
+        self._ps  = (1 - self._cs) * self._ps + ps_scale * (self._invsqrtC @ step)
+
+        ps_norm     = float(np.linalg.norm(self._ps))
+        self._sigma = float(np.clip(
+            self._sigma * np.exp((self._cs / self._ds) * (ps_norm / self._chin - 1)),
+            1e-10, 1e6,
+        ))
+
+        ps_norm_normed = ps_norm / float(
+            np.sqrt(1 - (1 - self._cs) ** (2 * (self._gen + 1)))
+        )
+        h_sigma  = 1.0 if ps_norm_normed < (1.4 + 2.0 / (n + 1)) * self._chin else 0.0
+        pc_scale = float(np.sqrt(self._cc * (2 - self._cc) * self._mu_eff))
+        self._pc = (1 - self._cc) * self._pc + h_sigma * pc_scale * step
+
+        delta_h = (1 - h_sigma) * self._cc * (2 - self._cc)
+        rank1   = np.outer(self._pc, self._pc)
+        rank_mu = np.einsum("i,ij,ik->jk", self._weights, elite_ys, elite_ys)
+        self._C = (
+            (1 - self._c1 - self._cmu) * self._C
+            + self._c1 * (rank1 + delta_h * self._C)
+            + self._cmu * rank_mu
+        )
+
+        self._gen += 1
+        return best_r, best_idx
+
+    def save_state(self, path: str) -> None:
+        """Persist full distribution state to an .npz file."""
+        np.savez(
+            path,
+            mean     = self._mean,
+            sigma    = np.float64(self._sigma),
+            C        = self._C,
+            B        = self._B,
+            D        = self._D,
+            invsqrtC = self._invsqrtC,
+            ps       = self._ps,
+            pc       = self._pc,
+            gen      = np.int64(self._gen),
+            n        = np.int64(self._n),
+        )
+
+    def load_state(self, path: str) -> None:
+        """Restore distribution state from an .npz file.
+
+        Raises ValueError if the saved dimension does not match.
+        """
+        with np.load(path) as data:
+            n_saved = int(data["n"])
+            if n_saved != self._n:
+                raise ValueError(
+                    f"CMAESDistribution: state dimension mismatch — "
+                    f"saved n={n_saved}, current n={self._n}. "
+                    f"Use --re-initialize to restart from scratch."
+                )
+            self._mean     = data["mean"].astype(np.float64)
+            self._sigma    = float(data["sigma"])
+            self._C        = data["C"].astype(np.float64)
+            self._B        = data["B"].astype(np.float64)
+            self._D        = data["D"].astype(np.float64)
+            self._invsqrtC = data["invsqrtC"].astype(np.float64)
+            self._ps       = data["ps"].astype(np.float64)
+            self._pc       = data["pc"].astype(np.float64)
+            self._gen      = int(data["gen"])
+
+
+# --------------------------------------------------------------------------- #
+# CMAESPolicy                                                                  #
+# --------------------------------------------------------------------------- #
+
+class CMAESPolicy(BasePolicy):
+    """(μ/μ_w, λ)-CMA-ES wrapped as a policy compatible with ``_greedy_loop_cmaes``.
+
+    The parameter space is a flat float64 vector of length *n_params*.
+    A *policy_factory* converts each sampled vector to an evaluable policy
+    object (e.g. a ``WeightedLinearPolicy`` for TMNF or an
+    ``SC2MultiHeadLinearPolicy`` for SC2).
+
+    All CMA-ES distribution state is stored in the wrapped
+    :class:`CMAESDistribution` instance; the delegating properties below
+    expose it so downstream test and analytics code can access it unchanged.
+
+    Parameters
+    ----------
+    obs_spec :
+        Observation spec of the target environment (passed through to
+        ``policy_factory``).
+    policy_factory :
+        Callable ``(flat: np.ndarray, obs_spec: ObsSpec) -> policy`` that
+        builds an evaluable policy from a parameter vector.
+    n_params :
+        Dimensionality of the flat parameter vector.
+    population_size :
+        λ — offspring sampled per generation (default 20).
+    initial_sigma :
+        Starting step size σ₀ (default 0.3).
+    eval_episodes :
+        Episodes to average per individual (default 1).
+    seed :
+        Optional RNG seed.
+    """
+
+    def __init__(
+        self,
+        obs_spec: ObsSpec,
+        policy_factory: Callable[[np.ndarray, ObsSpec], Any],
+        n_params: int,
+        *,
+        population_size: int = 20,
+        initial_sigma: float = 0.3,
+        eval_episodes: int = 1,
+        seed: int | None = None,
+    ) -> None:
+        self._obs_spec        = obs_spec
+        self._policy_factory  = policy_factory
+        self._eval_episodes   = max(1, int(eval_episodes))
+        self._dist            = CMAESDistribution(
+            n_params,
+            population_size = population_size,
+            initial_sigma   = initial_sigma,
+            seed            = seed,
+        )
+
+        self._champion        = None
+        self._champion_reward = float("-inf")
+
+    # ------------------------------------------------------------------
+    # Delegating properties — expose distribution internals for tests /
+    # analytics that inspect policy._mean, policy._C, etc.
+    # ------------------------------------------------------------------
+
+    @property
+    def _n(self)        -> int:            return self._dist._n
+    @property
+    def _lam(self)      -> int:            return self._dist._lam
+    @property
+    def _mu(self)       -> int:            return self._dist._mu
+    @property
+    def _weights(self)  -> np.ndarray:     return self._dist._weights
+    @property
+    def _mean(self)     -> np.ndarray:     return self._dist._mean
+    @property
+    def _sigma(self)    -> float:          return self._dist._sigma
+    @property
+    def _C(self)        -> np.ndarray:     return self._dist._C
+    @property
+    def _B(self)        -> np.ndarray:     return self._dist._B
+    @property
+    def _D(self)        -> np.ndarray:     return self._dist._D
+    @property
+    def _invsqrtC(self) -> np.ndarray:     return self._dist._invsqrtC
+    @property
+    def _ps(self)       -> np.ndarray:     return self._dist._ps
+    @property
+    def _pc(self)       -> np.ndarray:     return self._dist._pc
+    @property
+    def _gen(self)      -> int:            return self._dist._gen
+    @property
+    def _pop_xs(self)   -> list:           return self._dist._pop_xs
+    @property
+    def _pop_ys(self)   -> list:           return self._dist._pop_ys
+
+    # ------------------------------------------------------------------
+    # _greedy_loop_cmaes interface
+    # ------------------------------------------------------------------
+
+    @property
+    def population_size(self) -> int:
+        return self._dist._lam
+
+    @property
+    def champion_reward(self) -> float:
+        return self._champion_reward
+
+    @property
+    def sigma(self) -> float:
+        return self._dist._sigma
+
+    def initialize_random(self) -> None:
+        """Seed the search mean at zero."""
+        self._dist.initialize_random()
+
+    def initialize_from_champion(self, champion: Any) -> None:
+        """Seed the search mean from an existing champion's flat weight vector."""
+        self._champion = champion
+
+        seeded_reward: float | None = None
+        for attr_name in ("champion_reward", "reward"):
+            reward_value = getattr(champion, attr_name, None)
+            if reward_value is not None:
+                try:
+                    seeded_reward = float(reward_value)
+                except (TypeError, ValueError):
+                    seeded_reward = None
+                else:
+                    if math.isfinite(seeded_reward):
+                        break
+                    seeded_reward = None
+
+        if seeded_reward is None and math.isfinite(self._champion_reward):
+            seeded_reward = float(self._champion_reward)
+
+        self._champion_reward = seeded_reward if seeded_reward is not None else float("-inf")
+        self._dist._mean = champion.to_flat().astype(np.float64)
+        logger.info(
+            "[CMAESPolicy] seeded mean from champion%s",
+            "" if seeded_reward is None
+            else f" (baseline reward={self._champion_reward:.6f})",
+        )
+
+    def sample_population(self) -> list:
+        """Sample λ offspring. Returns a list of policy objects."""
+        xs = self._dist.sample()
+        return [self._policy_factory(x, self._obs_spec) for x in xs]
+
+    def update_distribution(self, rewards: list[float]) -> bool:
+        """Apply (μ/μ_w, λ)-CMA-ES update. Returns True if champion improved."""
+        best_r, best_idx = self._dist.update(rewards)
+
+        improved = False
+        if best_r > self._champion_reward:
+            self._champion_reward = best_r
+            self._champion = self._policy_factory(
+                self._dist._pop_xs[best_idx], self._obs_spec
+            )
+            improved = True
+
+        return improved
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        if self._champion is None:
+            raise RuntimeError(
+                "CMAESPolicy: no champion yet — call sample_population() and "
+                "update_distribution() for at least one generation first."
+            )
+        return self._champion(obs)
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type":     "cmaes",
+            "population_size": self._dist._lam,
+            "sigma":           float(self._dist._sigma),
+            "n_params":        self._dist._n,
+            "eval_episodes":   self._eval_episodes,
+            "champion_reward": float(self._champion_reward),
+        }
+
+    def save(self, path: str) -> None:
+        """Save champion weights (must implement save())."""
+        if self._champion is not None and hasattr(self._champion, "save"):
+            self._champion.save(path)
+
+    def save_trainer_state(self, path: str) -> None:
+        """Persist full CMA-ES distribution state to an .npz file."""
+        self._dist.save_state(path)
+        logger.debug("[CMAESPolicy] trainer state saved → %s", path)
+
+    def load_trainer_state(self, path: str) -> None:
+        """Restore CMA-ES distribution state from an .npz file.
+
+        Raises ValueError if the saved dimension does not match.
+        """
+        self._dist.load_state(path)
+        logger.info("[CMAESPolicy] trainer state loaded from %s (gen=%d, sigma=%.4f)",
+                    path, self._dist._gen, self._dist._sigma)

--- a/framework/cmaes.py
+++ b/framework/cmaes.py
@@ -135,12 +135,12 @@ class CMAESDistribution:
             self._pop_ys.append(y)
         return list(self._pop_xs)
 
-    def update(self, rewards: list[float]) -> tuple[bool, int | None]:
+    def update(self, rewards: list[float]) -> tuple[float, int]:
         """Apply (μ/μ_w, λ)-CMA-ES update.
 
-        Returns ``(improved, best_idx)`` where ``improved`` is True when the
-        best-seen reward increased and ``best_idx`` is the index of the best
-        offspring (or None if no improvement).
+        Returns ``(best_r, best_idx)`` where ``best_r`` is the highest reward
+        in this generation and ``best_idx`` is that offspring's index in the
+        population list returned by the preceding ``sample()`` call.
         """
         if len(rewards) != self._lam:
             raise ValueError(f"Expected {self._lam} rewards, got {len(rewards)}")

--- a/framework/dqn.py
+++ b/framework/dqn.py
@@ -1,0 +1,472 @@
+"""Generic Deep Q-Network policy.
+
+DQNPolicy — MLP Q-network (pure numpy) with experience replay, target network,
+            and Adam optimiser.  Parameterised on an ObsSpec and a discrete
+            action array so it can be used by any game integration.
+            Optional ``available_actions_fn`` activates action-availability
+            masking (switches internal buffer to MaskedReplayBuffer and masks
+            Q-values before argmax).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+import numpy as np
+
+from framework.obs_spec import ObsSpec
+from framework.policies import BasePolicy
+from framework.replay import MaskedReplayBuffer, ReplayBuffer
+
+logger = logging.getLogger(__name__)
+
+
+class DQNPolicy(BasePolicy):
+    """Deep Q-network with experience replay and a periodically-synced target network.
+
+    Architecture: obs → Linear → ReLU → ... → Linear(n_actions)
+    Pure numpy; Adam optimiser; ε-greedy exploration with linear decay.
+
+    Parameters
+    ----------
+    obs_spec :
+        Observation spec.  Provides ``dim`` (input width) and ``scales``
+        (per-feature normalisation).
+    discrete_actions :
+        Array of shape ``(n_actions, action_dim)``; each row is one action.
+    hidden_sizes :
+        MLP hidden-layer widths (default ``[64, 64]``).
+    replay_buffer_size :
+        Capacity of the circular experience-replay buffer.
+    batch_size :
+        Mini-batch size for gradient steps.
+    min_replay_size :
+        Buffer fill level before gradient steps start.
+    target_update_freq :
+        Gradient steps between target-network syncs.
+    learning_rate :
+        Adam step size.
+    epsilon_start / epsilon_end / epsilon_decay_steps :
+        ε-greedy schedule (linear decay over *epsilon_decay_steps* env steps).
+    gamma :
+        Discount factor.
+    available_actions_fn :
+        Optional callable ``(info: dict) -> np.ndarray[bool]`` of shape
+        ``(n_actions,)``.  When provided, illegal actions are masked to
+        ``-inf`` before greedy selection, random exploration is restricted to
+        legal actions, and the replay buffer stores the mask so the target
+        network never bootstraps through unavailable Q-values.
+    seed :
+        Optional RNG seed for reproducibility.
+    """
+
+    def __init__(
+        self,
+        obs_spec: ObsSpec,
+        discrete_actions: np.ndarray,
+        *,
+        hidden_sizes: list[int] | None = None,
+        replay_buffer_size: int = 10_000,
+        batch_size: int = 64,
+        min_replay_size: int = 500,
+        target_update_freq: int = 200,
+        learning_rate: float = 0.001,
+        epsilon_start: float = 1.0,
+        epsilon_end: float = 0.05,
+        epsilon_decay_steps: int = 5_000,
+        gamma: float = 0.99,
+        available_actions_fn: Callable[[dict], np.ndarray] | None = None,
+        seed: int | None = None,
+    ) -> None:
+        self._obs_spec    = obs_spec
+        self._obs_dim     = obs_spec.dim
+        self._scales      = obs_spec.scales
+        self._actions     = np.array(discrete_actions, dtype=np.float32)
+        self._n_actions   = len(self._actions)
+        self._hidden      = list(hidden_sizes or [64, 64])
+        self._buf_maxlen  = int(replay_buffer_size)
+        self._batch_size  = int(batch_size)
+        self._min_replay  = int(min_replay_size)
+        self._target_freq = int(target_update_freq)
+        self._lr          = float(learning_rate)
+        self._eps_start   = float(epsilon_start)
+        self._eps         = float(epsilon_start)
+        self._eps_end     = float(epsilon_end)
+        self._eps_steps   = int(epsilon_decay_steps)
+        self._eps_delta   = (float(epsilon_start) - float(epsilon_end)) / max(1, int(epsilon_decay_steps))
+        self._gamma       = float(gamma)
+        self._avail_fn    = available_actions_fn
+        self._seed        = seed
+
+        self._masked      = available_actions_fn is not None
+        if self._masked:
+            self._replay: ReplayBuffer = MaskedReplayBuffer(replay_buffer_size, self._n_actions)
+            self._cached_mask = np.ones(self._n_actions, dtype=bool)
+        else:
+            self._replay = ReplayBuffer(replay_buffer_size)
+
+        self._total_steps = 0
+        self._grad_steps  = 0
+
+        self._online = self._build_net()
+        self._target = self._build_net()
+        self._sync_target()
+
+        self._m_w = [np.zeros_like(w) for w in self._online["weights"]]
+        self._m_b = [np.zeros_like(b) for b in self._online["biases"]]
+        self._v_w = [np.zeros_like(w) for w in self._online["weights"]]
+        self._v_b = [np.zeros_like(b) for b in self._online["biases"]]
+        self._adam_t = 0
+
+    # ------------------------------------------------------------------
+    # Construction helpers
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def from_cfg(
+        cls,
+        cfg: dict,
+        obs_spec: ObsSpec,
+        discrete_actions: np.ndarray,
+        available_actions_fn: Callable[[dict], np.ndarray] | None = None,
+    ) -> "DQNPolicy":
+        obj = cls(
+            obs_spec            = obs_spec,
+            discrete_actions    = discrete_actions,
+            hidden_sizes        = cfg.get("hidden_sizes",        [64, 64]),
+            replay_buffer_size  = cfg.get("replay_buffer_size",  10_000),
+            batch_size          = cfg.get("batch_size",          64),
+            min_replay_size     = cfg.get("min_replay_size",     500),
+            target_update_freq  = cfg.get("target_update_freq",  200),
+            learning_rate       = cfg.get("learning_rate",       0.001),
+            epsilon_start       = cfg.get("epsilon_start",       1.0),
+            epsilon_end         = cfg.get("epsilon_end",         0.05),
+            epsilon_decay_steps = cfg.get("epsilon_decay_steps", 5_000),
+            gamma               = cfg.get("gamma",               0.99),
+            available_actions_fn = available_actions_fn,
+            seed                = cfg.get("seed",                None),
+        )
+        if "online_weights" in cfg:
+            required = ["online_weights", "online_biases", "target_weights", "target_biases"]
+            missing  = [k for k in required if k not in cfg]
+            if missing:
+                raise KeyError(f"DQNPolicy.from_cfg: missing keys {missing}")
+
+            loaded_w = [np.array(w, dtype=np.float32) for w in cfg["online_weights"]]
+            if loaded_w[0].shape[1] != obj._obs_dim:
+                raise ValueError(
+                    f"DQNPolicy.from_cfg: weight shape mismatch — "
+                    f"first layer has input dim {loaded_w[0].shape[1]} "
+                    f"but obs_dim is {obj._obs_dim}"
+                )
+            obj._online["weights"] = loaded_w
+            obj._online["biases"]  = [np.array(b, dtype=np.float32) for b in cfg["online_biases"]]
+            obj._target["weights"] = [np.array(w, dtype=np.float32) for w in cfg["target_weights"]]
+            obj._target["biases"]  = [np.array(b, dtype=np.float32) for b in cfg["target_biases"]]
+            obj._eps         = float(cfg.get("epsilon",      obj._eps_end))
+            obj._total_steps = int(cfg.get("total_steps",   0))
+            obj._grad_steps  = int(cfg.get("grad_steps",    0))
+            obj._m_w = [np.zeros_like(w) for w in obj._online["weights"]]
+            obj._m_b = [np.zeros_like(b) for b in obj._online["biases"]]
+            obj._v_w = [np.zeros_like(w) for w in obj._online["weights"]]
+            obj._v_b = [np.zeros_like(b) for b in obj._online["biases"]]
+            logger.info("[DQNPolicy] loaded weights from cfg (eps=%.4f, steps=%d)",
+                        obj._eps, obj._total_steps)
+        return obj
+
+    def _build_net(self) -> dict:
+        rng  = np.random.default_rng(self._seed)
+        dims = [self._obs_dim] + self._hidden + [self._n_actions]
+        weights, biases = [], []
+        for i in range(len(dims) - 1):
+            fan_in = dims[i]
+            w = rng.standard_normal((dims[i + 1], fan_in)).astype(np.float32)
+            w *= np.sqrt(2.0 / fan_in)
+            b = np.zeros(dims[i + 1], dtype=np.float32)
+            weights.append(w)
+            biases.append(b)
+        return {"weights": weights, "biases": biases}
+
+    def _sync_target(self) -> None:
+        self._target["weights"] = [w.copy() for w in self._online["weights"]]
+        self._target["biases"]  = [b.copy() for b in self._online["biases"]]
+
+    # ------------------------------------------------------------------
+    # Forward pass
+    # ------------------------------------------------------------------
+
+    def _forward(self, net: dict, x: np.ndarray) -> tuple[np.ndarray, list, list]:
+        single = x.ndim == 1
+        if single:
+            x = x[np.newaxis, :]
+        h: np.ndarray = x.astype(np.float32)
+        layer_inputs: list[np.ndarray] = []
+        pre_relu:     list[np.ndarray] = []
+        for i, (w, b) in enumerate(zip(net["weights"], net["biases"])):
+            layer_inputs.append(h)
+            z = h @ w.T + b
+            if i < len(net["weights"]) - 1:
+                pre_relu.append(z)
+                h = np.maximum(0.0, z)
+            else:
+                h = z
+        return (h[0] if single else h), layer_inputs, pre_relu
+
+    def _q_values(self, net: dict, obs_norm: np.ndarray) -> np.ndarray:
+        q, _, _ = self._forward(net, obs_norm)
+        return q
+
+    # ------------------------------------------------------------------
+    # Training
+    # ------------------------------------------------------------------
+
+    def _gradient_step(
+        self,
+        obs_b: np.ndarray,
+        act_b: np.ndarray,
+        rew_b: np.ndarray,
+        next_b: np.ndarray,
+        done_b: np.ndarray,
+        mask_b: np.ndarray | None = None,
+    ) -> None:
+        obs_norm  = obs_b  / self._scales
+        next_norm = next_b / self._scales
+        B         = len(act_b)
+
+        q_next = self._q_values(self._target, next_norm)
+        if mask_b is not None:
+            q_next_masked = q_next.copy()
+            q_next_masked[~mask_b] = -np.inf
+            # fall back to unmasked argmax if all masked for a row
+            all_masked = ~mask_b.any(axis=1)
+            if all_masked.any():
+                q_next_masked[all_masked] = q_next[all_masked]
+            targets = rew_b + self._gamma * np.max(q_next_masked, axis=1) * (1.0 - done_b)
+        else:
+            targets = rew_b + self._gamma * np.max(q_next, axis=1) * (1.0 - done_b)
+
+        q_all, layer_inputs, pre_relu = self._forward(self._online, obs_norm)
+
+        grad_out = np.zeros_like(q_all)
+        grad_out[np.arange(B), act_b] = 2.0 * (q_all[np.arange(B), act_b] - targets) / B
+
+        g = grad_out
+        grad_params: list[tuple[np.ndarray, np.ndarray]] = []
+        for i in range(len(self._online["weights"]) - 1, -1, -1):
+            a_in = layer_inputs[i]
+            dW   = g.T @ a_in
+            db   = g.sum(axis=0)
+            grad_params.append((dW, db))
+            if i > 0:
+                g = (g @ self._online["weights"][i]) * (pre_relu[i - 1] > 0)
+        grad_params.reverse()
+
+        self._adam_t += 1
+        t      = self._adam_t
+        b1, b2 = 0.9, 0.999
+        eps_a  = 1e-8
+        for i, (dW, db) in enumerate(grad_params):
+            self._m_w[i] = b1 * self._m_w[i] + (1.0 - b1) * dW
+            self._v_w[i] = b2 * self._v_w[i] + (1.0 - b2) * dW ** 2
+            mw_hat = self._m_w[i] / (1.0 - b1 ** t)
+            vw_hat = self._v_w[i] / (1.0 - b2 ** t)
+            self._online["weights"][i] -= self._lr * mw_hat / (np.sqrt(vw_hat) + eps_a)
+
+            self._m_b[i] = b1 * self._m_b[i] + (1.0 - b1) * db
+            self._v_b[i] = b2 * self._v_b[i] + (1.0 - b2) * db ** 2
+            mb_hat = self._m_b[i] / (1.0 - b1 ** t)
+            vb_hat = self._v_b[i] / (1.0 - b2 ** t)
+            self._online["biases"][i] -= self._lr * mb_hat / (np.sqrt(vb_hat) + eps_a)
+
+        self._grad_steps += 1
+        if self._grad_steps % self._target_freq == 0:
+            self._sync_target()
+            logger.debug("[DQNPolicy] target synced at grad_step %d", self._grad_steps)
+
+    # ------------------------------------------------------------------
+    # Policy interface
+    # ------------------------------------------------------------------
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        if self._masked:
+            mask = self._cached_mask
+            if np.random.random() < self._eps:
+                available = np.where(mask)[0]
+                if len(available) == 0:
+                    available = np.arange(self._n_actions)
+                return self._actions[np.random.choice(available)].copy()
+            obs_norm = (obs / self._scales).astype(np.float32)
+            q = self._q_values(self._online, obs_norm).copy()
+            q[~mask] = -np.inf
+            if np.all(~mask):
+                q = self._q_values(self._online, obs_norm)
+            return self._actions[int(np.argmax(q))].copy()
+        else:
+            if np.random.random() < self._eps:
+                return self._actions[np.random.randint(self._n_actions)].copy()
+            obs_norm = (obs / self._scales).astype(np.float32)
+            q        = self._q_values(self._online, obs_norm)
+            return self._actions[int(np.argmax(q))].copy()
+
+    def update(
+        self,
+        obs: np.ndarray,
+        action: np.ndarray | int,
+        reward: float,
+        next_obs: np.ndarray,
+        done: bool,
+        **kwargs,
+    ) -> None:
+        if isinstance(action, (int, np.integer)):
+            action_idx = int(action)
+        else:
+            diffs = np.abs(self._actions - action[np.newaxis, :]).sum(axis=1)
+            action_idx = int(np.argmin(diffs))
+
+        if self._masked:
+            info = kwargs.get("info") or {}
+            if self._avail_fn is not None:
+                new_mask = self._avail_fn(info)
+                self._cached_mask = np.asarray(new_mask, dtype=bool)
+            mask = self._cached_mask
+            self._replay.push(obs, action_idx, reward, next_obs, done, mask)  # type: ignore[call-arg]
+        else:
+            self._replay.push(obs, action_idx, reward, next_obs, done)
+
+        self._total_steps += 1
+        self._eps = max(self._eps_end, self._eps - self._eps_delta)
+
+        if len(self._replay) >= self._min_replay:
+            if self._masked:
+                obs_b, act_b, rew_b, next_b, done_b, mask_b = self._replay.sample(self._batch_size)  # type: ignore[misc]
+                self._gradient_step(obs_b, act_b, rew_b, next_b, done_b, mask_b)
+            else:
+                obs_b, act_b, rew_b, next_b, done_b = self._replay.sample(self._batch_size)
+                self._gradient_step(obs_b, act_b, rew_b, next_b, done_b)
+
+    def on_episode_end(self) -> None:
+        pass  # epsilon decays per step, not per episode
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type":         "dqn",
+            "hidden_sizes":        self._hidden,
+            "replay_buffer_size":  self._buf_maxlen,
+            "batch_size":          self._batch_size,
+            "min_replay_size":     self._min_replay,
+            "target_update_freq":  self._target_freq,
+            "learning_rate":       float(self._lr),
+            "epsilon_start":       float(self._eps_start),
+            "epsilon_end":         float(self._eps_end),
+            "epsilon_decay_steps": self._eps_steps,
+            "gamma":               float(self._gamma),
+            "epsilon":             float(self._eps),
+            "total_steps":         self._total_steps,
+            "grad_steps":          self._grad_steps,
+            "online_weights":      [w.tolist() for w in self._online["weights"]],
+            "online_biases":       [b.tolist() for b in self._online["biases"]],
+            "target_weights":      [w.tolist() for w in self._target["weights"]],
+            "target_biases":       [b.tolist() for b in self._target["biases"]],
+        }
+
+    # ------------------------------------------------------------------
+    # Trainer state persistence
+    # ------------------------------------------------------------------
+
+    def save_trainer_state(self, path: str) -> None:
+        """Persist replay buffer and Adam optimiser moments to an .npz file."""
+        buf = list(self._replay._buf)
+        n   = len(buf)
+        if n > 0:
+            obs_arr  = np.stack([t[0] for t in buf]).astype(np.float32)
+            act_arr  = np.array([t[1] for t in buf], dtype=np.int32)
+            rew_arr  = np.array([t[2] for t in buf], dtype=np.float32)
+            next_arr = np.stack([t[3] for t in buf]).astype(np.float32)
+            done_arr = np.array([t[4] for t in buf], dtype=np.float32)
+        else:
+            obs_arr  = np.empty((0, self._obs_dim), dtype=np.float32)
+            act_arr  = np.empty(0, dtype=np.int32)
+            rew_arr  = np.empty(0, dtype=np.float32)
+            next_arr = np.empty((0, self._obs_dim), dtype=np.float32)
+            done_arr = np.empty(0, dtype=np.float32)
+
+        n_layers = len(self._m_w)
+        arrays: dict = dict(
+            replay_obs  = obs_arr,
+            replay_act  = act_arr,
+            replay_rew  = rew_arr,
+            replay_next = next_arr,
+            replay_done = done_arr,
+            total_steps = np.int64(self._total_steps),
+            grad_steps  = np.int64(self._grad_steps),
+            adam_t      = np.int64(self._adam_t),
+            epsilon     = np.float32(self._eps),
+            obs_dim     = np.int64(self._obs_dim),
+            n_layers    = np.int64(n_layers),
+        )
+        for i in range(n_layers):
+            arrays[f"m_w_{i}"] = self._m_w[i]
+            arrays[f"m_b_{i}"] = self._m_b[i]
+            arrays[f"v_w_{i}"] = self._v_w[i]
+            arrays[f"v_b_{i}"] = self._v_b[i]
+        np.savez(path, **arrays)
+        logger.debug("[DQNPolicy] trainer state saved → %s (buf=%d)", path, n)
+
+    def load_trainer_state(self, path: str) -> None:
+        """Restore replay buffer and Adam optimiser moments from an .npz file.
+
+        Raises ValueError if obs_dim or layer count do not match the current
+        network architecture.
+        """
+        with np.load(path) as data:
+            saved_obs_dim = int(data["obs_dim"])
+            if saved_obs_dim != self._obs_dim:
+                raise ValueError(
+                    f"DQNPolicy: trainer state obs_dim mismatch — "
+                    f"saved={saved_obs_dim}, current={self._obs_dim}. "
+                    f"Use --re-initialize to restart from scratch."
+                )
+            n_layers = int(data["n_layers"])
+            if n_layers != len(self._m_w):
+                raise ValueError(
+                    f"DQNPolicy: trainer state n_layers mismatch — "
+                    f"saved={n_layers}, current={len(self._m_w)}. "
+                    f"Use --re-initialize to restart from scratch."
+                )
+            for i in range(n_layers):
+                mw = data[f"m_w_{i}"]
+                if mw.shape != self._m_w[i].shape:
+                    raise ValueError(
+                        f"DQNPolicy: Adam moment m_w[{i}] shape mismatch — "
+                        f"saved={mw.shape}, current={self._m_w[i].shape}. "
+                        f"Use --re-initialize to restart from scratch."
+                    )
+
+            if self._masked:
+                self._replay = MaskedReplayBuffer(self._buf_maxlen, self._n_actions)
+            else:
+                self._replay = ReplayBuffer(self._buf_maxlen)
+            for i in range(len(data["replay_obs"])):
+                self._replay.push(
+                    data["replay_obs"][i], int(data["replay_act"][i]),
+                    float(data["replay_rew"][i]), data["replay_next"][i],
+                    bool(data["replay_done"][i]),
+                )
+
+            self._total_steps = int(data["total_steps"])
+            self._grad_steps  = int(data["grad_steps"])
+            self._adam_t      = int(data["adam_t"])
+            self._eps         = float(data["epsilon"])
+            for i in range(n_layers):
+                self._m_w[i] = data[f"m_w_{i}"]
+                self._m_b[i] = data[f"m_b_{i}"]
+                self._v_w[i] = data[f"v_w_{i}"]
+                self._v_b[i] = data[f"v_b_{i}"]
+        logger.info(
+            "[DQNPolicy] trainer state loaded from %s (buf=%d, steps=%d, eps=%.4f)",
+            path, len(self._replay), self._total_steps, self._eps,
+        )

--- a/framework/dqn.py
+++ b/framework/dqn.py
@@ -387,12 +387,16 @@ class DQNPolicy(BasePolicy):
             rew_arr  = np.array([t[2] for t in buf], dtype=np.float32)
             next_arr = np.stack([t[3] for t in buf]).astype(np.float32)
             done_arr = np.array([t[4] for t in buf], dtype=np.float32)
+            if self._masked:
+                mask_arr = np.stack([t[5] for t in buf])  # (n, n_actions) bool
         else:
             obs_arr  = np.empty((0, self._obs_dim), dtype=np.float32)
             act_arr  = np.empty(0, dtype=np.int32)
             rew_arr  = np.empty(0, dtype=np.float32)
             next_arr = np.empty((0, self._obs_dim), dtype=np.float32)
             done_arr = np.empty(0, dtype=np.float32)
+            if self._masked:
+                mask_arr = np.empty((0, self._n_actions), dtype=bool)
 
         n_layers = len(self._m_w)
         arrays: dict = dict(
@@ -402,6 +406,10 @@ class DQNPolicy(BasePolicy):
             replay_next = next_arr,
             replay_done = done_arr,
             total_steps = np.int64(self._total_steps),
+        )
+        if self._masked:
+            arrays["replay_mask"] = mask_arr
+        arrays.update(
             grad_steps  = np.int64(self._grad_steps),
             adam_t      = np.int64(self._adam_t),
             epsilon     = np.float32(self._eps),
@@ -450,12 +458,21 @@ class DQNPolicy(BasePolicy):
                 self._replay = MaskedReplayBuffer(self._buf_maxlen, self._n_actions)
             else:
                 self._replay = ReplayBuffer(self._buf_maxlen)
+            has_masks = self._masked and "replay_mask" in data
             for i in range(len(data["replay_obs"])):
-                self._replay.push(
-                    data["replay_obs"][i], int(data["replay_act"][i]),
-                    float(data["replay_rew"][i]), data["replay_next"][i],
-                    bool(data["replay_done"][i]),
-                )
+                if has_masks:
+                    self._replay.push(
+                        data["replay_obs"][i], int(data["replay_act"][i]),
+                        float(data["replay_rew"][i]), data["replay_next"][i],
+                        bool(data["replay_done"][i]),
+                        mask=data["replay_mask"][i],
+                    )
+                else:
+                    self._replay.push(
+                        data["replay_obs"][i], int(data["replay_act"][i]),
+                        float(data["replay_rew"][i]), data["replay_next"][i],
+                        bool(data["replay_done"][i]),
+                    )
 
             self._total_steps = int(data["total_steps"])
             self._grad_steps  = int(data["grad_steps"])

--- a/framework/lstm.py
+++ b/framework/lstm.py
@@ -1,0 +1,456 @@
+"""Generic LSTM-based policies for RL.
+
+LSTMCore            — single-layer LSTM with TMNF-compatible output heads
+                      (steer / accel / brake).  Parameterised on ObsSpec
+                      instead of a raw n_lidar_rays integer.  The flat weight
+                      interface (to_flat / with_flat / flat_dim) is identical
+                      to the game-specific LSTMPolicy so CMA-ES / ES wrappers
+                      can swap them interchangeably.
+
+LSTMEvolutionPolicy — (μ/μ_w, λ)-ES outer optimiser wrapping LSTMCore as the
+                      inner individual.  Uses the _greedy_loop_cmaes interface:
+                      sample_population() / update_distribution().  Step size
+                      adapted via the 1/5 success rule (isotropic Gaussian).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import numpy as np
+
+from framework.obs_spec import ObsSpec
+from framework.policies import BasePolicy
+
+logger = logging.getLogger(__name__)
+
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-np.clip(x, -20.0, 20.0)))
+
+
+# --------------------------------------------------------------------------- #
+# LSTMCore                                                                     #
+# --------------------------------------------------------------------------- #
+
+class LSTMCore(BasePolicy):
+    """Single-layer LSTM policy (pure numpy).
+
+    Hidden state (h, c) persists across steps within an episode.
+    Trained via an outer evolutionary optimiser (LSTMEvolutionPolicy).
+    ``on_episode_end()`` resets (h, c) to zeros.
+
+    Output heads:
+      steer = tanh(W_steer · h)           → [-1, 1]
+      accel = sigmoid(W_accel · h) > 0.5  → {0, 1}
+      brake = sigmoid(W_brake · h) > 0.5  → {0, 1}
+
+    Parameters
+    ----------
+    obs_spec :
+        Observation spec providing ``dim`` and ``scales`` for input normalisation.
+    hidden_size :
+        LSTM hidden / cell state dimensionality (default 32).
+    seed :
+        Optional RNG seed for weight initialisation.
+    """
+
+    def __init__(
+        self,
+        obs_spec: ObsSpec,
+        hidden_size: int = 32,
+        seed: int | None = None,
+    ) -> None:
+        self._obs_spec    = obs_spec
+        self._obs_dim     = obs_spec.dim
+        self._scales      = obs_spec.scales
+        self._hidden_size = int(hidden_size)
+
+        h    = self._hidden_size
+        c_in = h + self._obs_dim
+        rng  = np.random.default_rng(seed)
+        gain = np.sqrt(2.0 / c_in)
+
+        self._W_f = rng.standard_normal((h, c_in)).astype(np.float32) * gain
+        self._b_f = np.zeros(h, dtype=np.float32)
+        self._W_i = rng.standard_normal((h, c_in)).astype(np.float32) * gain
+        self._b_i = np.zeros(h, dtype=np.float32)
+        self._W_g = rng.standard_normal((h, c_in)).astype(np.float32) * gain
+        self._b_g = np.zeros(h, dtype=np.float32)
+        self._W_o = rng.standard_normal((h, c_in)).astype(np.float32) * gain
+        self._b_o = np.zeros(h, dtype=np.float32)
+
+        self._W_steer = rng.standard_normal(h).astype(np.float32) * np.sqrt(2.0 / h)
+        self._W_accel = rng.standard_normal(h).astype(np.float32) * np.sqrt(2.0 / h)
+        self._W_brake = rng.standard_normal(h).astype(np.float32) * np.sqrt(2.0 / h)
+
+        self._h = np.zeros(h, dtype=np.float32)
+        self._c = np.zeros(h, dtype=np.float32)
+
+    # ------------------------------------------------------------------
+    # Flat parameter interface (used by LSTMEvolutionPolicy)
+    # ------------------------------------------------------------------
+
+    @property
+    def flat_dim(self) -> int:
+        h    = self._hidden_size
+        c_in = h + self._obs_dim
+        return 4 * (h * c_in + h) + 3 * h
+
+    def to_flat(self) -> np.ndarray:
+        return np.concatenate([
+            self._W_f.ravel(), self._b_f,
+            self._W_i.ravel(), self._b_i,
+            self._W_g.ravel(), self._b_g,
+            self._W_o.ravel(), self._b_o,
+            self._W_steer,
+            self._W_accel,
+            self._W_brake,
+        ]).astype(np.float32)
+
+    def with_flat(self, flat: np.ndarray) -> "LSTMCore":
+        """Return a new LSTMCore whose weights come from a flat parameter vector."""
+        flat = np.asarray(flat, dtype=np.float32)
+        if flat.shape[0] != self.flat_dim:
+            raise ValueError(
+                f"LSTMCore.with_flat: expected flat vector of size {self.flat_dim}, "
+                f"got {flat.shape[0]}"
+            )
+
+        obj = object.__new__(LSTMCore)
+        obj._obs_spec    = self._obs_spec
+        obj._obs_dim     = self._obs_dim
+        obj._scales      = self._scales
+        obj._hidden_size = self._hidden_size
+
+        h    = self._hidden_size
+        c_in = h + self._obs_dim
+
+        off = 0
+
+        def _take(shape: tuple) -> np.ndarray:
+            nonlocal off
+            n   = int(np.prod(shape))
+            out = flat[off: off + n].reshape(shape).copy()
+            off += n
+            return out
+
+        obj._W_f    = _take((h, c_in))
+        obj._b_f    = _take((h,))
+        obj._W_i    = _take((h, c_in))
+        obj._b_i    = _take((h,))
+        obj._W_g    = _take((h, c_in))
+        obj._b_g    = _take((h,))
+        obj._W_o    = _take((h, c_in))
+        obj._b_o    = _take((h,))
+        obj._W_steer = _take((h,))
+        obj._W_accel = _take((h,))
+        obj._W_brake = _take((h,))
+        obj._h      = np.zeros(h, dtype=np.float32)
+        obj._c      = np.zeros(h, dtype=np.float32)
+        return obj
+
+    def mutated(self, scale: float, **_) -> "LSTMCore":
+        """Return a new LSTMCore with Gaussian noise applied to all parameters."""
+        flat  = self.to_flat()
+        noise = np.random.default_rng().standard_normal(len(flat)).astype(np.float32)
+        return self.with_flat(flat + scale * noise)
+
+    # ------------------------------------------------------------------
+    # Policy interface
+    # ------------------------------------------------------------------
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        x  = (obs / self._scales).astype(np.float32)
+        hx = np.concatenate([self._h, x])
+
+        f = _sigmoid(self._W_f @ hx + self._b_f)
+        i = _sigmoid(self._W_i @ hx + self._b_i)
+        g = np.tanh(self._W_g   @ hx + self._b_g)
+        o = _sigmoid(self._W_o  @ hx + self._b_o)
+
+        self._c = f * self._c + i * g
+        self._h = o * np.tanh(self._c)
+
+        steer = float(np.tanh(np.dot(self._W_steer, self._h)))
+        accel = float(_sigmoid(np.dot(self._W_accel, self._h)) > 0.5)
+        brake = float(_sigmoid(np.dot(self._W_brake, self._h)) > 0.5)
+        return np.array([steer, accel, brake], dtype=np.float32)
+
+    def update(
+        self,
+        obs: np.ndarray,
+        action: np.ndarray | int,
+        reward: float,
+        next_obs: np.ndarray,
+        done: bool,
+        **kwargs,
+    ) -> None:
+        pass  # no online update; training via outer evolutionary optimiser
+
+    def _reset_hidden_state(self) -> None:
+        self._h = np.zeros(self._hidden_size, dtype=np.float32)
+        self._c = np.zeros(self._hidden_size, dtype=np.float32)
+
+    def on_episode_start(self, **kwargs) -> None:
+        self._reset_hidden_state()
+
+    def on_episode_end(self) -> None:
+        self._reset_hidden_state()
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type": "lstm",
+            "hidden_size": self._hidden_size,
+            "obs_dim":     self._obs_dim,
+            "W_f": self._W_f.tolist(), "b_f": self._b_f.tolist(),
+            "W_i": self._W_i.tolist(), "b_i": self._b_i.tolist(),
+            "W_g": self._W_g.tolist(), "b_g": self._b_g.tolist(),
+            "W_o": self._W_o.tolist(), "b_o": self._b_o.tolist(),
+            "W_steer": self._W_steer.tolist(),
+            "W_accel": self._W_accel.tolist(),
+            "W_brake": self._W_brake.tolist(),
+        }
+
+    @classmethod
+    def from_cfg(cls, cfg: dict, obs_spec: ObsSpec) -> "LSTMCore":
+        obj = object.__new__(cls)
+        obj._obs_spec    = obs_spec
+        obj._hidden_size = int(cfg["hidden_size"])
+        obj._obs_dim     = obs_spec.dim
+        obj._scales      = obs_spec.scales
+        obj._W_f    = np.array(cfg["W_f"],    dtype=np.float32)
+        obj._b_f    = np.array(cfg["b_f"],    dtype=np.float32)
+        obj._W_i    = np.array(cfg["W_i"],    dtype=np.float32)
+        obj._b_i    = np.array(cfg["b_i"],    dtype=np.float32)
+        obj._W_g    = np.array(cfg["W_g"],    dtype=np.float32)
+        obj._b_g    = np.array(cfg["b_g"],    dtype=np.float32)
+        obj._W_o    = np.array(cfg["W_o"],    dtype=np.float32)
+        obj._b_o    = np.array(cfg["b_o"],    dtype=np.float32)
+        obj._W_steer = np.array(cfg["W_steer"], dtype=np.float32)
+        obj._W_accel = np.array(cfg["W_accel"], dtype=np.float32)
+        obj._W_brake = np.array(cfg["W_brake"], dtype=np.float32)
+        h = obj._hidden_size
+        obj._h = np.zeros(h, dtype=np.float32)
+        obj._c = np.zeros(h, dtype=np.float32)
+        return obj
+
+
+# --------------------------------------------------------------------------- #
+# LSTMEvolutionPolicy                                                          #
+# --------------------------------------------------------------------------- #
+
+class LSTMEvolutionPolicy(BasePolicy):
+    """(μ/μ_w, λ)-ES outer optimiser wrapping LSTMCore as the inner individual.
+
+    Uses the ``_greedy_loop_cmaes`` interface: ``sample_population()`` /
+    ``update_distribution()``.  Maintains an isotropic Gaussian search
+    distribution (no full covariance matrix — infeasible for the ~7K-dimensional
+    LSTM parameter space).  Step size adapted via the 1/5 success rule.
+
+    Inference delegates to the champion LSTMCore.
+
+    Parameters
+    ----------
+    obs_spec :
+        Observation spec passed to each LSTMCore individual.
+    hidden_size :
+        LSTM hidden / cell state dimensionality (default 32).
+    population_size :
+        λ — offspring sampled per generation (default 20).
+    initial_sigma :
+        Starting step size (default 0.05).
+    seed :
+        Optional RNG seed.
+    """
+
+    def __init__(
+        self,
+        obs_spec: ObsSpec,
+        hidden_size: int = 32,
+        population_size: int = 20,
+        initial_sigma: float = 0.05,
+        seed: int | None = None,
+    ) -> None:
+        self._obs_spec = obs_spec
+        self._lam      = int(population_size)
+        self._sigma    = float(initial_sigma)
+        self._rng      = np.random.default_rng(seed)
+
+        self._template = LSTMCore(obs_spec=obs_spec, hidden_size=hidden_size)
+        self._flat_dim = self._template.flat_dim
+        self._mean     = self._template.to_flat().astype(np.float64)
+
+        mu             = self._lam // 2
+        self._mu       = mu
+        raw_w          = np.array(
+            [np.log(mu + 0.5) - np.log(i + 1) for i in range(mu)],
+            dtype=np.float64,
+        )
+        self._recomb_w = raw_w / raw_w.sum()
+
+        self._pop: list[np.ndarray]         = []
+        self._champion: LSTMCore | None     = None
+        self._champion_reward: float        = float("-inf")
+
+    # ------------------------------------------------------------------
+    # _greedy_loop_cmaes interface
+    # ------------------------------------------------------------------
+
+    @property
+    def population_size(self) -> int:
+        return self._lam
+
+    @property
+    def champion_reward(self) -> float:
+        return self._champion_reward
+
+    @property
+    def sigma(self) -> float:
+        return self._sigma
+
+    def initialize_from_champion(self, champion: LSTMCore) -> None:
+        champion_flat_dim    = champion.flat_dim
+        expected_hidden_size = getattr(self._template, "_hidden_size", None)
+        champion_hidden_size = getattr(champion,       "_hidden_size", None)
+        expected_obs_dim     = getattr(self._template, "_obs_dim", None)
+        champion_obs_dim     = getattr(champion,       "_obs_dim", None)
+
+        mismatch_reasons: list[str] = []
+        if champion_flat_dim != self._flat_dim:
+            mismatch_reasons.append(
+                f"flat_dim mismatch (expected {self._flat_dim}, got {champion_flat_dim})"
+            )
+        if (
+            expected_hidden_size is not None
+            and champion_hidden_size is not None
+            and champion_hidden_size != expected_hidden_size
+        ):
+            mismatch_reasons.append(
+                "hidden_size mismatch "
+                f"(expected {expected_hidden_size}, got {champion_hidden_size})"
+            )
+        if (
+            expected_obs_dim is not None
+            and champion_obs_dim is not None
+            and champion_obs_dim != expected_obs_dim
+        ):
+            mismatch_reasons.append(
+                f"obs_dim mismatch (expected {expected_obs_dim}, got {champion_obs_dim})"
+            )
+        if mismatch_reasons:
+            raise ValueError(
+                "Cannot initialise LSTMEvolutionPolicy from an incompatible champion: "
+                + "; ".join(mismatch_reasons)
+            )
+        self._champion = champion
+        self._mean     = champion.to_flat().astype(np.float64)
+        logger.info("[LSTMEvolutionPolicy] seeded mean from champion")
+
+    def sample_population(self) -> list[LSTMCore]:
+        self._pop = []
+        for _ in range(self._lam):
+            z = self._rng.standard_normal(self._flat_dim)
+            self._pop.append(self._mean + self._sigma * z)
+        return [self._template.with_flat(x) for x in self._pop]
+
+    def update_distribution(self, rewards: list[float]) -> bool:
+        if len(rewards) != self._lam:
+            raise ValueError(f"Expected {self._lam} rewards, got {len(rewards)}")
+        if len(self._pop) != self._lam:
+            raise RuntimeError(
+                "update_distribution() called before a matching sample_population(). "
+                f"Expected {self._lam} samples in _pop, got {len(self._pop)}. "
+                "Call sample_population() first."
+            )
+
+        order     = np.argsort(rewards)[::-1]
+        prev_best = self._champion_reward
+        improved  = False
+
+        best_r = rewards[order[0]]
+        if best_r > self._champion_reward:
+            self._champion_reward = best_r
+            self._champion        = self._template.with_flat(
+                np.array(self._pop[order[0]], dtype=np.float32)
+            )
+            improved = True
+
+        elite_xs   = np.stack([self._pop[order[i]] for i in range(self._mu)])
+        self._mean = np.einsum("i,ij->j", self._recomb_w, elite_xs)
+
+        n_success    = sum(1 for r in rewards if r > prev_best)
+        success_rate = n_success / self._lam
+        self._sigma  = float(np.clip(
+            self._sigma * (1.2 if success_rate > 0.2 else 0.85),
+            1e-6, 1e2,
+        ))
+
+        return improved
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        if self._champion is None:
+            raise RuntimeError(
+                "LSTMEvolutionPolicy: no champion yet — call sample_population() "
+                "and update_distribution() for at least one generation first."
+            )
+        return self._champion(obs)
+
+    def on_episode_start(self, **kwargs) -> None:
+        if self._champion is not None:
+            self._champion.on_episode_start(**kwargs)
+
+    def on_episode_end(self) -> None:
+        if self._champion is not None:
+            self._champion.on_episode_end()
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type":     "lstm",
+            "hidden_size":     self._template._hidden_size,
+            "population_size": self._lam,
+            "sigma":           float(self._sigma),
+            "obs_dim":         self._template._obs_dim,
+            "champion_reward": float(self._champion_reward),
+        }
+
+    def save(self, path: str) -> None:
+        if self._champion is not None:
+            self._champion.save(path)
+
+    def save_trainer_state(self, path: str) -> None:
+        """Persist isotropic ES distribution state (mean, sigma) to an .npz file."""
+        np.savez(
+            path,
+            mean     = self._mean,
+            sigma    = np.float64(self._sigma),
+            flat_dim = np.int64(self._flat_dim),
+        )
+        logger.debug("[LSTMEvolutionPolicy] trainer state saved → %s", path)
+
+    def load_trainer_state(self, path: str) -> None:
+        """Restore ES distribution state from an .npz file.
+
+        Raises ValueError if the saved flat_dim does not match.
+        """
+        with np.load(path) as data:
+            saved_flat_dim = int(data["flat_dim"])
+            if saved_flat_dim != self._flat_dim:
+                raise ValueError(
+                    f"LSTMEvolutionPolicy: trainer state flat_dim mismatch — "
+                    f"saved={saved_flat_dim}, current={self._flat_dim}. "
+                    f"The network architecture (hidden_size or obs_spec) may have changed. "
+                    f"Use --re-initialize to restart from scratch."
+                )
+            self._mean  = data["mean"].astype(np.float64)
+            self._sigma = float(data["sigma"])
+        logger.info("[LSTMEvolutionPolicy] trainer state loaded from %s (sigma=%.4f)",
+                    path, self._sigma)

--- a/framework/reinforce.py
+++ b/framework/reinforce.py
@@ -1,0 +1,671 @@
+"""Generic REINFORCE (Monte Carlo Policy Gradient) policies.
+
+REINFORCEPolicy       — single softmax output head over a discrete action set.
+TwoHeadREINFORCEPolicy — shared trunk + fn_idx softmax head + spatial sigmoid
+                         head; mirrors the SC2 two-head design but parameterised
+                         on obs_spec / n_fn_ids / n_spatial so it can be used by
+                         any game integration that needs a combined discrete +
+                         continuous action.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+import numpy as np
+
+from framework.obs_spec import ObsSpec
+from framework.policies import BasePolicy
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- #
+# Sigmoid helper                                                               #
+# --------------------------------------------------------------------------- #
+
+def _sigmoid(x: np.ndarray) -> np.ndarray:
+    return 1.0 / (1.0 + np.exp(-np.clip(x, -20.0, 20.0)))
+
+
+# --------------------------------------------------------------------------- #
+# REINFORCEPolicy                                                              #
+# --------------------------------------------------------------------------- #
+
+class REINFORCEPolicy(BasePolicy):
+    """REINFORCE (Monte Carlo Policy Gradient) with optional entropy regularisation.
+
+    Action head: softmax over *output_dim* discrete actions.
+    Each episode accumulates (log_prob, reward) pairs; gradient update fires on
+    episode end using discounted, normalised returns.
+
+    Parameters
+    ----------
+    obs_spec :
+        Observation spec providing ``dim`` and ``scales`` for normalisation.
+    action_decoder :
+        Callable ``(action_idx: int) -> np.ndarray`` that converts a sampled
+        index to the action array returned by ``__call__``.
+    output_dim :
+        Number of discrete actions (= softmax output width).
+    hidden_sizes :
+        MLP hidden-layer widths (default ``[64, 64]``).
+    learning_rate :
+        Gradient-ascent step size.
+    gamma :
+        Discount factor for return computation.
+    entropy_coeff :
+        Entropy regularisation weight; 0 disables the term.
+    baseline :
+        ``"running_mean"`` (EMA of episode returns) or ``"none"``.
+    available_actions_fn :
+        Optional callable ``(info: dict) -> np.ndarray[bool]`` masking illegal
+        actions.  When set, unavailable logits are set to ``-inf`` before
+        sampling and their gradients are zeroed.
+    seed :
+        RNG seed for weight initialisation.
+    """
+
+    def __init__(
+        self,
+        obs_spec: ObsSpec,
+        action_decoder: Callable[[int], np.ndarray],
+        *,
+        output_dim: int,
+        hidden_sizes: list[int] | None = None,
+        learning_rate: float = 0.001,
+        gamma: float = 0.99,
+        entropy_coeff: float = 0.01,
+        baseline: str = "running_mean",
+        available_actions_fn: Callable[..., np.ndarray] | None = None,
+        seed: int | None = None,
+    ) -> None:
+        self._obs_spec       = obs_spec
+        self._action_decoder = action_decoder
+        self._output_dim     = int(output_dim)
+        self._hidden         = list(hidden_sizes or [64, 64])
+        self._lr             = float(learning_rate)
+        self._gamma          = float(gamma)
+        self._entropy_coeff  = float(entropy_coeff)
+        self._baseline_type  = baseline
+        self._avail_fn       = available_actions_fn
+
+        # Attributes accessed by tests and downstream code
+        self._obs_dim = obs_spec.dim
+        self._scales  = obs_spec.scales
+
+        self._weights, self._biases = self._build_net(seed)
+
+        # Episode buffers (one entry per non-warmup step)
+        self._ep_grads: list[tuple]   = []
+        self._ep_rewards: list[float] = []
+
+        # Running-mean baseline (EMA of total episode returns)
+        self._baseline_val   = 0.0
+        self._baseline_alpha = 0.05
+
+    # ------------------------------------------------------------------
+    # Network construction
+    # ------------------------------------------------------------------
+
+    def _build_net(
+        self, seed: int | None
+    ) -> tuple[list[np.ndarray], list[np.ndarray]]:
+        rng  = np.random.default_rng(seed)
+        dims = [self._obs_dim] + self._hidden + [self._output_dim]
+        weights, biases = [], []
+        for i in range(len(dims) - 1):
+            fan_in = dims[i]
+            w = rng.standard_normal((dims[i + 1], fan_in)).astype(np.float32)
+            w *= np.sqrt(2.0 / fan_in)
+            b = np.zeros(dims[i + 1], dtype=np.float32)
+            weights.append(w)
+            biases.append(b)
+        return weights, biases
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _softmax(z: np.ndarray) -> np.ndarray:
+        z_s = z - z.max()
+        e   = np.exp(z_s)
+        return e / e.sum()
+
+    def _forward(
+        self, obs_norm: np.ndarray
+    ) -> tuple[np.ndarray, list[np.ndarray], list[np.ndarray]]:
+        """Forward pass; caches (layer_inputs, pre_relu) for backprop."""
+        x: np.ndarray      = obs_norm.astype(np.float32)
+        layer_inputs: list = []
+        pre_relu: list     = []
+        for i, (w, b) in enumerate(zip(self._weights, self._biases)):
+            layer_inputs.append(x.copy())
+            z = w @ x + b
+            if i < len(self._weights) - 1:
+                pre_relu.append(z.copy())
+                x = np.maximum(0.0, z)
+            else:
+                logits = z
+        probs = self._softmax(logits)
+        return probs, layer_inputs, pre_relu
+
+    # ------------------------------------------------------------------
+    # Policy interface
+    # ------------------------------------------------------------------
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        obs_norm           = obs / self._scales
+        probs, l_in, pre_r = self._forward(obs_norm)
+        action_idx         = int(np.random.choice(self._output_dim, p=probs))
+        self._ep_grads.append((l_in, pre_r, probs.copy(), action_idx))
+        return self._action_decoder(action_idx).copy()
+
+    def update(
+        self,
+        obs: np.ndarray,
+        action: np.ndarray | int,
+        reward: float,
+        next_obs: np.ndarray,
+        done: bool,
+        **kwargs,
+    ) -> None:
+        self._ep_rewards.append(float(reward))
+
+    def on_episode_end(self) -> None:
+        T = min(len(self._ep_grads), len(self._ep_rewards))
+        if T == 0:
+            self._ep_grads.clear()
+            self._ep_rewards.clear()
+            return
+
+        # Discounted returns
+        G = np.zeros(T, dtype=np.float64)
+        running = 0.0
+        for t in reversed(range(T)):
+            running = self._ep_rewards[t] + self._gamma * running
+            G[t]    = running
+
+        baseline_for_advantages = self._baseline_val
+        if self._baseline_type == "running_mean":
+            self._baseline_val = (
+                (1 - self._baseline_alpha) * self._baseline_val
+                + self._baseline_alpha * float(G[0])
+            )
+
+        G_std = float(G.std())
+        if G_std > 1e-6:
+            G_norm = (G - G.mean()) / (G_std + 1e-8)
+        else:
+            G_norm = G - baseline_for_advantages
+
+        dW = [np.zeros_like(w, dtype=np.float64) for w in self._weights]
+        dB = [np.zeros_like(b, dtype=np.float64) for b in self._biases]
+
+        for t in range(T):
+            l_in, pre_r, probs, a_idx = self._ep_grads[t]
+            advantage = float(G_norm[t])
+
+            delta          = -probs.copy().astype(np.float64)
+            delta[a_idx]  += 1.0
+            delta          *= advantage
+
+            if self._entropy_coeff > 0.0:
+                log_p        = np.log(probs.astype(np.float64) + 1e-8)
+                H            = -float(np.dot(probs, log_p))
+                entropy_grad = -probs.astype(np.float64) * (log_p + H)
+                delta       += self._entropy_coeff * entropy_grad
+
+            g = delta
+            for i in range(len(self._weights) - 1, -1, -1):
+                dW[i] += np.outer(g, l_in[i])
+                dB[i] += g
+                if i > 0:
+                    g = self._weights[i].T @ g * (pre_r[i - 1] > 0)
+
+        lr_t = self._lr / T
+        for i in range(len(self._weights)):
+            self._weights[i] += (lr_t * dW[i]).astype(np.float32)
+            self._biases[i]  += (lr_t * dB[i]).astype(np.float32)
+
+        self._ep_grads.clear()
+        self._ep_rewards.clear()
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type":    "reinforce",
+            "hidden_sizes":   self._hidden,
+            "learning_rate":  float(self._lr),
+            "gamma":          float(self._gamma),
+            "entropy_coeff":  float(self._entropy_coeff),
+            "baseline":       self._baseline_type,
+            "output_dim":     self._output_dim,
+            "obs_dim":        self._obs_dim,
+            "baseline_value": float(self._baseline_val),
+            "weights":        [w.tolist() for w in self._weights],
+            "biases":         [b.tolist() for b in self._biases],
+        }
+
+    @classmethod
+    def from_cfg(
+        cls,
+        cfg: dict,
+        obs_spec: ObsSpec,
+        action_decoder: Callable[[int], np.ndarray],
+    ) -> "REINFORCEPolicy":
+        obj = cls(
+            obs_spec       = obs_spec,
+            action_decoder = action_decoder,
+            output_dim     = cfg.get("output_dim", len(cfg.get("weights", [[]][-1]))),
+            hidden_sizes   = cfg.get("hidden_sizes",  [64, 64]),
+            learning_rate  = cfg.get("learning_rate", 0.001),
+            gamma          = cfg.get("gamma",         0.99),
+            entropy_coeff  = cfg.get("entropy_coeff", 0.01),
+            baseline       = cfg.get("baseline",      "running_mean"),
+        )
+        if "weights" in cfg:
+            obj._weights = [np.array(w, dtype=np.float32) for w in cfg["weights"]]
+            obj._biases  = [np.array(b, dtype=np.float32) for b in cfg["biases"]]
+        if "baseline_value" in cfg:
+            obj._baseline_val = float(cfg["baseline_value"])
+        return obj
+
+    def save_trainer_state(self, path: str) -> None:
+        """Persist running-mean baseline and obs_dim to an .npz file."""
+        np.savez(
+            path,
+            baseline_val = np.float64(self._baseline_val),
+            obs_dim      = np.int64(self._obs_dim),
+        )
+        logger.debug("[REINFORCEPolicy] trainer state saved → %s", path)
+
+    def load_trainer_state(self, path: str) -> None:
+        """Restore baseline from an .npz file.
+
+        Raises ValueError if the saved obs_dim does not match.
+        """
+        with np.load(path) as data:
+            saved_obs_dim = int(data["obs_dim"])
+            if saved_obs_dim != self._obs_dim:
+                raise ValueError(
+                    f"REINFORCEPolicy: trainer state obs_dim mismatch — "
+                    f"saved={saved_obs_dim}, current={self._obs_dim}. "
+                    f"The observation space may have changed. "
+                    f"Use --re-initialize to restart from scratch."
+                )
+            self._baseline_val = float(data["baseline_val"])
+        logger.info("[REINFORCEPolicy] trainer state loaded from %s (baseline=%.4f)",
+                    path, self._baseline_val)
+
+
+# --------------------------------------------------------------------------- #
+# TwoHeadREINFORCEPolicy                                                      #
+# --------------------------------------------------------------------------- #
+
+class TwoHeadREINFORCEPolicy(BasePolicy):
+    """REINFORCE with a shared trunk and two independent output heads.
+
+    * **fn_head** — *n_fn_ids* logits, softmax → sampled ``fn_idx``;
+      unavailable IDs are masked to ``-∞`` before sampling.
+    * **spatial_head** — *n_spatial* logits, sigmoid → continuous coordinates
+      in ``[0, 1]^n_spatial``.
+
+    Both heads are trained jointly via REINFORCE with a deterministic gradient
+    for the spatial head (sigmoid policy gradient).
+
+    Parameters
+    ----------
+    obs_spec :
+        Observation spec.
+    n_fn_ids :
+        Width of the fn_idx softmax head.
+    n_spatial :
+        Width of the spatial sigmoid head (e.g. 2 for (x, y)).
+    action_fn :
+        Callable ``(fn_idx: int, sp_sig: np.ndarray) -> np.ndarray`` that
+        assembles the policy's action array from sampled outputs.
+    hidden_sizes :
+        Shared trunk hidden-layer widths (default ``[128, 64]``).
+    learning_rate :
+        Gradient step size (default ``0.0003``).
+    gamma :
+        Discount factor (default ``0.995``).
+    entropy_coeff :
+        Entropy regularisation weight for the fn head (default ``0.05``).
+    baseline :
+        ``"running_mean"`` (EMA) or ``"none"``.
+    available_fn_ids_fn :
+        Optional callable ``(info: dict) -> set[int] | None`` that returns
+        available fn IDs per step.  ``None`` means all IDs are available.
+    seed :
+        Optional RNG seed.
+    """
+
+    def __init__(
+        self,
+        obs_spec: ObsSpec,
+        n_fn_ids: int,
+        n_spatial: int,
+        action_fn: Callable[[int, np.ndarray], np.ndarray],
+        *,
+        hidden_sizes: list[int] | None = None,
+        learning_rate: float = 0.0003,
+        gamma: float = 0.995,
+        entropy_coeff: float = 0.05,
+        baseline: str = "running_mean",
+        available_fn_ids_fn: Callable[..., "set[int] | None"] | None = None,
+        seed: int | None = None,
+    ) -> None:
+        self._obs_spec         = obs_spec
+        self._obs_dim          = obs_spec.dim
+        self._scales           = obs_spec.scales
+        self._n_fn_ids         = int(n_fn_ids)
+        self._n_spatial        = int(n_spatial)
+        self._action_fn        = action_fn
+        self._hidden           = list(hidden_sizes or [128, 64])
+        self._lr               = float(learning_rate)
+        self._gamma            = float(gamma)
+        self._entropy_coeff    = float(entropy_coeff)
+        self._baseline_type    = baseline
+        self._avail_fn_ids_fn  = available_fn_ids_fn
+
+        self._rng = np.random.default_rng(seed)
+
+        (
+            self._trunk_w,
+            self._trunk_b,
+            self._fn_w,
+            self._fn_b,
+            self._sp_w,
+            self._sp_b,
+        ) = self._build_net(seed)
+
+        self._ep_grads: list[tuple]   = []
+        self._ep_rewards: list[float] = []
+
+        self._baseline_val   = 0.0
+        self._baseline_alpha = 0.05
+
+        self._available_fn_ids: "set[int] | None" = None
+
+    # ------------------------------------------------------------------
+    # Network construction
+    # ------------------------------------------------------------------
+
+    def _build_net(
+        self, seed: int | None
+    ) -> tuple[
+        list[np.ndarray], list[np.ndarray],
+        np.ndarray, np.ndarray,
+        np.ndarray, np.ndarray,
+    ]:
+        rng = np.random.default_rng(seed)
+
+        trunk_w: list[np.ndarray] = []
+        trunk_b: list[np.ndarray] = []
+        dims = [self._obs_dim] + self._hidden
+        for i in range(len(dims) - 1):
+            fan_in = dims[i]
+            w = rng.standard_normal((dims[i + 1], fan_in)).astype(np.float32)
+            w *= np.sqrt(2.0 / fan_in)
+            b = np.zeros(dims[i + 1], dtype=np.float32)
+            trunk_w.append(w)
+            trunk_b.append(b)
+
+        h_dim = self._hidden[-1] if self._hidden else self._obs_dim
+
+        fn_w = rng.standard_normal((self._n_fn_ids, h_dim)).astype(np.float32)
+        fn_w *= np.sqrt(2.0 / h_dim)
+        fn_b = np.zeros(self._n_fn_ids, dtype=np.float32)
+
+        sp_w = rng.standard_normal((self._n_spatial, h_dim)).astype(np.float32)
+        sp_w *= np.sqrt(2.0 / h_dim)
+        sp_b = np.zeros(self._n_spatial, dtype=np.float32)
+
+        return trunk_w, trunk_b, fn_w, fn_b, sp_w, sp_b
+
+    # ------------------------------------------------------------------
+    # Utilities
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _softmax(z: np.ndarray) -> np.ndarray:
+        z_s = z - z.max()
+        e   = np.exp(z_s)
+        return e / e.sum()
+
+    def _trunk_forward(
+        self, obs_norm: np.ndarray
+    ) -> tuple[np.ndarray, list[np.ndarray], list[np.ndarray]]:
+        x: np.ndarray      = obs_norm.astype(np.float32)
+        layer_inputs: list = []
+        pre_relu: list     = []
+        for w, b in zip(self._trunk_w, self._trunk_b):
+            layer_inputs.append(x.copy())
+            z = w @ x + b
+            pre_relu.append(z.copy())
+            x = np.maximum(0.0, z)
+        return x, layer_inputs, pre_relu
+
+    def _build_fn_mask(self, available_fn_ids: "set[int] | None") -> np.ndarray:
+        mask = np.ones(self._n_fn_ids, dtype=bool)
+        if available_fn_ids is not None:
+            for i in range(self._n_fn_ids):
+                mask[i] = i in available_fn_ids
+        if not mask.any():
+            mask[0] = True
+        return mask
+
+    # ------------------------------------------------------------------
+    # Policy interface
+    # ------------------------------------------------------------------
+
+    def on_episode_start(self, **kwargs) -> None:
+        self._ep_grads.clear()
+        self._ep_rewards.clear()
+        info      = kwargs.get("info") or {}
+        available = info.get("available_fn_ids")
+        if available is not None:
+            self._available_fn_ids = set(available)
+        else:
+            self._available_fn_ids = None
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        obs_norm = obs / self._scales
+        h_last, l_in, pre_r = self._trunk_forward(obs_norm)
+
+        fn_logits = self._fn_w @ h_last + self._fn_b
+        fn_mask   = self._build_fn_mask(self._available_fn_ids)
+        fn_logits_masked = fn_logits.copy()
+        fn_logits_masked[~fn_mask] = -np.inf
+        fn_probs  = self._softmax(fn_logits_masked)
+        fn_idx    = int(self._rng.choice(self._n_fn_ids, p=fn_probs))
+
+        sp_logits = self._sp_w @ h_last + self._sp_b
+        sp_sig    = np.array(
+            [_sigmoid(float(sp_logits[i])) for i in range(self._n_spatial)],
+            dtype=np.float32,
+        )
+
+        self._ep_grads.append((l_in, pre_r, h_last.copy(), fn_probs.copy(),
+                                fn_idx, sp_sig.copy(), fn_mask.copy()))
+
+        return self._action_fn(fn_idx, sp_sig)
+
+    def update(
+        self,
+        obs: np.ndarray,
+        action: np.ndarray | int,
+        reward: float,
+        next_obs: np.ndarray,
+        done: bool,
+        **kwargs,
+    ) -> None:
+        self._ep_rewards.append(float(reward))
+        info      = kwargs.get("info") or {}
+        available = info.get("available_fn_ids")
+        if available is not None:
+            self._available_fn_ids = set(available)
+
+    def on_episode_end(self) -> None:
+        T = min(len(self._ep_grads), len(self._ep_rewards))
+        if T == 0:
+            self._ep_grads.clear()
+            self._ep_rewards.clear()
+            return
+
+        G = np.zeros(T, dtype=np.float64)
+        running = 0.0
+        for t in reversed(range(T)):
+            running = self._ep_rewards[t] + self._gamma * running
+            G[t]    = running
+
+        baseline_for_advantages = self._baseline_val
+        if self._baseline_type == "running_mean":
+            self._baseline_val = (
+                (1 - self._baseline_alpha) * self._baseline_val
+                + self._baseline_alpha * float(G[0])
+            )
+
+        G_std = float(G.std())
+        if G_std > 1e-6:
+            G_norm = (G - G.mean()) / (G_std + 1e-8)
+        else:
+            G_norm = G - baseline_for_advantages
+
+        dW_trunk = [np.zeros_like(w, dtype=np.float64) for w in self._trunk_w]
+        dB_trunk = [np.zeros_like(b, dtype=np.float64) for b in self._trunk_b]
+        dW_fn    = np.zeros_like(self._fn_w, dtype=np.float64)
+        dB_fn    = np.zeros_like(self._fn_b, dtype=np.float64)
+        dW_sp    = np.zeros_like(self._sp_w, dtype=np.float64)
+        dB_sp    = np.zeros_like(self._sp_b, dtype=np.float64)
+
+        for t in range(T):
+            l_in, pre_r, h_last, fn_probs, fn_idx, sp_sig, fn_mask = self._ep_grads[t]
+            advantage = float(G_norm[t])
+
+            delta_fn = -fn_probs.copy().astype(np.float64)
+            delta_fn[fn_idx] += 1.0
+            delta_fn[~fn_mask] = 0.0
+            delta_fn *= advantage
+
+            if self._entropy_coeff > 0.0:
+                log_p_fn      = np.log(fn_probs.astype(np.float64) + 1e-8)
+                H_fn          = -float(np.dot(fn_probs[fn_mask], log_p_fn[fn_mask]))
+                ent_grad_fn   = np.zeros(self._n_fn_ids, dtype=np.float64)
+                ent_grad_fn[fn_mask] = -(
+                    fn_probs[fn_mask].astype(np.float64) * (log_p_fn[fn_mask] + H_fn)
+                )
+                delta_fn += self._entropy_coeff * ent_grad_fn
+
+            sp_sig_d = sp_sig.astype(np.float64)
+            delta_sp = advantage * (sp_sig_d * (1.0 - sp_sig_d))
+
+            h_last_d = h_last.astype(np.float64)
+            dW_fn += np.outer(delta_fn, h_last_d)
+            dB_fn += delta_fn
+            dW_sp += np.outer(delta_sp, h_last_d)
+            dB_sp += delta_sp
+
+            if self._trunk_w:
+                g_trunk = (
+                    self._fn_w.T.astype(np.float64) @ delta_fn
+                    + self._sp_w.T.astype(np.float64) @ delta_sp
+                )
+                n_trunk = len(self._trunk_w)
+                for i in range(n_trunk - 1, -1, -1):
+                    g_trunk = g_trunk * (pre_r[i] > 0).astype(np.float64)
+                    dW_trunk[i] += np.outer(g_trunk, l_in[i].astype(np.float64))
+                    dB_trunk[i] += g_trunk
+                    if i > 0:
+                        g_trunk = self._trunk_w[i].T.astype(np.float64) @ g_trunk
+
+        lr_t = self._lr / T
+        for i in range(len(self._trunk_w)):
+            self._trunk_w[i] += (lr_t * dW_trunk[i]).astype(np.float32)
+            self._trunk_b[i] += (lr_t * dB_trunk[i]).astype(np.float32)
+        self._fn_w += (lr_t * dW_fn).astype(np.float32)
+        self._fn_b += (lr_t * dB_fn).astype(np.float32)
+        self._sp_w += (lr_t * dW_sp).astype(np.float32)
+        self._sp_b += (lr_t * dB_sp).astype(np.float32)
+
+        self._ep_grads.clear()
+        self._ep_rewards.clear()
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_cfg(self) -> dict:
+        return {
+            "policy_type":    "two_head_reinforce",
+            "hidden_sizes":   self._hidden,
+            "learning_rate":  float(self._lr),
+            "gamma":          float(self._gamma),
+            "entropy_coeff":  float(self._entropy_coeff),
+            "baseline":       self._baseline_type,
+            "n_fn_ids":       self._n_fn_ids,
+            "n_spatial":      self._n_spatial,
+            "obs_dim":        self._obs_dim,
+            "baseline_value": float(self._baseline_val),
+            "trunk_weights":  [w.tolist() for w in self._trunk_w],
+            "trunk_biases":   [b.tolist() for b in self._trunk_b],
+            "fn_weights":     self._fn_w.tolist(),
+            "fn_biases":      self._fn_b.tolist(),
+            "sp_weights":     self._sp_w.tolist(),
+            "sp_biases":      self._sp_b.tolist(),
+        }
+
+    @classmethod
+    def from_cfg(
+        cls,
+        cfg: dict,
+        obs_spec: ObsSpec,
+        action_fn: Callable[[int, np.ndarray], np.ndarray],
+        available_fn_ids_fn: "Callable[..., set[int] | None] | None" = None,
+    ) -> "TwoHeadREINFORCEPolicy":
+        obj = cls(
+            obs_spec          = obs_spec,
+            n_fn_ids          = cfg.get("n_fn_ids",       6),
+            n_spatial         = cfg.get("n_spatial",      2),
+            action_fn         = action_fn,
+            hidden_sizes      = cfg.get("hidden_sizes",   [128, 64]),
+            learning_rate     = cfg.get("learning_rate",  0.0003),
+            gamma             = cfg.get("gamma",          0.995),
+            entropy_coeff     = cfg.get("entropy_coeff",  0.05),
+            baseline          = cfg.get("baseline",       "running_mean"),
+            available_fn_ids_fn = available_fn_ids_fn,
+        )
+        if "trunk_weights" in cfg:
+            obj._trunk_w = [np.array(w, dtype=np.float32) for w in cfg["trunk_weights"]]
+            obj._trunk_b = [np.array(b, dtype=np.float32) for b in cfg["trunk_biases"]]
+        if "fn_weights" in cfg:
+            obj._fn_w = np.array(cfg["fn_weights"], dtype=np.float32)
+            obj._fn_b = np.array(cfg["fn_biases"],  dtype=np.float32)
+        if "sp_weights" in cfg:
+            obj._sp_w = np.array(cfg["sp_weights"], dtype=np.float32)
+            obj._sp_b = np.array(cfg["sp_biases"],  dtype=np.float32)
+        if "baseline_value" in cfg:
+            obj._baseline_val = float(cfg["baseline_value"])
+        return obj
+
+    def save_trainer_state(self, path: str) -> None:
+        np.savez(path,
+                 baseline_val=np.float64(self._baseline_val),
+                 obs_dim=np.int64(self._obs_dim))
+
+    def load_trainer_state(self, path: str) -> None:
+        with np.load(path) as data:
+            saved_obs_dim = int(data["obs_dim"])
+            if saved_obs_dim != self._obs_dim:
+                raise ValueError(
+                    f"TwoHeadREINFORCEPolicy: trainer state obs_dim mismatch — "
+                    f"saved={saved_obs_dim}, current={self._obs_dim}. "
+                    f"Use --re-initialize to restart from scratch."
+                )
+            self._baseline_val = float(data["baseline_val"])
+        logger.info("[TwoHeadREINFORCEPolicy] trainer state loaded from %s", path)

--- a/framework/reinforce.py
+++ b/framework/reinforce.py
@@ -103,6 +103,9 @@ class REINFORCEPolicy(BasePolicy):
         self._baseline_val   = 0.0
         self._baseline_alpha = 0.05
 
+        # Cached availability mask (None = all actions legal)
+        self._available_mask: np.ndarray | None = None
+
     # ------------------------------------------------------------------
     # Network construction
     # ------------------------------------------------------------------
@@ -154,11 +157,32 @@ class REINFORCEPolicy(BasePolicy):
     # Policy interface
     # ------------------------------------------------------------------
 
+    def on_episode_start(self, **kwargs) -> None:
+        self._ep_grads.clear()
+        self._ep_rewards.clear()
+        if self._avail_fn is not None:
+            info = kwargs.get("info") or {}
+            result = self._avail_fn(info)
+            if result is not None:
+                self._available_mask = np.asarray(result, dtype=bool)
+
     def __call__(self, obs: np.ndarray) -> np.ndarray:
         obs_norm           = obs / self._scales
         probs, l_in, pre_r = self._forward(obs_norm)
-        action_idx         = int(np.random.choice(self._output_dim, p=probs))
-        self._ep_grads.append((l_in, pre_r, probs.copy(), action_idx))
+        if self._available_mask is not None:
+            masked = probs * self._available_mask
+            total  = float(masked.sum())
+            if total > 1e-10:
+                masked = masked / total
+            else:
+                masked = self._available_mask.astype(np.float32)
+                masked = masked / float(masked.sum())
+            action_idx   = int(np.random.choice(self._output_dim, p=masked))
+            stored_probs = masked
+        else:
+            action_idx   = int(np.random.choice(self._output_dim, p=probs))
+            stored_probs = probs.copy()
+        self._ep_grads.append((l_in, pre_r, stored_probs, action_idx))
         return self._action_decoder(action_idx).copy()
 
     def update(
@@ -171,6 +195,11 @@ class REINFORCEPolicy(BasePolicy):
         **kwargs,
     ) -> None:
         self._ep_rewards.append(float(reward))
+        if self._avail_fn is not None:
+            info   = kwargs.get("info") or {}
+            result = self._avail_fn(info)
+            if result is not None:
+                self._available_mask = np.asarray(result, dtype=bool)
 
     def on_episode_end(self) -> None:
         T = min(len(self._ep_grads), len(self._ep_rewards))
@@ -260,7 +289,9 @@ class REINFORCEPolicy(BasePolicy):
         obj = cls(
             obs_spec       = obs_spec,
             action_decoder = action_decoder,
-            output_dim     = cfg.get("output_dim", len(cfg.get("weights", [[]][-1]))),
+            output_dim     = cfg.get("output_dim",
+                                     np.array(cfg["biases"][-1]).shape[0]
+                                     if "biases" in cfg else 1),
             hidden_sizes   = cfg.get("hidden_sizes",  [64, 64]),
             learning_rate  = cfg.get("learning_rate", 0.001),
             gamma          = cfg.get("gamma",         0.99),
@@ -467,8 +498,11 @@ class TwoHeadREINFORCEPolicy(BasePolicy):
     def on_episode_start(self, **kwargs) -> None:
         self._ep_grads.clear()
         self._ep_rewards.clear()
-        info      = kwargs.get("info") or {}
-        available = info.get("available_fn_ids")
+        info = kwargs.get("info") or {}
+        if self._avail_fn_ids_fn is not None:
+            available = self._avail_fn_ids_fn(info)
+        else:
+            available = info.get("available_fn_ids")
         if available is not None:
             self._available_fn_ids = set(available)
         else:
@@ -506,8 +540,11 @@ class TwoHeadREINFORCEPolicy(BasePolicy):
         **kwargs,
     ) -> None:
         self._ep_rewards.append(float(reward))
-        info      = kwargs.get("info") or {}
-        available = info.get("available_fn_ids")
+        info = kwargs.get("info") or {}
+        if self._avail_fn_ids_fn is not None:
+            available = self._avail_fn_ids_fn(info)
+        else:
+            available = info.get("available_fn_ids")
         if available is not None:
             self._available_fn_ids = set(available)
 

--- a/framework/replay.py
+++ b/framework/replay.py
@@ -1,0 +1,91 @@
+"""Replay buffers for off-policy RL algorithms.
+
+ReplayBuffer        — circular (obs, action_idx, reward, next_obs, done) buffer
+MaskedReplayBuffer  — extends with a per-transition available-actions mask
+"""
+from __future__ import annotations
+
+from collections import deque
+
+import numpy as np
+
+
+class ReplayBuffer:
+    """Fixed-size circular buffer of (obs, action_idx, reward, next_obs, done) tuples."""
+
+    def __init__(self, maxlen: int) -> None:
+        self._buf: deque = deque(maxlen=maxlen)
+
+    def push(
+        self,
+        obs: np.ndarray,
+        action_idx: int,
+        reward: float,
+        next_obs: np.ndarray,
+        done: bool,
+    ) -> None:
+        self._buf.append((
+            obs.copy(), int(action_idx), float(reward), next_obs.copy(), bool(done),
+        ))
+
+    def sample(
+        self, batch_size: int
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        replace = batch_size > len(self._buf)
+        idxs    = np.random.choice(len(self._buf), size=batch_size, replace=replace)
+        batch   = [self._buf[i] for i in idxs]
+        obs_b   = np.stack([t[0] for t in batch]).astype(np.float32)
+        act_b   = np.array([t[1] for t in batch], dtype=np.int32)
+        rew_b   = np.array([t[2] for t in batch], dtype=np.float32)
+        next_b  = np.stack([t[3] for t in batch]).astype(np.float32)
+        done_b  = np.array([t[4] for t in batch], dtype=np.float32)
+        return obs_b, act_b, rew_b, next_b, done_b
+
+    def __len__(self) -> int:
+        return len(self._buf)
+
+
+class MaskedReplayBuffer(ReplayBuffer):
+    """Replay buffer that stores an available-actions mask with each transition.
+
+    Adds a boolean ``mask`` column of shape ``(n_actions,)`` to each stored
+    tuple.  The mask represents which actions are legal in the *next* state s'
+    of the transition; used to restrict ``max_a' Q_target(s', a')`` to legal
+    next-state actions so the target network never bootstraps through
+    unavailable Q-values.
+    """
+
+    def __init__(self, maxlen: int, n_actions: int) -> None:
+        super().__init__(maxlen)
+        self._n_actions = n_actions
+
+    def push(  # type: ignore[override]
+        self,
+        obs: np.ndarray,
+        action_idx: int,
+        reward: float,
+        next_obs: np.ndarray,
+        done: bool,
+        mask: np.ndarray | None = None,
+    ) -> None:
+        if mask is None:
+            mask = np.ones(self._n_actions, dtype=bool)
+        self._buf.append((
+            obs.copy(), int(action_idx), float(reward),
+            next_obs.copy(), bool(done), mask.copy(),
+        ))
+
+    def sample(  # type: ignore[override]
+        self,
+        batch_size: int,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        replace = batch_size > len(self._buf)
+        idxs    = np.random.choice(len(self._buf), size=batch_size, replace=replace)
+        batch   = [self._buf[i] for i in idxs]
+        obs_b   = np.stack([t[0] for t in batch]).astype(np.float32)
+        act_b   = np.array([t[1] for t in batch], dtype=np.int32)
+        rew_b   = np.array([t[2] for t in batch], dtype=np.float32)
+        next_b  = np.stack([t[3] for t in batch]).astype(np.float32)
+        done_b  = np.array([t[4] for t in batch], dtype=np.float32)
+        mask_b  = np.stack([t[5] for t in batch])   # (B, n_actions) bool
+        return obs_b, act_b, rew_b, next_b, done_b, mask_b

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,6 +2,8 @@
 
 - [Coverage at a glance](#coverage-at-a-glance)
 - [Framework / shared](#framework--shared)
+  - [test\_cmaes\_distribution.py — `CMAESDistribution` pure-math unit tests](#test_cmaes_distributionpy--cmaesdistribution-pure-math-unit-tests)
+  - [test\_framework\_algorithm\_equivalence.py — framework ↔ TMNF byte-identical verification](#test_framework_algorithm_equivalencepy--framework--tmnf-byte-identical-verification)
   - [test\_analytics\_no\_matplotlib.py — analytics importable when matplotlib missing](#test_analytics_no_matplotlibpy--analytics-importable-when-matplotlib-missing)
   - [test\_analytics\_task\_metrics.py — `TaskMetrics` dataclass + summary table formatting](#test_analytics_task_metricspy--taskmetrics-dataclass--summary-table-formatting)
   - [test\_belief.py — fog-of-war belief encoder](#test_beliefpy--fog-of-war-belief-encoder)
@@ -26,12 +28,12 @@
   - [test\_weighted\_linear\_policy.py — linear `WeightedLinearPolicy`](#test_weighted_linear_policypy--linear-weightedlinearpolicy)
   - [test\_neural\_net\_policy.py — pure-numpy MLP policy](#test_neural_net_policypy--pure-numpy-mlp-policy)
   - [test\_genetic\_policy.py — population evolutionary loop](#test_genetic_policypy--population-evolutionary-loop)
-  - [test\_cmaes\_policy.py — CMA-ES on linear weights](#test_cmaes_policypy--cma-es-on-linear-weights)
+  - [test\_cmaes\_policy.py — `CMAESPolicy` (framework) via TMNF factory](#test_cmaes_policypy--cmaespolicy-framework-via-tmnf-factory)
   - [test\_epsilon\_greedy\_policy.py — tabular Q-learning](#test_epsilon_greedy_policypy--tabular-q-learning)
   - [test\_mcts\_policy.py — UCT-style online Q](#test_mcts_policypy--uct-style-online-q)
-  - [test\_neural\_dqn\_policy.py — DQN (replay + target net)](#test_neural_dqn_policypy--dqn-replay--target-net)
-  - [test\_reinforce\_policy.py — Monte-Carlo policy gradient](#test_reinforce_policypy--monte-carlo-policy-gradient)
-  - [test\_lstm\_policy.py — LSTM evolution policy](#test_lstm_policypy--lstm-evolution-policy)
+  - [test\_neural\_dqn\_policy.py — `DQNPolicy` (framework) + `ReplayBuffer`](#test_neural_dqn_policypy--dqnpolicy-framework--replaybuffer)
+  - [test\_reinforce\_policy.py — `REINFORCEPolicy` (framework) Monte-Carlo PG](#test_reinforce_policypy--reinforcepolicy-framework-monte-carlo-pg)
+  - [test\_lstm\_policy.py — `LSTMCore` + `LSTMEvolutionPolicy` (framework)](#test_lstm_policypy--lstmcore--lstmevolutionpolicy-framework)
 - [TMNF I/O](#tmnf-io)
   - [test\_rl\_client.py — `RLClient` (game-thread bridge, action windowing)](#test_rl_clientpy--rlclient-game-thread-bridge-action-windowing)
 - [TORCS](#torcs)
@@ -95,7 +97,12 @@ Game-agnostic plumbing under `framework/`, `distributed/`, `config/`,
 `analytics.py`, `grid_search.py`, the train_rl entry point, and shared utility
 modules.
 
-**Tested.** Reward calculator math (linear components, n_ticks scaling,
+**Tested.** `CMAESDistribution` pure-math (initialisation invariants,
+sample/update mechanics, convergence on a quadratic, save/load .npz
+round-trips, dimension mismatch guard); framework ↔ TMNF byte-identical
+forward-pass verification for `DQNPolicy`, `REINFORCEPolicy`, and `LSTMCore`
+(Q-values, softmax logits, hidden-state trajectory, seed-matched initial
+weights). Reward calculator math (linear components, n_ticks scaling,
 finish-bonus / progress invariants, curiosity glue); curiosity modules (ICM
 and RND, factory dispatch); fog-of-war belief encoder; staleness-based
 info-gain; `TaskMetrics` aggregation and summary-table formatting;
@@ -120,6 +127,19 @@ diff'ing (analytics tests assert files appear, not their contents); the Azure
 Terraform stack under `infrastructure/`; the Windows bootstrap script
 `setup_and_run.ps1` (PowerShell-only; cannot run on Linux CI); long convergence
 behaviour of the actual `train_rl()` loop end-to-end on a real env.
+
+### test_cmaes_distribution.py — `CMAESDistribution` pure-math unit tests
+- Init: n / λ / μ=λ/2 / recombination weights sum=1 and decreasing / σ stored / C=I / ps+pc=0 / gen=0 / μ_eff > 1
+- initialize_random: mean set to zero
+- sample: returns λ vectors of shape (n,) / distinct / fills pop_xs/pop_ys / reproducible with same seed
+- update: returns (best_r, best_idx) tuple / correct best values / gen increments / mean shifts / σ positive / C symmetric / C positive-definite / multiple generations move mean / wrong reward count raises / no-sample raises
+- Convergence: mean converges toward quadratic minimum after 30 generations
+- Save/load: preserves mean / σ / covariance / generation / dim mismatch raises / evolution continues correctly from loaded state
+
+### test_framework_algorithm_equivalence.py — framework ↔ TMNF byte-identical verification
+- DQNPolicy: Q-values identical on zero/random obs when weights shared / action shape / greedy action matches / same seed → same initial weights
+- REINFORCEPolicy: softmax probs identical on zero/random obs when weights shared / probs sum to 1 / same seed → same initial weights
+- LSTMCore: hidden state identical after one step / action identical after one step / hidden state identical after 10-step sequence / episode reset in sync / flat roundtrip preserves output to float32 precision / same seed → same initial weights
 
 ### test_analytics_no_matplotlib.py — analytics importable when matplotlib missing
 - framework analytics import works without matplotlib
@@ -257,6 +277,14 @@ tick-window state machine, decision_idx clamping, and the finish/respawn /
 hard-crash forced-commit paths — is fully covered against a `MagicMock`
 TMInterface.
 
+Note: `test_cmaes_policy.py`, `test_neural_dqn_policy.py`,
+`test_reinforce_policy.py`, and `test_lstm_policy.py` now import from
+`framework.cmaes`, `framework.dqn` / `framework.replay`, `framework.reinforce`,
+and `framework.lstm` respectively (Phase A extraction).  They exercise the
+framework classes through TMNF-flavoured instantiation
+(`obs_spec=TMNF_OBS_SPEC`, TMNF action decoder / `DISCRETE_ACTIONS`), so all
+TMNF-specific behaviour is still covered.
+
 **Not tested.** The actual TMInterface bind to a running Trackmania process;
 the `mss` window-grab + OpenCV LIDAR pipeline (only the *configuration* of
 LIDAR is reached via reward-config tests, the raycast loop is not unit
@@ -278,7 +306,7 @@ real driving on the `a03_centerline` track.
 - eval_episodes: default=1 / stored / in to_cfg / cfg roundtrip / cfg default / single reward / 3-episode average / reset count
 - adaptive mutation: mutation_scale logged in GreedySimResult / scale decreases on zero-improvement run / disabled leaves scale unchanged
 
-### test_cmaes_policy.py — CMA-ES on linear weights
+### test_cmaes_policy.py — `CMAESPolicy` (framework) via TMNF factory
 - defaults: pop size / μ=λ/2 / weights sum=1 / C=I at init
 - init: random zero mean / from champion seeds mean / sets champion
 - sample: returns count / WeightedLinearPolicy instances / fills pop_xs/ys
@@ -294,27 +322,27 @@ real driving on the `a03_centerline` track.
 ### test_mcts_policy.py — UCT-style online Q
 - action in range; unseen state random; visit count increments; Q changes; exploitation prefers high Q; visits accumulate
 
-### test_neural_dqn_policy.py — DQN (replay + target net)
-- ReplayBuffer: push+len / circular eviction / sample shapes / w/o replacement / with replacement when small
-- Policy: action shape+range / greedy discrete / random when ε=1 / buffer fills on update / ε decays / floored / target sync / weight shapes
-- Cfg: roundtrip / policy_type key / on_episode_end no-op / missing keys raise / shape mismatch raises
+### test_neural_dqn_policy.py — `DQNPolicy` (framework) + `ReplayBuffer`
+- ReplayBuffer (`framework.replay`): push+len / circular eviction / sample shapes / w/o replacement / with replacement when small
+- DQNPolicy (`framework.dqn`): action shape+range / greedy discrete / random when ε=1 / buffer fills on update / ε decays / floored / target sync / weight shapes
+- Cfg: roundtrip (`policy_type="dqn"`) / on_episode_end no-op / missing keys raise / shape mismatch raises (via `TMNF_OBS_SPEC.with_lidar`)
 - Bandit convergence; save/load replay buffer + Adam moments; wrong obs_dim raises
 
-### test_reinforce_policy.py — Monte-Carlo policy gradient
-- action shape; steer range; accel/brake binary; discrete
+### test_reinforce_policy.py — `REINFORCEPolicy` (framework) Monte-Carlo PG
+- action shape; steer range; accel/brake discrete; action from DISCRETE_ACTIONS
 - buffers: fill / clear on episode end / empty on_episode_end no-op
 - weights match hidden_sizes; buffer lengths match; weights change after update; gradient direction
-- entropy_coeff = 0 vs nonzero; cfg required keys / policy_type / restore weights+hyperparams; save+reload; lidar; baseline roundtrip; wrong obs dim raises
+- entropy_coeff = 0 vs nonzero; cfg required keys (`output_dim` not `n_lidar_rays`) / policy_type / restore weights+hyperparams; save+reload; lidar via `obs_spec.with_lidar(4)`; baseline roundtrip; wrong obs dim raises
 
-### test_lstm_policy.py — LSTM evolution policy
-- Forward: action shape / steer range / accel+brake binary / hidden updates / episode reset zeros / update no-op / different history → different action
-- Flat encoding: dim correct / to_flat shape / roundtrip / zeros hidden / preserves weights / wrong size raises / mutated differs / same hidden_size / lidar roundtrip
-- Cfg: required keys / policy_type / from_cfg roundtrip / save+reload
-- Trainer: pop size / σ property / champion = -inf / flat dim matches template / μ=λ/2 / recomb sum=1
-- Sample: count / LSTM type / fills buffer / distinct individuals
+### test_lstm_policy.py — `LSTMCore` + `LSTMEvolutionPolicy` (framework)
+- LSTMCore (`framework.lstm`): action shape / steer range / accel+brake binary / hidden updates / episode reset zeros / update no-op / different history → different action
+- Flat encoding: dim correct / to_flat shape / roundtrip / zeros hidden / preserves weights / wrong size raises / mutated differs / same hidden_size / lidar roundtrip via `obs_spec.with_lidar(3)`
+- Cfg: required keys (`obs_dim` not `n_lidar_rays`) / policy_type / from_cfg roundtrip / save+reload
+- LSTMEvolutionPolicy: pop size / σ property / champion = -inf / flat dim matches template / μ=λ/2 / recomb sum=1
+- Sample: count / LSTMCore type / fills buffer / distinct individuals
 - Update: true first time / sets champion / tracks best / false on no improve / mean shifts / wrong count raises / no sample raises / σ adapts
 - Call: raises before update / valid after; on_episode_end resets champion hidden state
-- to_cfg keys / policy_type / save yaml / init from champion / mean→target / save+load roundtrip / wrong flat dim raises
+- to_cfg keys (`sigma` + `champion_reward`; no `n_lidar_rays`) / policy_type / save yaml / init from champion / mean→target / save+load roundtrip / wrong flat dim raises
 
 ## TMNF I/O
 

--- a/tests/test_cmaes_distribution.py
+++ b/tests/test_cmaes_distribution.py
@@ -1,0 +1,316 @@
+"""Pure-math tests for CMAESDistribution in framework/cmaes.py."""
+import unittest
+
+import numpy as np
+
+from framework.cmaes import CMAESDistribution
+
+
+def _make(n=5, lam=10, sigma=0.3, seed=0) -> CMAESDistribution:
+    return CMAESDistribution(n, population_size=lam, initial_sigma=sigma, seed=seed)
+
+
+class TestCMAESDistributionInit(unittest.TestCase):
+
+    def test_n_stored(self):
+        d = _make(n=7)
+        self.assertEqual(d._n, 7)
+
+    def test_lam_stored(self):
+        d = _make(lam=12)
+        self.assertEqual(d._lam, 12)
+
+    def test_mu_is_half_lambda(self):
+        d = _make(lam=20)
+        self.assertEqual(d._mu, 10)
+
+    def test_recombination_weights_sum_to_one(self):
+        d = _make(lam=16)
+        self.assertAlmostEqual(float(d._weights.sum()), 1.0, places=10)
+
+    def test_recombination_weights_positive_decreasing(self):
+        d = _make(lam=10)
+        w = d._weights
+        for i in range(len(w) - 1):
+            self.assertGreater(float(w[i]), float(w[i + 1]))
+
+    def test_initial_sigma_stored(self):
+        d = _make(sigma=0.7)
+        self.assertAlmostEqual(d._sigma, 0.7)
+
+    def test_covariance_is_identity(self):
+        d = _make(n=4)
+        np.testing.assert_array_almost_equal(d._C, np.eye(4))
+
+    def test_ps_and_pc_are_zero(self):
+        d = _make(n=6)
+        np.testing.assert_array_equal(d._ps, np.zeros(6))
+        np.testing.assert_array_equal(d._pc, np.zeros(6))
+
+    def test_generation_starts_at_zero(self):
+        d = _make()
+        self.assertEqual(d._gen, 0)
+
+    def test_mu_eff_positive(self):
+        d = _make(lam=20)
+        self.assertGreater(d._mu_eff, 1.0)
+
+
+class TestCMAESDistributionInitializeRandom(unittest.TestCase):
+
+    def test_mean_is_zero_after_initialize(self):
+        d = _make(n=5)
+        d.initialize_random()
+        np.testing.assert_array_equal(d._mean, np.zeros(5))
+
+
+class TestCMAESDistributionSample(unittest.TestCase):
+
+    def test_sample_returns_lambda_vectors(self):
+        d   = _make(n=4, lam=8)
+        pop = d.sample()
+        self.assertEqual(len(pop), 8)
+
+    def test_sample_vector_shape(self):
+        d   = _make(n=6, lam=5)
+        pop = d.sample()
+        for x in pop:
+            self.assertEqual(x.shape, (6,))
+
+    def test_sample_vectors_are_distinct(self):
+        d   = _make(n=4, lam=6, seed=1)
+        pop = d.sample()
+        for i in range(len(pop)):
+            for j in range(i + 1, len(pop)):
+                self.assertFalse(np.allclose(pop[i], pop[j]))
+
+    def test_sample_fills_pop_xs_and_pop_ys(self):
+        d = _make(n=4, lam=6)
+        d.sample()
+        self.assertEqual(len(d._pop_xs), 6)
+        self.assertEqual(len(d._pop_ys), 6)
+
+    def test_sample_reproducible_with_same_seed(self):
+        d1 = _make(n=4, lam=5, seed=7)
+        d2 = _make(n=4, lam=5, seed=7)
+        pop1 = d1.sample()
+        pop2 = d2.sample()
+        for x1, x2 in zip(pop1, pop2):
+            np.testing.assert_array_equal(x1, x2)
+
+
+class TestCMAESDistributionUpdate(unittest.TestCase):
+
+    def _sample_and_update(self, d, rewards=None):
+        d.sample()
+        if rewards is None:
+            rewards = [float(i) for i in range(d._lam)]
+        return d.update(rewards)
+
+    def test_update_returns_tuple(self):
+        d = _make(n=3, lam=6)
+        result = self._sample_and_update(d)
+        self.assertIsInstance(result, tuple)
+        self.assertEqual(len(result), 2)
+
+    def test_update_returns_best_reward(self):
+        d   = _make(n=3, lam=6)
+        d.sample()
+        rewards = [1.0, 5.0, 2.0, 3.0, 0.5, 4.0]
+        best_r, _ = d.update(rewards)
+        self.assertAlmostEqual(best_r, 5.0)
+
+    def test_update_returns_best_index(self):
+        d = _make(n=3, lam=6, seed=0)
+        d.sample()
+        rewards = [1.0, 5.0, 2.0, 3.0, 0.5, 4.0]
+        _, best_idx = d.update(rewards)
+        self.assertEqual(best_idx, 1)
+
+    def test_generation_increments_after_update(self):
+        d = _make(n=3, lam=6)
+        self._sample_and_update(d)
+        self.assertEqual(d._gen, 1)
+
+    def test_mean_changes_after_update(self):
+        d        = _make(n=5, lam=8, seed=0)
+        old_mean = d._mean.copy()
+        self._sample_and_update(d)
+        self.assertFalse(np.allclose(d._mean, old_mean))
+
+    def test_wrong_reward_count_raises(self):
+        d = _make(n=3, lam=6)
+        d.sample()
+        with self.assertRaises(ValueError):
+            d.update([1.0] * 5)
+
+    def test_update_without_sample_raises(self):
+        d = _make(n=3, lam=6)
+        # Never called sample() — _pop_xs/_pop_ys are empty
+        with self.assertRaises(RuntimeError):
+            d.update([1.0] * 6)
+
+    def test_sigma_positive_after_update(self):
+        d = _make(n=4, lam=8)
+        self._sample_and_update(d)
+        self.assertGreater(d._sigma, 0.0)
+
+    def test_covariance_symmetric_after_update(self):
+        d = _make(n=5, lam=10)
+        self._sample_and_update(d)
+        np.testing.assert_array_almost_equal(d._C, d._C.T, decimal=12)
+
+    def test_covariance_positive_definite_after_update(self):
+        d = _make(n=5, lam=10)
+        for _ in range(3):
+            self._sample_and_update(d)
+        eigvals = np.linalg.eigvalsh(d._C)
+        self.assertTrue(np.all(eigvals > 0))
+
+    def test_multiple_generations_change_mean(self):
+        d = _make(n=4, lam=8)
+        mean_after = []
+        for _ in range(5):
+            self._sample_and_update(d)
+            mean_after.append(d._mean.copy())
+        for i in range(len(mean_after) - 1):
+            self.assertFalse(np.allclose(mean_after[i], mean_after[i + 1]))
+
+
+class TestCMAESDistributionConvergence(unittest.TestCase):
+
+    def test_converges_toward_quadratic_minimum(self):
+        """After 30 generations the mean should be closer to zero than at start."""
+        n      = 5
+        lam    = 20
+        d      = CMAESDistribution(n, population_size=lam, initial_sigma=1.0, seed=0)
+        # Force a known non-zero starting mean
+        d._mean = np.array([3.0, -2.0, 1.5, -1.0, 2.5])
+        target = np.zeros(n)
+
+        initial_dist = float(np.linalg.norm(d._mean - target))
+
+        for _ in range(30):
+            xs = d.sample()
+            rewards = [-float(np.sum(x ** 2)) for x in xs]
+            d.update(rewards)
+
+        final_dist = float(np.linalg.norm(d._mean - target))
+        self.assertLess(final_dist, initial_dist,
+                        f"CMA-ES failed to converge: initial={initial_dist:.3f}, "
+                        f"final={final_dist:.3f}")
+
+
+class TestCMAESDistributionSaveLoad(unittest.TestCase):
+
+    def test_save_load_preserves_mean(self):
+        import tempfile, os
+        d = _make(n=4, lam=8, seed=5)
+        for _ in range(3):
+            d.sample()
+            d.update([float(i) for i in range(8)])
+
+        with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
+            path = f.name
+        try:
+            d.save_state(path)
+            d2 = _make(n=4, lam=8)
+            d2.load_state(path)
+            np.testing.assert_array_equal(d._mean, d2._mean)
+        finally:
+            os.unlink(path)
+
+    def test_save_load_preserves_sigma(self):
+        import tempfile, os
+        d = _make(n=4, lam=8, seed=3)
+        d.sample()
+        d.update([float(i) for i in range(8)])
+
+        with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
+            path = f.name
+        try:
+            d.save_state(path)
+            d2 = _make(n=4, lam=8)
+            d2.load_state(path)
+            self.assertAlmostEqual(d._sigma, d2._sigma, places=12)
+        finally:
+            os.unlink(path)
+
+    def test_save_load_preserves_covariance(self):
+        import tempfile, os
+        d = _make(n=4, lam=8, seed=2)
+        for _ in range(5):
+            d.sample()
+            d.update([float(i) for i in range(8)])
+
+        with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
+            path = f.name
+        try:
+            d.save_state(path)
+            d2 = _make(n=4, lam=8)
+            d2.load_state(path)
+            np.testing.assert_array_almost_equal(d._C, d2._C, decimal=12)
+        finally:
+            os.unlink(path)
+
+    def test_save_load_preserves_generation(self):
+        import tempfile, os
+        d = _make(n=4, lam=8)
+        for _ in range(7):
+            d.sample()
+            d.update([float(i) for i in range(8)])
+
+        with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
+            path = f.name
+        try:
+            d.save_state(path)
+            d2 = _make(n=4, lam=8)
+            d2.load_state(path)
+            self.assertEqual(d._gen, d2._gen)
+        finally:
+            os.unlink(path)
+
+    def test_load_wrong_dimension_raises(self):
+        import tempfile, os
+        d = _make(n=4, lam=8)
+        with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
+            path = f.name
+        try:
+            d.save_state(path)
+            d2 = _make(n=7, lam=8)
+            with self.assertRaises(ValueError):
+                d2.load_state(path)
+        finally:
+            os.unlink(path)
+
+    def test_evolution_continues_after_load(self):
+        """After loading state, evolution should continue from the loaded mean."""
+        import tempfile, os
+        d = _make(n=4, lam=8, seed=9)
+        for _ in range(5):
+            d.sample()
+            d.update([float(i) for i in range(8)])
+
+        with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
+            path = f.name
+        try:
+            d.save_state(path)
+
+            d2 = CMAESDistribution(4, population_size=8, seed=99)
+            d2.load_state(path)
+
+            # Verify the loaded mean matches
+            np.testing.assert_array_equal(d._mean, d2._mean)
+
+            # Verify evolution continues from the loaded state (mean shifts)
+            prev_mean = d2._mean.copy()
+            d2.sample()
+            d2.update([float(i) for i in range(8)])
+            self.assertFalse(np.allclose(d2._mean, prev_mean),
+                             "Mean did not change after continuing evolution from loaded state")
+        finally:
+            os.unlink(path)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_cmaes_policy.py
+++ b/tests/test_cmaes_policy.py
@@ -1,4 +1,4 @@
-"""Tests for CMAESPolicy in policies.py."""
+"""Tests for CMAESPolicy in framework/cmaes.py."""
 import os
 import tempfile
 import unittest
@@ -6,112 +6,153 @@ from unittest.mock import patch
 
 import numpy as np
 
-from games.tmnf.policies import CMAESPolicy, WeightedLinearPolicy
+from framework.cmaes import CMAESPolicy
+from framework.policies import WeightedLinearPolicy
+from games.tmnf.obs_spec import BASE_OBS_DIM, TMNF_OBS_SPEC
 
+# ---------------------------------------------------------------------------
+# TMNF helper: build a CMAESPolicy that produces WeightedLinearPolicy instances
+# ---------------------------------------------------------------------------
+
+_OBS_SPEC = TMNF_OBS_SPEC
+_N_HEADS  = 3          # steer + accel + brake
+
+
+def _tmnf_factory(flat: np.ndarray, obs_spec) -> WeightedLinearPolicy:
+    """Convert a flat [steer|accel|brake] vector into a WeightedLinearPolicy."""
+    names = obs_spec.names
+    n     = obs_spec.dim
+    cfg   = {
+        "steer_weights": {names[i]: float(flat[i])             for i in range(n)},
+        "accel_weights": {names[i]: float(flat[n + i])         for i in range(n)},
+        "brake_weights": {names[i]: float(flat[2 * n + i])     for i in range(n)},
+    }
+    return WeightedLinearPolicy.from_cfg(cfg, obs_spec, ["steer", "accel", "brake"])
+
+
+def _make_tmnf_policy(**kw) -> CMAESPolicy:
+    """Create a TMNF-flavoured CMAESPolicy via the framework API."""
+    n_params = _OBS_SPEC.dim * _N_HEADS
+    defaults = dict(population_size=10, initial_sigma=0.3)
+    defaults.update(kw)
+    return CMAESPolicy(_OBS_SPEC, _tmnf_factory, n_params, **defaults)
+
+
+# ---------------------------------------------------------------------------
+# Tests — initialisation
+# ---------------------------------------------------------------------------
 
 class TestCMAESPolicyInit(unittest.TestCase):
 
     def test_default_population_size(self):
-        policy = CMAESPolicy(population_size=10, initial_sigma=0.3)
+        policy = _make_tmnf_policy(population_size=10, initial_sigma=0.3)
         self.assertEqual(policy._lam, 10)
 
     def test_mu_is_half_lambda(self):
-        policy = CMAESPolicy(population_size=20)
+        policy = _make_tmnf_policy(population_size=20)
         self.assertEqual(policy._mu, 10)
 
     def test_weights_sum_to_one(self):
-        policy = CMAESPolicy(population_size=16)
+        policy = _make_tmnf_policy(population_size=16)
         self.assertAlmostEqual(float(policy._weights.sum()), 1.0, places=10)
 
     def test_covariance_is_identity_at_init(self):
-        policy = CMAESPolicy(population_size=10)
+        policy = _make_tmnf_policy(population_size=10)
         np.testing.assert_array_almost_equal(policy._C, np.eye(policy._n))
 
     def test_initialize_random_sets_zero_mean(self):
-        policy = CMAESPolicy(population_size=10)
+        policy = _make_tmnf_policy(population_size=10)
         policy.initialize_random()
         np.testing.assert_array_equal(policy._mean, np.zeros(policy._n))
 
     def test_initialize_from_champion_seeds_mean(self):
-        policy    = CMAESPolicy(population_size=10, n_lidar_rays=0)
-        names     = WeightedLinearPolicy.get_obs_names(0)
-        cfg       = {
+        policy   = _make_tmnf_policy(population_size=10)
+        names    = _OBS_SPEC.names
+        cfg      = {
             "steer_weights": {n: 1.0 for n in names},
             "accel_weights": {n: 0.0 for n in names},
             "brake_weights": {n: 0.0 for n in names},
         }
-        champion  = WeightedLinearPolicy.from_cfg(cfg)
+        champion = WeightedLinearPolicy.from_cfg(cfg, _OBS_SPEC, ["steer", "accel", "brake"])
         policy.initialize_from_champion(champion)
-        expected  = champion.to_flat().astype(np.float64)
+        expected = champion.to_flat().astype(np.float64)
         np.testing.assert_array_almost_equal(policy._mean, expected)
 
     def test_initialize_from_champion_sets_champion(self):
-        policy   = CMAESPolicy(population_size=10)
-        names    = WeightedLinearPolicy.get_obs_names(0)
+        policy   = _make_tmnf_policy(population_size=10)
+        names    = _OBS_SPEC.names
         cfg      = {
             "steer_weights": {n: 0.5 for n in names},
             "accel_weights": {n: 0.5 for n in names},
             "brake_weights": {n: 0.0 for n in names},
         }
-        champion = WeightedLinearPolicy.from_cfg(cfg)
+        champion = WeightedLinearPolicy.from_cfg(cfg, _OBS_SPEC, ["steer", "accel", "brake"])
         policy.initialize_from_champion(champion)
         self.assertIs(policy._champion, champion)
 
 
+# ---------------------------------------------------------------------------
+# Tests — sampling
+# ---------------------------------------------------------------------------
+
 class TestCMAESPolicySampling(unittest.TestCase):
 
     def test_sample_population_returns_correct_count(self):
-        policy = CMAESPolicy(population_size=12)
+        policy = _make_tmnf_policy(population_size=12)
         policy.initialize_random()
         population = policy.sample_population()
         self.assertEqual(len(population), 12)
 
     def test_sample_population_returns_weighted_linear_policies(self):
-        policy = CMAESPolicy(population_size=8)
+        policy = _make_tmnf_policy(population_size=8)
         policy.initialize_random()
         population = policy.sample_population()
         for ind in population:
             self.assertIsInstance(ind, WeightedLinearPolicy)
 
     def test_pop_xs_and_ys_filled_after_sample(self):
-        policy = CMAESPolicy(population_size=6)
+        policy = _make_tmnf_policy(population_size=6)
         policy.initialize_random()
         policy.sample_population()
         self.assertEqual(len(policy._pop_xs), 6)
         self.assertEqual(len(policy._pop_ys), 6)
 
 
+# ---------------------------------------------------------------------------
+# Tests — update
+# ---------------------------------------------------------------------------
+
 class TestCMAESPolicyUpdate(unittest.TestCase):
 
     def _make_and_sample(self, pop=10):
-        policy = CMAESPolicy(population_size=pop, initial_sigma=0.5)
+        policy = _make_tmnf_policy(population_size=pop, initial_sigma=0.5)
         policy.initialize_random()
         policy.sample_population()
         return policy
 
     def test_update_sets_champion_on_first_call(self):
-        policy = self._make_and_sample()
+        policy  = self._make_and_sample()
         rewards = list(range(policy._lam))
         policy.update_distribution(rewards)
         self.assertIsNotNone(policy._champion)
 
     def test_update_returns_true_when_champion_improved(self):
-        policy = self._make_and_sample()
+        policy  = self._make_and_sample()
         rewards = [float(i) for i in range(policy._lam)]
         improved = policy.update_distribution(rewards)
         self.assertTrue(improved)
 
     def test_update_returns_false_when_no_improvement(self):
-        policy = self._make_and_sample()
+        policy  = self._make_and_sample()
         rewards = [100.0] * policy._lam
-        policy.update_distribution(rewards)     # sets champion_reward = 100.0
+        policy.update_distribution(rewards)
 
         policy.sample_population()
         improved = policy.update_distribution([50.0] * policy._lam)
         self.assertFalse(improved)
 
     def test_champion_reward_is_best_seen(self):
-        policy = self._make_and_sample()
+        policy  = self._make_and_sample()
         rewards = [10.0, 99.0] + [1.0] * (policy._lam - 2)
         policy.update_distribution(rewards)
         self.assertAlmostEqual(policy.champion_reward, 99.0)
@@ -127,39 +168,40 @@ class TestCMAESPolicyUpdate(unittest.TestCase):
             policy.update_distribution([0.0] * (policy._lam - 1))
 
     def test_update_without_sample_raises(self):
-        policy = CMAESPolicy(population_size=6)
+        policy = _make_tmnf_policy(population_size=6)
         policy.initialize_random()
-        # Never called sample_population() — _pop_xs/_pop_ys are empty
         with self.assertRaises(RuntimeError):
             policy.update_distribution([0.0] * 6)
 
     def test_mean_moves_after_update(self):
-        policy = CMAESPolicy(population_size=10, initial_sigma=0.5)
+        policy   = _make_tmnf_policy(population_size=10, initial_sigma=0.5)
         policy.initialize_random()
         old_mean = policy._mean.copy()
         policy.sample_population()
-        # Give high reward to all — any non-zero step should shift the mean
-        rewards = [float(i) for i in range(policy._lam)]
+        rewards  = [float(i) for i in range(policy._lam)]
         policy.update_distribution(rewards)
         self.assertFalse(np.allclose(policy._mean, old_mean))
 
 
+# ---------------------------------------------------------------------------
+# Tests — callable
+# ---------------------------------------------------------------------------
+
 class TestCMAESPolicyCallable(unittest.TestCase):
 
     def test_call_raises_before_any_update(self):
-        policy = CMAESPolicy(population_size=6)
+        policy = _make_tmnf_policy(population_size=6)
         policy.initialize_random()
-        obs = np.zeros(21, dtype=np.float32)
+        obs = np.zeros(BASE_OBS_DIM, dtype=np.float32)
         with self.assertRaises(RuntimeError):
             policy(obs)
 
     def test_call_returns_valid_action_after_update(self):
-        policy = CMAESPolicy(population_size=6, initial_sigma=0.3)
+        policy = _make_tmnf_policy(population_size=6, initial_sigma=0.3)
         policy.initialize_random()
         policy.sample_population()
         policy.update_distribution([float(i) for i in range(6)])
 
-        from games.tmnf.obs_spec import BASE_OBS_DIM
         obs    = np.zeros(BASE_OBS_DIM, dtype=np.float32)
         action = policy(obs)
         self.assertEqual(action.shape, (3,))
@@ -169,22 +211,25 @@ class TestCMAESPolicyCallable(unittest.TestCase):
         self.assertIn(float(action[2]), (0.0, 1.0))
 
 
+# ---------------------------------------------------------------------------
+# Tests — serialisation
+# ---------------------------------------------------------------------------
+
 class TestCMAESPolicySerialisation(unittest.TestCase):
 
     def test_to_cfg_contains_required_keys(self):
-        policy = CMAESPolicy(population_size=10, initial_sigma=0.3)
+        policy = _make_tmnf_policy(population_size=10, initial_sigma=0.3)
         cfg    = policy.to_cfg()
         for key in ("policy_type", "population_size", "sigma",
-                    "n_lidar_rays", "champion_reward", "eval_episodes"):
+                    "n_params", "champion_reward", "eval_episodes"):
             self.assertIn(key, cfg)
 
     def test_to_cfg_policy_type(self):
-        policy = CMAESPolicy(population_size=10)
+        policy = _make_tmnf_policy(population_size=10)
         self.assertEqual(policy.to_cfg()["policy_type"], "cmaes")
 
     def test_save_writes_weighted_linear_yaml(self, tmp_path=None):
-        import tempfile, os
-        policy = CMAESPolicy(population_size=6, initial_sigma=0.3)
+        policy = _make_tmnf_policy(population_size=6, initial_sigma=0.3)
         policy.initialize_random()
         policy.sample_population()
         policy.update_distribution([float(i) for i in range(6)])
@@ -211,35 +256,34 @@ class TestCMAESPolicySerialisation(unittest.TestCase):
 class TestCMAESEvalEpisodes(unittest.TestCase):
 
     def test_eval_episodes_default_is_one(self):
-        policy = CMAESPolicy(population_size=10)
+        policy = _make_tmnf_policy(population_size=10)
         self.assertEqual(policy._eval_episodes, 1)
 
     def test_eval_episodes_stored(self):
-        policy = CMAESPolicy(population_size=10, eval_episodes=3)
+        policy = _make_tmnf_policy(population_size=10, eval_episodes=3)
         self.assertEqual(policy._eval_episodes, 3)
 
     def test_eval_episodes_in_to_cfg(self):
-        policy = CMAESPolicy(population_size=10, eval_episodes=4)
-        cfg = policy.to_cfg()
+        policy = _make_tmnf_policy(population_size=10, eval_episodes=4)
+        cfg    = policy.to_cfg()
         self.assertIn("eval_episodes", cfg)
         self.assertEqual(cfg["eval_episodes"], 4)
 
     def test_eval_episodes_clamped_to_at_least_one(self):
-        policy = CMAESPolicy(population_size=10, eval_episodes=0)
+        policy = _make_tmnf_policy(population_size=10, eval_episodes=0)
         self.assertEqual(policy._eval_episodes, 1)
 
     def _run_one_gen_and_capture(self, pop_size, eval_episodes, rewards_seq):
         """Run one generation and capture rewards passed to update_distribution."""
         from framework.training import _greedy_loop_cmaes
-        from games.tmnf.obs_spec import BASE_OBS_DIM
 
-        policy = CMAESPolicy(population_size=pop_size, initial_sigma=0.3,
-                             eval_episodes=eval_episodes)
+        policy = _make_tmnf_policy(population_size=pop_size, initial_sigma=0.3,
+                                   eval_episodes=eval_episodes)
         policy.initialize_random()
 
         rewards_iter = iter(rewards_seq)
-        captured = []
-        original_fn = policy.update_distribution
+        captured     = []
+        original_fn  = policy.update_distribution
 
         def _capture(rewards):
             captured.append(list(rewards))
@@ -252,7 +296,8 @@ class TestCMAESEvalEpisodes(unittest.TestCase):
             def step(self, action):
                 info = {"track_progress": 0.5, "laps_completed": 0,
                         "pos_x": 0.0, "pos_z": 0.0}
-                return np.zeros(BASE_OBS_DIM, dtype=np.float32), next(rewards_iter), True, False, info
+                return (np.zeros(BASE_OBS_DIM, dtype=np.float32),
+                        next(rewards_iter), True, False, info)
 
             def get_episode_time_limit(self):
                 return None
@@ -273,7 +318,6 @@ class TestCMAESEvalEpisodes(unittest.TestCase):
         return captured
 
     def test_eval_episodes_1_passes_single_reward(self):
-        """eval_episodes=1 passes one reward per offspring unchanged."""
         captured = self._run_one_gen_and_capture(
             pop_size=4, eval_episodes=1,
             rewards_seq=[10.0, 20.0, 30.0, 40.0],
@@ -283,9 +327,6 @@ class TestCMAESEvalEpisodes(unittest.TestCase):
         np.testing.assert_allclose(captured[0], [10.0, 20.0, 30.0, 40.0])
 
     def test_eval_episodes_3_averages_rewards(self):
-        """eval_episodes=3 passes the mean of 3 episode rewards per offspring."""
-        # 2 offspring, 3 episodes each
-        # ind0: 10, 20, 30 → mean 20; ind1: 40, 50, 60 → mean 50
         captured = self._run_one_gen_and_capture(
             pop_size=2, eval_episodes=3,
             rewards_seq=[10.0, 20.0, 30.0, 40.0, 50.0, 60.0],
@@ -295,17 +336,15 @@ class TestCMAESEvalEpisodes(unittest.TestCase):
         np.testing.assert_allclose(captured[0], [20.0, 50.0])
 
     def test_eval_episodes_2_correct_reset_count(self):
-        """eval_episodes=2 calls env.reset() pop_size * 2 times per generation."""
         from framework.training import _greedy_loop_cmaes
-        from games.tmnf.obs_spec import BASE_OBS_DIM
 
-        pop_size = 3
+        pop_size      = 3
         eval_episodes = 2
-        policy = CMAESPolicy(population_size=pop_size, initial_sigma=0.3,
-                             eval_episodes=eval_episodes)
+        policy        = _make_tmnf_policy(population_size=pop_size, initial_sigma=0.3,
+                                          eval_episodes=eval_episodes)
         policy.initialize_random()
 
-        reset_count = [0]
+        reset_count  = [0]
         rewards_iter = iter([float(i) for i in range(100)])
 
         class _CountingEnv:
@@ -316,7 +355,8 @@ class TestCMAESEvalEpisodes(unittest.TestCase):
             def step(self, action):
                 info = {"track_progress": 0.5, "laps_completed": 0,
                         "pos_x": 0.0, "pos_z": 0.0}
-                return np.zeros(BASE_OBS_DIM, dtype=np.float32), next(rewards_iter), True, False, info
+                return (np.zeros(BASE_OBS_DIM, dtype=np.float32),
+                        next(rewards_iter), True, False, info)
 
             def get_episode_time_limit(self):
                 return None
@@ -336,18 +376,19 @@ class TestCMAESEvalEpisodes(unittest.TestCase):
         self.assertEqual(reset_count[0], pop_size * eval_episodes)
 
 
+# ---------------------------------------------------------------------------
+# Tests — convergence
+# ---------------------------------------------------------------------------
+
 class TestCMAESConvergence(unittest.TestCase):
 
     def test_converges_toward_quadratic_maximum(self):
-        """CMA-ES mean should move toward the maximizer of a quadratic in <=50 generations."""
-        from games.tmnf.obs_spec import BASE_OBS_DIM
-
-        policy  = CMAESPolicy(population_size=20, initial_sigma=1.0, n_lidar_rays=0, seed=42)
+        """CMA-ES mean should move toward the maximizer of a quadratic in ≤50 generations."""
+        policy = _make_tmnf_policy(population_size=20, initial_sigma=1.0, seed=42)
         policy.initialize_random()
 
-        n_weights = BASE_OBS_DIM * 3
+        n_weights = BASE_OBS_DIM * _N_HEADS
         target    = np.ones(n_weights, dtype=np.float64)
-
         initial_dist = float(np.linalg.norm(policy._mean - target))
 
         for _ in range(50):
@@ -366,10 +407,14 @@ class TestCMAESConvergence(unittest.TestCase):
         )
 
 
+# ---------------------------------------------------------------------------
+# Tests — trainer state
+# ---------------------------------------------------------------------------
+
 class TestCMAESTrainerState(unittest.TestCase):
 
     def _make_trained_policy(self, n_gens: int = 3) -> CMAESPolicy:
-        policy = CMAESPolicy(population_size=10, initial_sigma=0.5, seed=42)
+        policy = _make_tmnf_policy(population_size=10, initial_sigma=0.5, seed=42)
         policy.initialize_random()
         for _ in range(n_gens):
             policy.sample_population()
@@ -379,7 +424,6 @@ class TestCMAESTrainerState(unittest.TestCase):
     def test_save_load_roundtrip_all_arrays(self):
         """save_trainer_state → load_trainer_state preserves all distribution arrays
         and the loaded state drives subsequent evolution correctly."""
-        import tempfile
         policy = self._make_trained_policy()
 
         with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
@@ -387,7 +431,7 @@ class TestCMAESTrainerState(unittest.TestCase):
         try:
             policy.save_trainer_state(path)
 
-            policy2 = CMAESPolicy(population_size=10, initial_sigma=0.99, seed=99)
+            policy2 = _make_tmnf_policy(population_size=10, initial_sigma=0.99, seed=99)
             policy2.initialize_random()
             policy2.load_trainer_state(path)
 
@@ -401,20 +445,17 @@ class TestCMAESTrainerState(unittest.TestCase):
             self.assertAlmostEqual(policy._sigma, policy2._sigma)
             self.assertEqual(policy._gen,         policy2._gen)
 
-            # Verify that evolution continues from the loaded state (gen increments)
             prev_mean = policy2._mean.copy()
             policy2.sample_population()
             policy2.update_distribution([float(i) for i in range(10)])
             self.assertEqual(policy2._gen, policy._gen + 1)
-            # Mean should have shifted from the loaded state
             self.assertFalse(np.allclose(policy2._mean, prev_mean))
         finally:
             os.unlink(path)
 
     def test_load_wrong_dimension_raises(self):
         """Loading state whose n differs from current obs space raises ValueError."""
-        import tempfile
-        policy1 = CMAESPolicy(population_size=6, n_lidar_rays=0)
+        policy1 = _make_tmnf_policy(population_size=6)
         policy1.initialize_random()
         policy1.sample_population()
         policy1.update_distribution([float(i) for i in range(6)])
@@ -423,7 +464,11 @@ class TestCMAESTrainerState(unittest.TestCase):
             path = f.name
         try:
             policy1.save_trainer_state(path)
-            policy2 = CMAESPolicy(population_size=6, n_lidar_rays=4)  # different n
+            # Different n_params (different obs_spec)
+            lidar_spec  = _OBS_SPEC.with_lidar(4)
+            n_params2   = lidar_spec.dim * _N_HEADS
+            policy2     = CMAESPolicy(lidar_spec, _tmnf_factory, n_params2,
+                                      population_size=6)
             with self.assertRaises(ValueError):
                 policy2.load_trainer_state(path)
         finally:

--- a/tests/test_framework_algorithm_equivalence.py
+++ b/tests/test_framework_algorithm_equivalence.py
@@ -1,0 +1,255 @@
+"""Verify framework algorithms produce byte-identical outputs to their TMNF game counterparts.
+
+Each test:
+  1. Creates both the framework version and the TMNF game version with identical
+     seeds and hyperparameters.
+  2. Copies weights from the framework policy into the TMNF policy (or vice versa),
+     ensuring they share exactly the same parameter values regardless of
+     initialisation order.
+  3. Asserts that forward-pass outputs are bit-for-bit identical.
+
+If any test here fails it means the framework port introduced a numerical
+discrepancy in the core computation (forward pass, Q-value computation, etc.).
+"""
+import unittest
+
+import numpy as np
+
+from framework.dqn import DQNPolicy
+from framework.lstm import LSTMCore
+from framework.reinforce import REINFORCEPolicy
+from games.tmnf.actions import DISCRETE_ACTIONS
+from games.tmnf.obs_spec import BASE_OBS_DIM, TMNF_OBS_SPEC
+from games.tmnf.policies import LSTMPolicy as TmnfLSTMPolicy
+from games.tmnf.policies import NeuralDQNPolicy as TmnfDQNPolicy
+from games.tmnf.policies import REINFORCEPolicy as TmnfREINFORCEPolicy
+
+_OBS_SPEC  = TMNF_OBS_SPEC
+_N         = BASE_OBS_DIM
+_N_ACTIONS = len(DISCRETE_ACTIONS)
+_ACTION_DEC = lambda i: DISCRETE_ACTIONS[i]  # noqa: E731
+
+
+def _zero_obs() -> np.ndarray:
+    return np.zeros(_N, dtype=np.float32)
+
+
+def _rand_obs(seed: int = 0) -> np.ndarray:
+    return np.random.default_rng(seed).standard_normal(_N).astype(np.float32)
+
+
+# ---------------------------------------------------------------------------
+# DQNPolicy ↔ NeuralDQNPolicy
+# ---------------------------------------------------------------------------
+
+class TestDQNEquivalence(unittest.TestCase):
+    """Framework DQNPolicy and TMNF NeuralDQNPolicy produce identical Q-values
+    when given the same weights and the same normalised observation."""
+
+    def _make_pair(self, hidden_sizes, seed):
+        fw = DQNPolicy(
+            _OBS_SPEC, DISCRETE_ACTIONS,
+            hidden_sizes=hidden_sizes,
+            replay_buffer_size=100,
+            min_replay_size=10,
+            seed=seed,
+        )
+        tmnf = TmnfDQNPolicy(
+            hidden_sizes=hidden_sizes,
+            replay_buffer_size=100,
+            min_replay_size=10,
+            n_lidar_rays=0,
+            seed=seed,
+        )
+        # Copy framework weights into TMNF policy so both share identical parameters.
+        for i in range(len(fw._online["weights"])):
+            tmnf._online["weights"][i] = fw._online["weights"][i].copy()
+            tmnf._online["biases"][i]  = fw._online["biases"][i].copy()
+        return fw, tmnf
+
+    def test_q_values_zero_obs(self):
+        fw, tmnf = self._make_pair([8, 8], seed=7)
+        obs_norm = _zero_obs() / fw._scales
+        fw_q   = fw._q_values(fw._online,     obs_norm)
+        tmnf_q = tmnf._q_values(tmnf._online, obs_norm)
+        np.testing.assert_array_equal(fw_q, tmnf_q)
+
+    def test_q_values_random_obs(self):
+        fw, tmnf = self._make_pair([16], seed=3)
+        obs_norm = _rand_obs(seed=5) / fw._scales
+        fw_q   = fw._q_values(fw._online,     obs_norm)
+        tmnf_q = tmnf._q_values(tmnf._online, obs_norm)
+        np.testing.assert_array_equal(fw_q, tmnf_q)
+
+    def test_q_values_shape(self):
+        fw, _ = self._make_pair([8], seed=0)
+        obs_norm = _zero_obs() / fw._scales
+        q = fw._q_values(fw._online, obs_norm)
+        self.assertEqual(q.shape, (_N_ACTIONS,))
+
+    def test_greedy_action_matches(self):
+        """Greedy action index must agree when both networks share weights."""
+        fw, tmnf = self._make_pair([8], seed=11)
+        obs = _rand_obs(seed=22)
+        fw._eps   = 0.0
+        tmnf._eps = 0.0
+        act_fw   = fw(obs)
+        act_tmnf = tmnf(obs)
+        np.testing.assert_array_equal(act_fw, act_tmnf)
+
+    def test_same_seed_produces_same_initial_weights(self):
+        """Both policies seeded identically should initialise to identical weights."""
+        seed = 42
+        fw   = DQNPolicy(_OBS_SPEC, DISCRETE_ACTIONS, hidden_sizes=[8], seed=seed)
+        tmnf = TmnfDQNPolicy(hidden_sizes=[8], n_lidar_rays=0, seed=seed)
+        for i in range(len(fw._online["weights"])):
+            np.testing.assert_array_equal(fw._online["weights"][i],
+                                          tmnf._online["weights"][i])
+            np.testing.assert_array_equal(fw._online["biases"][i],
+                                          tmnf._online["biases"][i])
+
+
+# ---------------------------------------------------------------------------
+# REINFORCEPolicy ↔ REINFORCEPolicy (TMNF)
+# ---------------------------------------------------------------------------
+
+class TestREINFORCEEquivalence(unittest.TestCase):
+    """Framework REINFORCEPolicy and TMNF REINFORCEPolicy produce identical
+    softmax distributions when given the same weights and the same observation."""
+
+    def _make_pair(self, hidden_sizes, seed):
+        fw = REINFORCEPolicy(
+            _OBS_SPEC, _ACTION_DEC,
+            output_dim=_N_ACTIONS,
+            hidden_sizes=hidden_sizes,
+            entropy_coeff=0.0,
+            seed=seed,
+        )
+        tmnf = TmnfREINFORCEPolicy(
+            hidden_sizes=hidden_sizes,
+            n_lidar_rays=0,
+            entropy_coeff=0.0,
+            seed=seed,
+        )
+        # Copy framework weights into TMNF policy.
+        for i in range(len(fw._weights)):
+            tmnf._weights[i] = fw._weights[i].copy()
+            tmnf._biases[i]  = fw._biases[i].copy()
+        return fw, tmnf
+
+    def _fw_probs(self, fw, obs):
+        probs, _, _ = fw._forward(obs / fw._scales)
+        return probs
+
+    def _tmnf_probs(self, tmnf, obs):
+        probs, _, _ = tmnf._forward(obs / tmnf._scales)
+        return probs
+
+    def test_softmax_probs_zero_obs(self):
+        fw, tmnf = self._make_pair([8, 8], seed=5)
+        obs = _zero_obs()
+        np.testing.assert_array_equal(
+            self._fw_probs(fw, obs),
+            self._tmnf_probs(tmnf, obs),
+        )
+
+    def test_softmax_probs_random_obs(self):
+        fw, tmnf = self._make_pair([16], seed=9)
+        obs = _rand_obs(seed=3)
+        np.testing.assert_array_equal(
+            self._fw_probs(fw, obs),
+            self._tmnf_probs(tmnf, obs),
+        )
+
+    def test_probs_sum_to_one(self):
+        fw, _ = self._make_pair([8], seed=0)
+        probs = self._fw_probs(fw, _rand_obs())
+        self.assertAlmostEqual(float(probs.sum()), 1.0, places=5)
+
+    def test_same_seed_produces_same_initial_weights(self):
+        """Both policies seeded identically should initialise to identical weights."""
+        seed = 13
+        fw   = REINFORCEPolicy(_OBS_SPEC, _ACTION_DEC, output_dim=_N_ACTIONS,
+                               hidden_sizes=[8], seed=seed)
+        tmnf = TmnfREINFORCEPolicy(hidden_sizes=[8], n_lidar_rays=0, seed=seed)
+        for i in range(len(fw._weights)):
+            np.testing.assert_array_equal(fw._weights[i], tmnf._weights[i])
+            np.testing.assert_array_equal(fw._biases[i],  tmnf._biases[i])
+
+
+# ---------------------------------------------------------------------------
+# LSTMCore ↔ LSTMPolicy (TMNF)
+# ---------------------------------------------------------------------------
+
+class TestLSTMEquivalence(unittest.TestCase):
+    """Framework LSTMCore and TMNF LSTMPolicy produce identical hidden states
+    and output actions when given the same weights and the same observations."""
+
+    def _make_pair(self, hidden_size, seed):
+        fw   = LSTMCore(_OBS_SPEC, hidden_size=hidden_size, seed=seed)
+        tmnf = TmnfLSTMPolicy(hidden_size=hidden_size, n_lidar_rays=0, seed=seed)
+        # Copy framework weights into TMNF policy.
+        for attr in ("_W_f", "_b_f", "_W_i", "_b_i",
+                     "_W_g", "_b_g", "_W_o", "_b_o",
+                     "_W_steer", "_W_accel", "_W_brake"):
+            setattr(tmnf, attr, getattr(fw, attr).copy())
+        return fw, tmnf
+
+    def test_hidden_state_identical_after_one_step(self):
+        fw, tmnf = self._make_pair(8, seed=0)
+        obs = _rand_obs(seed=1)
+        fw(obs)
+        tmnf(obs)
+        np.testing.assert_array_equal(fw._h, tmnf._h)
+        np.testing.assert_array_equal(fw._c, tmnf._c)
+
+    def test_action_identical_after_one_step(self):
+        fw, tmnf = self._make_pair(8, seed=2)
+        obs = _rand_obs(seed=4)
+        act_fw   = fw(obs)
+        act_tmnf = tmnf(obs)
+        np.testing.assert_array_equal(act_fw, act_tmnf)
+
+    def test_hidden_state_identical_after_sequence(self):
+        fw, tmnf = self._make_pair(16, seed=3)
+        for i in range(10):
+            obs = _rand_obs(seed=i)
+            fw(obs)
+            tmnf(obs)
+        np.testing.assert_array_equal(fw._h, tmnf._h)
+        np.testing.assert_array_equal(fw._c, tmnf._c)
+
+    def test_episode_reset_in_sync(self):
+        fw, tmnf = self._make_pair(8, seed=5)
+        for _ in range(5):
+            fw(_rand_obs(seed=0))
+            tmnf(_rand_obs(seed=0))
+        fw.on_episode_end()
+        tmnf.on_episode_end()
+        np.testing.assert_array_equal(fw._h, tmnf._h)
+        np.testing.assert_array_equal(fw._c, tmnf._c)
+
+    def test_flat_roundtrip_produces_same_output(self):
+        """to_flat() / with_flat() must preserve weights to float32 precision."""
+        fw = LSTMCore(_OBS_SPEC, hidden_size=8, seed=6)
+        flat = fw.to_flat()
+        fw2  = fw.with_flat(flat)
+        obs  = _rand_obs(seed=7)
+        np.testing.assert_array_almost_equal(fw(obs), fw2(obs), decimal=5)
+
+    def test_same_seed_produces_same_initial_weights(self):
+        """Both policies seeded identically should initialise to identical weights."""
+        seed = 17
+        fw   = LSTMCore(_OBS_SPEC, hidden_size=8, seed=seed)
+        tmnf = TmnfLSTMPolicy(hidden_size=8, n_lidar_rays=0, seed=seed)
+        for attr in ("_W_f", "_b_f", "_W_i", "_b_i",
+                     "_W_g", "_b_g", "_W_o", "_b_o",
+                     "_W_steer", "_W_accel", "_W_brake"):
+            np.testing.assert_array_equal(
+                getattr(fw, attr), getattr(tmnf, attr),
+                err_msg=f"{attr} mismatch between framework and TMNF",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_lstm_policy.py
+++ b/tests/test_lstm_policy.py
@@ -1,13 +1,16 @@
-"""Tests for LSTMPolicy and LSTMEvolutionPolicy in games/tmnf/policies.py."""
+"""Tests for LSTMCore and LSTMEvolutionPolicy in framework/lstm.py."""
 import unittest
 
 import numpy as np
 
-from games.tmnf.policies import LSTMPolicy, LSTMEvolutionPolicy
-from games.tmnf.obs_spec import BASE_OBS_DIM
-
+from framework.lstm import LSTMCore, LSTMEvolutionPolicy
+from games.tmnf.obs_spec import BASE_OBS_DIM, TMNF_OBS_SPEC
 
 _OBS_DIM = BASE_OBS_DIM
+_OBS_SPEC = TMNF_OBS_SPEC
+
+# Alias so existing test references like LSTMPolicy(...) still read naturally
+LSTMPolicy = LSTMCore
 
 
 def _zero_obs(n_lidar_rays: int = 0) -> np.ndarray:
@@ -19,13 +22,13 @@ def _rand_obs(n_lidar_rays: int = 0, seed: int = 0) -> np.ndarray:
 
 
 # ---------------------------------------------------------------------------
-# LSTMPolicy unit tests
+# LSTMCore unit tests
 # ---------------------------------------------------------------------------
 
 class TestLSTMPolicyStructure(unittest.TestCase):
 
     def setUp(self):
-        self.policy = LSTMPolicy(hidden_size=8, n_lidar_rays=0, seed=0)
+        self.policy = LSTMPolicy(_OBS_SPEC, hidden_size=8, seed=0)
 
     def test_action_shape(self):
         action = self.policy(_zero_obs())
@@ -79,8 +82,8 @@ class TestLSTMPolicyStructure(unittest.TestCase):
         obs_seq  = [_rand_obs(seed=i) for i in range(5)]
         final    = _rand_obs(seed=99)
 
-        policy_a = LSTMPolicy(hidden_size=16, seed=7)
-        policy_b = LSTMPolicy(hidden_size=16, seed=7)
+        policy_a = LSTMPolicy(_OBS_SPEC, hidden_size=16, seed=7)
+        policy_b = LSTMPolicy(_OBS_SPEC, hidden_size=16, seed=7)
 
         # Feed different history to each
         for obs in obs_seq:
@@ -97,7 +100,7 @@ class TestLSTMPolicyStructure(unittest.TestCase):
 class TestLSTMFlatInterface(unittest.TestCase):
 
     def setUp(self):
-        self.policy = LSTMPolicy(hidden_size=8, n_lidar_rays=0, seed=1)
+        self.policy = LSTMPolicy(_OBS_SPEC, hidden_size=8, seed=1)
 
     def test_flat_dim_correct(self):
         h    = 8
@@ -151,7 +154,8 @@ class TestLSTMFlatInterface(unittest.TestCase):
         self.assertEqual(mutant._obs_dim,     self.policy._obs_dim)
 
     def test_flat_roundtrip_with_lidar(self):
-        p    = LSTMPolicy(hidden_size=4, n_lidar_rays=3, seed=5)
+        lidar_spec = _OBS_SPEC.with_lidar(3)
+        p    = LSTMPolicy(lidar_spec, hidden_size=4, seed=5)
         flat = p.to_flat()
         p2   = p.with_flat(flat)
         np.testing.assert_array_almost_equal(flat, p2.to_flat(), decimal=6)
@@ -160,21 +164,21 @@ class TestLSTMFlatInterface(unittest.TestCase):
 class TestLSTMPolicySerialisation(unittest.TestCase):
 
     def test_to_cfg_contains_required_keys(self):
-        p   = LSTMPolicy(hidden_size=8)
+        p   = LSTMPolicy(_OBS_SPEC, hidden_size=8)
         cfg = p.to_cfg()
-        for key in ("policy_type", "hidden_size", "n_lidar_rays", "obs_dim",
+        for key in ("policy_type", "hidden_size", "obs_dim",
                     "W_f", "b_f", "W_i", "b_i", "W_g", "b_g", "W_o", "b_o",
                     "W_steer", "W_accel", "W_brake"):
             self.assertIn(key, cfg)
 
     def test_policy_type_string(self):
-        p = LSTMPolicy(hidden_size=8)
+        p = LSTMPolicy(_OBS_SPEC, hidden_size=8)
         self.assertEqual(p.to_cfg()["policy_type"], "lstm")
 
     def test_from_cfg_roundtrip(self):
-        p   = LSTMPolicy(hidden_size=8, seed=3)
+        p   = LSTMPolicy(_OBS_SPEC, hidden_size=8, seed=3)
         cfg = p.to_cfg()
-        p2  = LSTMPolicy.from_cfg(cfg)
+        p2  = LSTMCore.from_cfg(cfg, _OBS_SPEC)
         np.testing.assert_array_almost_equal(p._W_f,    p2._W_f,    decimal=6)
         np.testing.assert_array_almost_equal(p._W_steer, p2._W_steer, decimal=6)
         self.assertEqual(p2._hidden_size, 8)
@@ -182,7 +186,7 @@ class TestLSTMPolicySerialisation(unittest.TestCase):
 
     def test_save_and_reload(self):
         import tempfile, os, yaml
-        p = LSTMPolicy(hidden_size=4, seed=42)
+        p = LSTMPolicy(_OBS_SPEC, hidden_size=4, seed=42)
         with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
             path = f.name
         try:
@@ -190,7 +194,7 @@ class TestLSTMPolicySerialisation(unittest.TestCase):
             with open(path) as f:
                 cfg = yaml.safe_load(f)
             self.assertEqual(cfg["policy_type"], "lstm")
-            p2 = LSTMPolicy.from_cfg(cfg)
+            p2 = LSTMCore.from_cfg(cfg, _OBS_SPEC)
             np.testing.assert_array_almost_equal(p._W_i, p2._W_i, decimal=5)
         finally:
             os.unlink(path)
@@ -203,49 +207,49 @@ class TestLSTMPolicySerialisation(unittest.TestCase):
 class TestLSTMEvolutionPolicyInit(unittest.TestCase):
 
     def test_population_size_property(self):
-        policy = LSTMEvolutionPolicy(population_size=12)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, population_size=12)
         self.assertEqual(policy.population_size, 12)
 
     def test_sigma_property(self):
-        policy = LSTMEvolutionPolicy(initial_sigma=0.07)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, initial_sigma=0.07)
         self.assertAlmostEqual(policy.sigma, 0.07)
 
     def test_champion_reward_starts_at_neg_inf(self):
-        policy = LSTMEvolutionPolicy()
+        policy = LSTMEvolutionPolicy(_OBS_SPEC)
         self.assertEqual(policy.champion_reward, float("-inf"))
 
     def test_flat_dim_matches_template(self):
-        policy = LSTMEvolutionPolicy(hidden_size=8)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=8)
         self.assertEqual(policy._flat_dim, policy._template.flat_dim)
 
     def test_mu_is_half_lambda(self):
-        policy = LSTMEvolutionPolicy(population_size=20)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, population_size=20)
         self.assertEqual(policy._mu, 10)
 
     def test_recomb_weights_sum_to_one(self):
-        policy = LSTMEvolutionPolicy(population_size=16)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, population_size=16)
         self.assertAlmostEqual(float(policy._recomb_w.sum()), 1.0, places=10)
 
 
 class TestLSTMEvolutionPolicySampling(unittest.TestCase):
 
     def test_sample_population_count(self):
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=8, seed=0)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=8, seed=0)
         pop    = policy.sample_population()
         self.assertEqual(len(pop), 8)
 
     def test_sample_population_returns_lstm_policies(self):
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=6, seed=1)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=6, seed=1)
         for ind in policy.sample_population():
-            self.assertIsInstance(ind, LSTMPolicy)
+            self.assertIsInstance(ind, LSTMCore)
 
     def test_pop_buffer_fills_on_sample(self):
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=6, seed=2)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=6, seed=2)
         policy.sample_population()
         self.assertEqual(len(policy._pop), 6)
 
     def test_sample_produces_distinct_individuals(self):
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=6, seed=3)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=6, seed=3)
         pop    = policy.sample_population()
         flat_0 = pop[0].to_flat()
         flat_1 = pop[1].to_flat()
@@ -255,8 +259,8 @@ class TestLSTMEvolutionPolicySampling(unittest.TestCase):
 class TestLSTMEvolutionPolicyUpdate(unittest.TestCase):
 
     def _setup(self, pop=8, seed=0):
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=pop,
-                                      initial_sigma=0.1, seed=seed)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=pop,
+                                     initial_sigma=0.1, seed=seed)
         policy.sample_population()
         return policy
 
@@ -269,7 +273,7 @@ class TestLSTMEvolutionPolicyUpdate(unittest.TestCase):
         policy = self._setup()
         policy.update_distribution([float(i) for i in range(8)])
         self.assertIsNotNone(policy._champion)
-        self.assertIsInstance(policy._champion, LSTMPolicy)
+        self.assertIsInstance(policy._champion, LSTMCore)
 
     def test_champion_reward_is_best_seen(self):
         policy = self._setup()
@@ -295,7 +299,7 @@ class TestLSTMEvolutionPolicyUpdate(unittest.TestCase):
             policy.update_distribution([0.0] * 5)  # wrong count
 
     def test_update_without_sample_raises(self):
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=8, seed=0)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=8, seed=0)
         # Never called sample_population() — _pop is empty
         with self.assertRaises(RuntimeError):
             policy.update_distribution([0.0] * 8)
@@ -311,13 +315,13 @@ class TestLSTMEvolutionPolicyUpdate(unittest.TestCase):
 class TestLSTMEvolutionPolicyCallable(unittest.TestCase):
 
     def test_call_raises_before_any_update(self):
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=4, seed=0)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=4, seed=0)
         policy.sample_population()
         with self.assertRaises(RuntimeError):
             policy(_zero_obs())
 
     def test_call_returns_valid_action_after_update(self):
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=4, seed=0)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=4, seed=0)
         policy.sample_population()
         policy.update_distribution([float(i) for i in range(4)])
         action = policy(_zero_obs())
@@ -328,7 +332,7 @@ class TestLSTMEvolutionPolicyCallable(unittest.TestCase):
         self.assertIn(float(action[2]), (0.0, 1.0))
 
     def test_on_episode_end_resets_champion_hidden_state(self):
-        policy = LSTMEvolutionPolicy(hidden_size=8, population_size=4, seed=0)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=8, population_size=4, seed=0)
         policy.sample_population()
         policy.update_distribution([float(i) for i in range(4)])
         # Drive champion hidden state non-zero
@@ -342,19 +346,19 @@ class TestLSTMEvolutionPolicyCallable(unittest.TestCase):
 class TestLSTMEvolutionPolicySerialisation(unittest.TestCase):
 
     def test_to_cfg_keys(self):
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=6)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=6)
         cfg    = policy.to_cfg()
         for key in ("policy_type", "hidden_size", "population_size",
-                    "sigma", "n_lidar_rays", "champion_reward"):
+                    "sigma", "champion_reward"):
             self.assertIn(key, cfg)
 
     def test_policy_type_string(self):
-        policy = LSTMEvolutionPolicy()
+        policy = LSTMEvolutionPolicy(_OBS_SPEC)
         self.assertEqual(policy.to_cfg()["policy_type"], "lstm")
 
     def test_save_writes_lstm_yaml(self):
         import tempfile, os, yaml
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=4, seed=0)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=4, seed=0)
         policy.sample_population()
         policy.update_distribution([float(i) for i in range(4)])
         with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
@@ -369,8 +373,8 @@ class TestLSTMEvolutionPolicySerialisation(unittest.TestCase):
             os.unlink(path)
 
     def test_initialize_from_champion(self):
-        champion = LSTMPolicy(hidden_size=8, seed=5)
-        policy   = LSTMEvolutionPolicy(hidden_size=8, population_size=4)
+        champion = LSTMPolicy(_OBS_SPEC, hidden_size=8, seed=5)
+        policy   = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=8, population_size=4)
         policy.initialize_from_champion(champion)
         np.testing.assert_array_almost_equal(
             policy._mean, champion.to_flat().astype(np.float64), decimal=6)
@@ -381,8 +385,8 @@ class TestLSTMEvolutionConvergence(unittest.TestCase):
 
     def test_mean_moves_toward_target(self):
         """ES mean should move toward the minimizer of a quadratic after 20 generations."""
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=16,
-                                      initial_sigma=0.5, n_lidar_rays=0, seed=42)
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=16,
+                                     initial_sigma=0.5, seed=42)
         target = np.ones(policy._flat_dim, dtype=np.float64)
         initial_dist = float(np.linalg.norm(policy._mean - target))
 
@@ -403,7 +407,7 @@ class TestLSTMEvolutionConvergence(unittest.TestCase):
 class TestLSTMEvolutionTrainerState(unittest.TestCase):
 
     def _make_trained_policy(self) -> "LSTMEvolutionPolicy":
-        policy = LSTMEvolutionPolicy(hidden_size=4, population_size=6,
+        policy = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=6,
                                      initial_sigma=0.1, seed=42)
         for _ in range(2):
             policy.sample_population()
@@ -421,7 +425,7 @@ class TestLSTMEvolutionTrainerState(unittest.TestCase):
         try:
             policy.save_trainer_state(path)
 
-            policy2 = LSTMEvolutionPolicy(hidden_size=4, population_size=6,
+            policy2 = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=6,
                                           initial_sigma=0.99, seed=99)
             policy2.load_trainer_state(path)
 
@@ -440,7 +444,7 @@ class TestLSTMEvolutionTrainerState(unittest.TestCase):
     def test_load_wrong_flat_dim_raises(self):
         """Loading state with mismatched flat_dim raises ValueError."""
         import tempfile, os
-        policy1 = LSTMEvolutionPolicy(hidden_size=4, population_size=4, n_lidar_rays=0)
+        policy1 = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=4, population_size=4)
         policy1.sample_population()
         policy1.update_distribution([float(i) for i in range(4)])
 
@@ -448,7 +452,7 @@ class TestLSTMEvolutionTrainerState(unittest.TestCase):
             path = f.name
         try:
             policy1.save_trainer_state(path)
-            policy2 = LSTMEvolutionPolicy(hidden_size=8, population_size=4, n_lidar_rays=0)
+            policy2 = LSTMEvolutionPolicy(_OBS_SPEC, hidden_size=8, population_size=4)
             with self.assertRaises(ValueError):
                 policy2.load_trainer_state(path)
         finally:

--- a/tests/test_neural_dqn_policy.py
+++ b/tests/test_neural_dqn_policy.py
@@ -1,17 +1,19 @@
-"""Tests for NeuralDQNPolicy and ReplayBuffer in policies.py."""
+"""Tests for DQNPolicy and ReplayBuffer in framework/dqn.py and framework/replay.py."""
 import unittest
 
 import numpy as np
 
-from games.tmnf.obs_spec import BASE_OBS_DIM
-from games.tmnf.policies import (
-    NeuralDQNPolicy,
-    ReplayBuffer,
-    _DISCRETE_ACTIONS,
-    _action_to_idx,
-)
+from framework.dqn import DQNPolicy
+from framework.replay import ReplayBuffer
+from games.tmnf.obs_spec import BASE_OBS_DIM, TMNF_OBS_SPEC
+from games.tmnf.actions import DISCRETE_ACTIONS, _action_to_idx
 
 _N = BASE_OBS_DIM
+
+# Alias for test code that referenced the old class name
+NeuralDQNPolicy = DQNPolicy
+
+_OBS_SPEC = TMNF_OBS_SPEC
 
 
 def _zero_obs() -> np.ndarray:
@@ -58,7 +60,6 @@ class TestReplayBuffer(unittest.TestCase):
         for i in range(20):
             buf.push(_rand_obs(), i % 9, float(i), _rand_obs(), False)
         _, act_b, rew_b, _, _ = buf.sample(10)
-        # rewards encode unique step indices — duplicates would repeat a reward
         self.assertEqual(len(set(rew_b.tolist())), 10)
 
     def test_sample_with_replacement_when_small(self):
@@ -66,18 +67,17 @@ class TestReplayBuffer(unittest.TestCase):
         buf = ReplayBuffer(maxlen=100)
         for i in range(3):
             buf.push(_rand_obs(), i % 9, float(i), _rand_obs(), False)
-        # Requesting more samples than buffer size should not raise
         obs_b, act_b, rew_b, next_b, done_b = buf.sample(10)
         self.assertEqual(obs_b.shape[0], 10)
 
 
 # ---------------------------------------------------------------------------
-# NeuralDQNPolicy structural tests
+# DQNPolicy structural tests
 # ---------------------------------------------------------------------------
 
 class TestNeuralDQNPolicyStructure(unittest.TestCase):
 
-    def _make(self, **kw) -> NeuralDQNPolicy:
+    def _make(self, **kw) -> DQNPolicy:
         defaults = dict(
             hidden_sizes=[8, 8],
             replay_buffer_size=200,
@@ -89,10 +89,9 @@ class TestNeuralDQNPolicyStructure(unittest.TestCase):
             epsilon_end=0.05,
             epsilon_decay_steps=100,
             gamma=0.99,
-            n_lidar_rays=0,
         )
         defaults.update(kw)
-        return NeuralDQNPolicy(**defaults)
+        return DQNPolicy(_OBS_SPEC, DISCRETE_ACTIONS, **defaults)
 
     def test_action_shape_and_range(self):
         p   = self._make(epsilon_start=0.0)
@@ -138,10 +137,8 @@ class TestNeuralDQNPolicyStructure(unittest.TestCase):
     def test_target_sync_happens(self):
         """Target network weights should match online after a sync."""
         p = self._make(target_update_freq=5, min_replay_size=16)
-        # Fill buffer and trigger enough gradient steps to force a sync
         for _ in range(50):
             p.update(_rand_obs(), np.random.randint(25), 0.0, _rand_obs(), False)
-        # After sync, target matches online
         for w_on, w_tgt in zip(p._online["weights"], p._target["weights"]):
             np.testing.assert_array_equal(w_on, w_tgt)
 
@@ -155,38 +152,39 @@ class TestNeuralDQNPolicyStructure(unittest.TestCase):
     def test_to_cfg_roundtrip(self):
         p   = self._make(epsilon_start=0.0)
         cfg = p.to_cfg()
-        p2  = NeuralDQNPolicy.from_cfg(cfg)
+        p2  = DQNPolicy.from_cfg(cfg, _OBS_SPEC, DISCRETE_ACTIONS)
         obs = _rand_obs()
-        # Greedy actions should match after round-trip
         p._eps  = 0.0
         p2._eps = 0.0
         np.testing.assert_array_equal(p(obs), p2(obs))
 
     def test_cfg_policy_type_key(self):
         p = self._make()
-        self.assertEqual(p.to_cfg()["policy_type"], "neural_dqn")
+        self.assertEqual(p.to_cfg()["policy_type"], "dqn")
 
     def test_on_episode_end_no_crash(self):
         p = self._make()
-        p.on_episode_end()   # should not raise
+        p.on_episode_end()
 
     def test_from_cfg_missing_keys_raises(self):
         """from_cfg() should raise KeyError if weight keys are incomplete."""
-        cfg = {"online_weights": [[[1.0]]]}  # missing other required keys
+        cfg = {"online_weights": [[[1.0]]]}
         with self.assertRaises(KeyError):
-            NeuralDQNPolicy.from_cfg(cfg)
+            DQNPolicy.from_cfg(cfg, _OBS_SPEC, DISCRETE_ACTIONS)
 
     def test_from_cfg_shape_mismatch_raises(self):
         """from_cfg() should raise ValueError when obs_dim doesn't match weights."""
         p   = self._make()
         cfg = p.to_cfg()
-        # Pass a different n_lidar_rays to cause shape mismatch
+        # Use a different obs_spec to cause shape mismatch
+        from games.tmnf.obs_spec import TMNF_OBS_SPEC
+        wrong_spec = TMNF_OBS_SPEC.with_lidar(5)
         with self.assertRaises(ValueError):
-            NeuralDQNPolicy.from_cfg(cfg, n_lidar_rays=5)
+            DQNPolicy.from_cfg(cfg, wrong_spec, DISCRETE_ACTIONS)
 
 
 # ---------------------------------------------------------------------------
-# NeuralDQNPolicy convergence test (2-state bandit MDP)
+# DQNPolicy convergence test (2-state bandit MDP)
 # ---------------------------------------------------------------------------
 
 class TestNeuralDQNConvergence(unittest.TestCase):
@@ -205,7 +203,9 @@ class TestNeuralDQNConvergence(unittest.TestCase):
         GOOD_R  =  1.0
         BAD_R   = -0.1
 
-        policy = NeuralDQNPolicy(
+        policy = DQNPolicy(
+            _OBS_SPEC,
+            DISCRETE_ACTIONS,
             hidden_sizes        = [32, 32],
             replay_buffer_size  = 5000,
             batch_size          = 32,
@@ -213,20 +213,17 @@ class TestNeuralDQNConvergence(unittest.TestCase):
             target_update_freq  = 25,
             learning_rate       = 0.005,
             epsilon_start       = 1.0,
-            epsilon_end         = 1.0,   # keep at 1; we push transitions directly
+            epsilon_end         = 1.0,
             epsilon_decay_steps = 1,
-            gamma               = 0.0,   # pure bandit — no bootstrapping
-            n_lidar_rays        = 0,
+            gamma               = 0.0,
         )
 
         next_obs = np.zeros(N, dtype=np.float32)
-        # Cycle through all 25 actions so each is equally represented
         for step in range(12500):
             action_idx = step % 25
             r = GOOD_R if action_idx == BEST else BAD_R
             policy.update(state, action_idx, r, next_obs, done=True)
 
-        # Evaluate greedy
         policy._eps = 0.0
         obs_norm    = (state / policy._scales).astype(np.float32)
         q_vals      = policy._q_values(policy._online, obs_norm)
@@ -236,14 +233,15 @@ class TestNeuralDQNConvergence(unittest.TestCase):
             greedy_idx, BEST,
             f"Expected greedy action {BEST}, got {greedy_idx}. Q-values: {q_vals.tolist()}"
         )
-        # The best action should also have a clearly higher Q-value
         self.assertGreater(float(q_vals[BEST]), float(np.max(np.delete(q_vals, BEST))))
 
 
 class TestNeuralDQNTrainerState(unittest.TestCase):
 
-    def _make_trained_policy(self) -> NeuralDQNPolicy:
-        policy = NeuralDQNPolicy(
+    def _make_trained_policy(self) -> DQNPolicy:
+        policy = DQNPolicy(
+            _OBS_SPEC,
+            DISCRETE_ACTIONS,
             hidden_sizes        = [16, 16],
             replay_buffer_size  = 200,
             batch_size          = 16,
@@ -253,9 +251,8 @@ class TestNeuralDQNTrainerState(unittest.TestCase):
             epsilon_start       = 1.0,
             epsilon_end         = 0.05,
             epsilon_decay_steps = 100,
-            n_lidar_rays        = 0,
         )
-        obs  = np.zeros(_N, dtype=np.float32)
+        obs      = np.zeros(_N, dtype=np.float32)
         next_obs = np.zeros(_N, dtype=np.float32)
         for i in range(50):
             policy.update(obs, i % 9, float(i % 3), next_obs, done=False)
@@ -266,33 +263,30 @@ class TestNeuralDQNTrainerState(unittest.TestCase):
         import tempfile, os
         policy = self._make_trained_policy()
         original_buf_len = len(policy._replay)
-
-        # Capture original buffer contents for comparison
-        original_buf = list(policy._replay._buf)
+        original_buf     = list(policy._replay._buf)
 
         with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
             path = f.name
         try:
             policy.save_trainer_state(path)
 
-            policy2 = NeuralDQNPolicy(
-                hidden_sizes        = [16, 16],
-                replay_buffer_size  = 200,
-                min_replay_size     = 32,
-                n_lidar_rays        = 0,
+            policy2 = DQNPolicy(
+                _OBS_SPEC,
+                DISCRETE_ACTIONS,
+                hidden_sizes       = [16, 16],
+                replay_buffer_size = 200,
+                min_replay_size    = 32,
             )
             policy2.load_trainer_state(path)
 
             self.assertEqual(len(policy2._replay), original_buf_len)
-
-            # Verify actual transition contents match
             restored_buf = list(policy2._replay._buf)
             for orig, rest in zip(original_buf, restored_buf):
-                np.testing.assert_array_equal(orig[0], rest[0])   # obs
-                self.assertEqual(orig[1], rest[1])                 # action_idx
-                self.assertAlmostEqual(orig[2], rest[2])           # reward
-                np.testing.assert_array_equal(orig[3], rest[3])   # next_obs
-                self.assertEqual(orig[4], rest[4])                 # done
+                np.testing.assert_array_equal(orig[0], rest[0])
+                self.assertEqual(orig[1], rest[1])
+                self.assertAlmostEqual(orig[2], rest[2])
+                np.testing.assert_array_equal(orig[3], rest[3])
+                self.assertEqual(orig[4], rest[4])
         finally:
             os.unlink(path)
 
@@ -306,11 +300,12 @@ class TestNeuralDQNTrainerState(unittest.TestCase):
         try:
             policy.save_trainer_state(path)
 
-            policy2 = NeuralDQNPolicy(
-                hidden_sizes        = [16, 16],
-                replay_buffer_size  = 200,
-                min_replay_size     = 32,
-                n_lidar_rays        = 0,
+            policy2 = DQNPolicy(
+                _OBS_SPEC,
+                DISCRETE_ACTIONS,
+                hidden_sizes       = [16, 16],
+                replay_buffer_size = 200,
+                min_replay_size    = 32,
             )
             policy2.load_trainer_state(path)
 
@@ -326,12 +321,13 @@ class TestNeuralDQNTrainerState(unittest.TestCase):
     def test_load_wrong_obs_dim_raises(self):
         """Loading state with mismatched obs_dim raises ValueError."""
         import tempfile, os
-        policy1 = NeuralDQNPolicy(hidden_sizes=[16], replay_buffer_size=10, n_lidar_rays=0)
+        policy1 = DQNPolicy(_OBS_SPEC, DISCRETE_ACTIONS, hidden_sizes=[16], replay_buffer_size=10)
         with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
             path = f.name
         try:
             policy1.save_trainer_state(path)
-            policy2 = NeuralDQNPolicy(hidden_sizes=[16], replay_buffer_size=10, n_lidar_rays=4)
+            wrong_spec = _OBS_SPEC.with_lidar(4)
+            policy2 = DQNPolicy(wrong_spec, DISCRETE_ACTIONS, hidden_sizes=[16], replay_buffer_size=10)
             with self.assertRaises(ValueError):
                 policy2.load_trainer_state(path)
         finally:

--- a/tests/test_reinforce_policy.py
+++ b/tests/test_reinforce_policy.py
@@ -1,14 +1,23 @@
-"""Tests for REINFORCEPolicy in games/tmnf/policies.py."""
+"""Tests for REINFORCEPolicy in framework/reinforce.py."""
 import unittest
 
 import numpy as np
 
-from games.tmnf.policies import REINFORCEPolicy
+from framework.reinforce import REINFORCEPolicy
 from games.tmnf.actions import DISCRETE_ACTIONS
-from games.tmnf.obs_spec import BASE_OBS_DIM
+from games.tmnf.obs_spec import BASE_OBS_DIM, TMNF_OBS_SPEC
+
+_OBS_DIM   = BASE_OBS_DIM
+_OBS_SPEC  = TMNF_OBS_SPEC
+_N_ACTIONS = len(DISCRETE_ACTIONS)
+_ACTION_DEC = lambda i: DISCRETE_ACTIONS[i]  # noqa: E731
 
 
-_OBS_DIM = BASE_OBS_DIM
+def _make(**kw) -> REINFORCEPolicy:
+    """Create a TMNF-flavoured REINFORCEPolicy via the framework API."""
+    defaults = dict(output_dim=_N_ACTIONS)
+    defaults.update(kw)
+    return REINFORCEPolicy(_OBS_SPEC, _ACTION_DEC, **defaults)
 
 
 def _zero_obs(n_lidar_rays: int = 0) -> np.ndarray:
@@ -23,7 +32,7 @@ def _rand_obs(n_lidar_rays: int = 0, seed: int = 0) -> np.ndarray:
 class TestREINFORCEPolicyStructure(unittest.TestCase):
 
     def setUp(self):
-        self.policy = REINFORCEPolicy(hidden_sizes=[8, 8], n_lidar_rays=0, seed=0)
+        self.policy = _make(hidden_sizes=[8, 8], seed=0)
 
     def test_action_shape(self):
         action = self.policy(_zero_obs())
@@ -69,12 +78,11 @@ class TestREINFORCEPolicyStructure(unittest.TestCase):
         self.assertEqual(len(self.policy._ep_rewards), 0)
 
     def test_on_episode_end_with_empty_buffer_is_noop(self):
-        # Should not raise
         self.policy.on_episode_end()
 
     def test_weights_match_hidden_sizes(self):
-        p = REINFORCEPolicy(hidden_sizes=[32, 16], n_lidar_rays=0)
-        dims = [_OBS_DIM, 32, 16, len(DISCRETE_ACTIONS)]
+        p    = _make(hidden_sizes=[32, 16])
+        dims = [_OBS_DIM, 32, 16, _N_ACTIONS]
         for i, (w, b) in enumerate(zip(p._weights, p._biases)):
             self.assertEqual(w.shape, (dims[i + 1], dims[i]))
             self.assertEqual(b.shape, (dims[i + 1],))
@@ -83,9 +91,8 @@ class TestREINFORCEPolicyStructure(unittest.TestCase):
 class TestREINFORCEDiscountedReturns(unittest.TestCase):
 
     def _run_synthetic(self, rewards):
-        """Run one synthetic episode and return gradient info."""
-        policy = REINFORCEPolicy(hidden_sizes=[8], learning_rate=0.1,
-                                 gamma=0.9, entropy_coeff=0.0, seed=42)
+        policy = _make(hidden_sizes=[8], learning_rate=0.1,
+                       gamma=0.9, entropy_coeff=0.0, seed=42)
         obs = _zero_obs()
         for _ in range(len(rewards)):
             policy(obs)
@@ -100,8 +107,8 @@ class TestREINFORCEDiscountedReturns(unittest.TestCase):
         self.assertEqual(len(policy._ep_rewards), len(rewards))
 
     def test_weights_change_after_update(self):
-        policy   = REINFORCEPolicy(hidden_sizes=[8], learning_rate=0.5,
-                                   gamma=0.99, entropy_coeff=0.0, seed=1)
+        policy   = _make(hidden_sizes=[8], learning_rate=0.5,
+                         gamma=0.99, entropy_coeff=0.0, seed=1)
         w_before = [w.copy() for w in policy._weights]
         obs      = _rand_obs(seed=42)
         policy(obs)
@@ -113,29 +120,24 @@ class TestREINFORCEDiscountedReturns(unittest.TestCase):
 
     def test_gradient_direction(self):
         """
-        Acceptance criterion: after many episodes where action 7 (accel+straight)
-        always gets high reward and everything else gets zero, the log-probability
-        of action 7 should increase compared to baseline.
-
-        We verify that the logit for action 7 grows relative to action 0.
+        After many episodes where action 7 always gets high reward, the
+        log-probability of action 7 should increase relative to action 0.
         """
         np.random.seed(123)
-        policy  = REINFORCEPolicy(hidden_sizes=[16], learning_rate=0.05,
-                                  gamma=1.0, entropy_coeff=0.0,
-                                  baseline="none", seed=0)
+        policy  = _make(hidden_sizes=[16], learning_rate=0.05,
+                        gamma=1.0, entropy_coeff=0.0,
+                        baseline="none", seed=0)
         obs     = _rand_obs(seed=7)
-        target  = 7  # accel+straight
+        target  = 7
 
         def _get_logit_diff():
-            # forward pass to read softmax probs
             probs, _, _ = policy._forward(obs / policy._scales)
             return float(probs[target]) - float(probs[0])
 
         diff_before = _get_logit_diff()
 
         for _ in range(200):
-            policy(obs)   # stochastic action
-            # Force override: pretend we always took action 7
+            policy(obs)
             l_in, pre_r, probs_ep, _ = policy._ep_grads[-1]
             policy._ep_grads[-1]     = (l_in, pre_r, probs_ep, target)
             policy.update(obs, DISCRETE_ACTIONS[target], 10.0, obs, True)
@@ -149,24 +151,22 @@ class TestREINFORCEDiscountedReturns(unittest.TestCase):
 class TestREINFORCEEntropyCoeff(unittest.TestCase):
 
     def test_zero_entropy_coeff_no_entropy_term(self):
-        policy = REINFORCEPolicy(hidden_sizes=[8], entropy_coeff=0.0, seed=0)
+        policy = _make(hidden_sizes=[8], entropy_coeff=0.0, seed=0)
         w_ref  = [w.copy() for w in policy._weights]
         obs    = _rand_obs(seed=1)
         policy(obs)
         policy.update(obs, np.array([0, 1, 0]), 1.0, obs, True)
         policy.on_episode_end()
-        # Just verify it ran without error and weights changed
         changed = any(not np.allclose(w_ref[i], policy._weights[i])
                       for i in range(len(policy._weights)))
         self.assertTrue(changed)
 
     def test_entropy_coeff_changes_gradient(self):
-        """Entropy term should produce different weight updates than without."""
-        obs   = _rand_obs(seed=5)
+        obs = _rand_obs(seed=5)
 
         def _weights_after(entropy_coeff):
-            p = REINFORCEPolicy(hidden_sizes=[8], learning_rate=0.5,
-                                gamma=1.0, entropy_coeff=entropy_coeff, seed=77)
+            p = _make(hidden_sizes=[8], learning_rate=0.5,
+                      gamma=1.0, entropy_coeff=entropy_coeff, seed=77)
             p(obs)
             p.update(obs, np.array([0, 1, 0]), 1.0, obs, True)
             p.on_episode_end()
@@ -180,58 +180,63 @@ class TestREINFORCEEntropyCoeff(unittest.TestCase):
 class TestREINFORCECfgRoundtrip(unittest.TestCase):
 
     def test_to_cfg_contains_required_keys(self):
-        policy = REINFORCEPolicy(hidden_sizes=[16, 8])
+        policy = _make(hidden_sizes=[16, 8])
         cfg    = policy.to_cfg()
         for key in ("policy_type", "hidden_sizes", "learning_rate",
                     "gamma", "entropy_coeff", "baseline",
-                    "n_lidar_rays", "weights", "biases"):
+                    "output_dim", "weights", "biases"):
             self.assertIn(key, cfg)
 
     def test_policy_type_string(self):
-        policy = REINFORCEPolicy()
+        policy = _make()
         self.assertEqual(policy.to_cfg()["policy_type"], "reinforce")
 
     def test_from_cfg_restores_weights(self):
-        policy = REINFORCEPolicy(hidden_sizes=[8, 4], seed=3)
+        policy = _make(hidden_sizes=[8, 4], seed=3)
         cfg    = policy.to_cfg()
-        loaded = REINFORCEPolicy.from_cfg(cfg)
+        loaded = REINFORCEPolicy.from_cfg(cfg, _OBS_SPEC, _ACTION_DEC)
         for w1, w2 in zip(policy._weights, loaded._weights):
             np.testing.assert_array_equal(w1, w2)
         for b1, b2 in zip(policy._biases, loaded._biases):
             np.testing.assert_array_equal(b1, b2)
 
     def test_from_cfg_restores_hyperparams(self):
-        policy = REINFORCEPolicy(hidden_sizes=[12], learning_rate=0.005,
-                                  gamma=0.95, entropy_coeff=0.02,
-                                  baseline="none")
+        policy = _make(hidden_sizes=[12], learning_rate=0.005,
+                       gamma=0.95, entropy_coeff=0.02,
+                       baseline="none")
         cfg    = policy.to_cfg()
-        loaded = REINFORCEPolicy.from_cfg(cfg)
-        self.assertAlmostEqual(loaded._lr,           0.005)
-        self.assertAlmostEqual(loaded._gamma,        0.95)
+        loaded = REINFORCEPolicy.from_cfg(cfg, _OBS_SPEC, _ACTION_DEC)
+        self.assertAlmostEqual(loaded._lr,            0.005)
+        self.assertAlmostEqual(loaded._gamma,         0.95)
         self.assertAlmostEqual(loaded._entropy_coeff, 0.02)
-        self.assertEqual(loaded._baseline_type,      "none")
+        self.assertEqual(loaded._baseline_type,       "none")
 
     def test_save_and_reload(self):
         import tempfile, os, yaml
-        policy = REINFORCEPolicy(hidden_sizes=[8], seed=9)
+        policy = _make(hidden_sizes=[8], seed=9)
         with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
             path = f.name
         try:
             policy.save(path)
             with open(path) as f:
                 cfg = yaml.safe_load(f)
-            loaded = REINFORCEPolicy.from_cfg(cfg)
+            loaded = REINFORCEPolicy.from_cfg(cfg, _OBS_SPEC, _ACTION_DEC)
             for w1, w2 in zip(policy._weights, loaded._weights):
                 np.testing.assert_array_almost_equal(w1, w2, decimal=5)
         finally:
             os.unlink(path)
 
     def test_from_cfg_with_lidar(self):
-        policy = REINFORCEPolicy(hidden_sizes=[8], n_lidar_rays=4, seed=2)
+        lidar_spec = _OBS_SPEC.with_lidar(4)
+        policy = REINFORCEPolicy(
+            lidar_spec, _ACTION_DEC, output_dim=_N_ACTIONS,
+            hidden_sizes=[8], seed=2,
+        )
         cfg    = policy.to_cfg()
-        loaded = REINFORCEPolicy.from_cfg(cfg, n_lidar_rays=4)
+        loaded = REINFORCEPolicy.from_cfg(cfg, lidar_spec, _ACTION_DEC)
         self.assertEqual(loaded._obs_dim, BASE_OBS_DIM + 4)
-        action = loaded(_zero_obs(n_lidar_rays=4))
+        obs    = np.zeros(BASE_OBS_DIM + 4, dtype=np.float32)
+        action = loaded(obs)
         self.assertEqual(action.shape, (3,))
 
 
@@ -240,15 +245,13 @@ class TestREINFORCETrainerState(unittest.TestCase):
     def test_save_load_roundtrip_baseline(self):
         """save_trainer_state → load_trainer_state preserves baseline_val."""
         import tempfile, os
-        policy = REINFORCEPolicy(hidden_sizes=[8], seed=0)
-        # Run a few episodes to shift the baseline from zero
+        policy = _make(hidden_sizes=[8], seed=0)
         obs = _rand_obs(seed=1)
         for _ in range(3):
             policy(obs)
             policy.update(obs, np.array([0, 1, 0]), 5.0, obs, True)
             policy.on_episode_end()
 
-        # Confirm the training loop actually changed the baseline from its initial value
         self.assertNotEqual(policy._baseline_val, 0.0,
                             "Expected baseline_val to change after training episodes")
 
@@ -257,7 +260,7 @@ class TestREINFORCETrainerState(unittest.TestCase):
         try:
             policy.save_trainer_state(path)
 
-            policy2 = REINFORCEPolicy(hidden_sizes=[8], seed=99)
+            policy2 = _make(hidden_sizes=[8], seed=99)
             policy2.load_trainer_state(path)
 
             self.assertAlmostEqual(policy._baseline_val, policy2._baseline_val, places=10)
@@ -267,12 +270,15 @@ class TestREINFORCETrainerState(unittest.TestCase):
     def test_load_wrong_obs_dim_raises(self):
         """Loading state with mismatched obs_dim raises ValueError."""
         import tempfile, os
-        policy1 = REINFORCEPolicy(n_lidar_rays=0)
+        policy1 = _make()
         with tempfile.NamedTemporaryFile(suffix=".npz", delete=False) as f:
             path = f.name
         try:
             policy1.save_trainer_state(path)
-            policy2 = REINFORCEPolicy(n_lidar_rays=4)
+            lidar_spec = _OBS_SPEC.with_lidar(4)
+            policy2 = REINFORCEPolicy(
+                lidar_spec, _ACTION_DEC, output_dim=_N_ACTIONS,
+            )
             with self.assertRaises(ValueError):
                 policy2.load_trainer_state(path)
         finally:


### PR DESCRIPTION
## Summary

- Extracted four core RL algorithms (REINFORCE, DQN, LSTM, CMA-ES) from `games/tmnf/policies.py` into new game-agnostic modules in `framework/`: `reinforce.py`, `dqn.py`, `lstm.py`, `cmaes.py`
- Created `framework/replay.py` with `ReplayBuffer` and `MaskedReplayBuffer` for off-policy algorithms
- Parameterised all policies on `ObsSpec` (observation metadata) and action decoders instead of hardcoded TMNF specifics, enabling reuse across any game integration
- Added comprehensive unit tests verifying framework implementations produce byte-identical outputs to their TMNF counterparts
- Updated existing test files to import from framework modules while maintaining backward compatibility

## Why

The original policies were tightly coupled to TMNF (hardcoded lidar ray counts, action arrays, observation dimensions). This blocked reuse in other game integrations (TORCS, SC2). By extracting to `framework/` with clean parameterisation on `ObsSpec` and action decoders, any game can now instantiate these algorithms without duplication or modification.

## Related issues

Closes #

## Type of change

- [x] New feature (no breaking change)
- [x] Refactor / internal cleanup

## How was this tested?

```bash
# Unit tests for framework algorithms
PYTHONPATH=. poetry run python -m pytest tests/test_cmaes_distribution.py -v
PYTHONPATH=. poetry run python -m pytest tests/test_cmaes_policy.py -v
PYTHONPATH=. poetry run python -m pytest tests/test_reinforce_policy.py -v
PYTHONPATH=. poetry run python -m pytest tests/test_neural_dqn_policy.py -v
PYTHONPATH=. poetry run python -m pytest tests/test_lstm_policy.py -v

# Byte-identical verification (framework ↔ TMNF)
PYTHONPATH=. poetry run python -m pytest tests/test_framework_algorithm_equivalence.py -v

# Full test suite
PYTHONPATH=. poetry run python -m pytest tests/ \
    --ignore=tests/test_env_termination.py \
    --ignore=tests/test_grid_search.py \
    --ignore=tests/integration/
```

All tests pass. Framework implementations verified to produce identical outputs to TMNF originals when given the same weights and observations.

## Checklist

### Code quality

- [x] Changes are scoped to the issue — no unrelated refactors mixed in
- [x] New / changed code follows the surrounding style
- [x] No accidentally-committed secrets or large binaries

### Tests

- [x] Added unit tests for new logic (`tests/test_cmaes_distribution.py`, `test_framework_algorithm_equivalence.py`)
- [x] Cross-platform unit tests pass locally
- [x] Existing tests updated to use framework imports while maintaining backward compatibility

### Documentation

- [x] Updated `tests/README.md` with new test files and their coverage

### Review

- [x] Self-reviewed the diff
- [x] Happy for an AI code review to run on this PR

### AI usage

- [ ] No AI was used to write this code
- [x] AI was used to write/generate some or all of this code

**If AI was used:** Claude Opus for initial skeleton, type annotations, and docstrings. Human review and validation of all numerical implementations against TMNF originals.

**Human involvement:** Manual verification that framework implementations produce byte-identical outputs to TMNF counterparts. Comprehensive test suite added to catch any numerical discrepancies.

## Notes for the reviewer

- **Backward compatibility**: `games/tmnf/policies.py` still exports the original classes (via imports from framework), so existing code continues to work
- **Byte-identical verification**: `test_framework_algorithm_equivalence.py` ensures framework versions match TMNF originals exactly — any numerical divergence will be caught
- **ObsSpec parameterisation**: All framework policies now accept `Obs

https://claude.ai/code/session_01S84FAUcAauvZsJnqTGdNgV