### PR TITLE
Phase B: add POLICY_REGISTRY and class-level POLICY_TYPE/LOOP_TYPE/make on BasePolicy (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ formatting, internal refactors with no behaviour change — can be skipped.
 ## [Unreleased]
 
 ### Added
+- `POLICY_REGISTRY` and `register_policy` decorator in `framework/policies.py`; the five built-in policies (`hill_climbing`, `neural_net`, `epsilon_greedy`, `mcts`, `genetic`) are now self-describing with `POLICY_TYPE`, `LOOP_TYPE`, `VALID_POLICY_PARAMS`, and `_construct_or_resume`. `framework/training.py:_make_policy` consults the registry first and falls back to `extra_policy_types` for game-registered policies (Phase B of #224).
 - Versioning + release system. `framework/version.py` resolves a
   runtime `code_version` string of the form
   `<PACKAGE_VERSION>+g<sha7>[.dirty]`; the value is persisted in every

--- a/framework/policies.py
+++ b/framework/policies.py
@@ -19,7 +19,7 @@ import math
 import os
 import pickle
 from abc import ABC, abstractmethod
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import numpy as np
 import yaml
@@ -46,7 +46,7 @@ class BasePolicy(ABC):
 
     POLICY_TYPE: ClassVar[str] = ""           # "" = abstract, not registrable
     LOOP_TYPE: ClassVar[str] = "hill_climbing"  # hill_climbing|q_learning|cmaes|genetic
-    VALID_POLICY_PARAMS: ClassVar[frozenset] = frozenset()
+    VALID_POLICY_PARAMS: ClassVar[frozenset[str]] = frozenset()
 
     @abstractmethod
     def __call__(self, obs: np.ndarray) -> np.ndarray:
@@ -87,7 +87,7 @@ class BasePolicy(ABC):
         No-op for policies with no persistent trainer state."""
 
     @classmethod
-    def _validate_params(cls, policy_params: dict) -> None:
+    def _validate_params(cls, policy_params: dict[str, Any]) -> None:
         if not cls.VALID_POLICY_PARAMS:
             return
         user_keys = {k for k in policy_params if not k.startswith("_")}
@@ -164,7 +164,7 @@ class WeightedLinearPolicy(BasePolicy):
 
     POLICY_TYPE = "hill_climbing"
     LOOP_TYPE = "hill_climbing"
-    VALID_POLICY_PARAMS: ClassVar[frozenset] = frozenset()
+    VALID_POLICY_PARAMS: ClassVar[frozenset[str]] = frozenset()
 
     def __init__(
         self,

--- a/framework/policies.py
+++ b/framework/policies.py
@@ -90,7 +90,8 @@ class BasePolicy(ABC):
     def _validate_params(cls, policy_params: dict) -> None:
         if not cls.VALID_POLICY_PARAMS:
             return
-        unknown = sorted(set(policy_params) - cls.VALID_POLICY_PARAMS)
+        user_keys = {k for k in policy_params if not k.startswith("_")}
+        unknown = sorted(user_keys - cls.VALID_POLICY_PARAMS)
         if unknown:
             raise ValueError(
                 f"policy_params contains keys that have no effect for "
@@ -609,7 +610,8 @@ class EpsilonGreedyPolicy(QTablePolicy):
         epsilon = policy_params.get("epsilon", 1.0)
         if os.path.exists(weights_file) and not re_initialize:
             with open(weights_file) as f:
-                saved_cfg = yaml.safe_load(f) or {}
+                _raw = yaml.safe_load(f)
+            saved_cfg = _raw if isinstance(_raw, dict) else {}
             epsilon = float(saved_cfg.get("epsilon", epsilon))
         policy = cls(
             obs_spec=obs_spec,

--- a/framework/policies.py
+++ b/framework/policies.py
@@ -19,6 +19,7 @@ import math
 import os
 import pickle
 from abc import ABC, abstractmethod
+from typing import ClassVar
 
 import numpy as np
 import yaml
@@ -42,6 +43,10 @@ def _qtable_pkl_path(yaml_path: str) -> str:
 
 class BasePolicy(ABC):
     """Abstract base class for all driving policies."""
+
+    POLICY_TYPE: ClassVar[str] = ""           # "" = abstract, not registrable
+    LOOP_TYPE: ClassVar[str] = "hill_climbing"  # hill_climbing|q_learning|cmaes|genetic
+    VALID_POLICY_PARAMS: ClassVar[frozenset] = frozenset()
 
     @abstractmethod
     def __call__(self, obs: np.ndarray) -> np.ndarray:
@@ -81,11 +86,65 @@ class BasePolicy(ABC):
         """Restore trainer-internal state from *path*.
         No-op for policies with no persistent trainer state."""
 
+    @classmethod
+    def _validate_params(cls, policy_params: dict) -> None:
+        if not cls.VALID_POLICY_PARAMS:
+            return
+        unknown = sorted(set(policy_params) - cls.VALID_POLICY_PARAMS)
+        if unknown:
+            raise ValueError(
+                f"policy_params contains keys that have no effect for "
+                f"policy_type={cls.POLICY_TYPE!r}: {unknown}. "
+                f"Valid keys: {sorted(cls.VALID_POLICY_PARAMS)}."
+            )
+
+    @classmethod
+    def make(cls, *, obs_spec, head_names, discrete_actions,
+             weights_file, policy_params, re_initialize) -> "BasePolicy":
+        cls._validate_params(policy_params)
+        return cls._construct_or_resume(
+            obs_spec=obs_spec, head_names=head_names,
+            discrete_actions=discrete_actions, weights_file=weights_file,
+            policy_params=policy_params, re_initialize=re_initialize,
+        )
+
+    @classmethod
+    def _construct_or_resume(cls, *, obs_spec, head_names, discrete_actions,
+                             weights_file, policy_params, re_initialize) -> "BasePolicy":
+        raise NotImplementedError("Subclass must override _construct_or_resume or make")
+
+
+# ---------------------------------------------------------------------------
+# Policy registry
+# ---------------------------------------------------------------------------
+
+POLICY_REGISTRY: dict[str, type[BasePolicy]] = {}
+
+
+def register_policy(cls: type[BasePolicy]) -> type[BasePolicy]:
+    if not cls.POLICY_TYPE:
+        raise ValueError(f"{cls.__name__} must set POLICY_TYPE before @register_policy")
+    if cls.POLICY_TYPE in POLICY_REGISTRY:
+        existing = POLICY_REGISTRY[cls.POLICY_TYPE]
+        raise ValueError(
+            f"Duplicate policy_type {cls.POLICY_TYPE!r}: "
+            f"{existing.__name__} vs {cls.__name__}"
+        )
+    POLICY_REGISTRY[cls.POLICY_TYPE] = cls
+    return cls
+
+
+def trainer_state_path(weights_file: str) -> str:
+    """Canonical path for a policy's trainer-state .npz file."""
+    return os.path.join(os.path.dirname(os.path.abspath(weights_file)),
+                        "trainer_state.npz")
+
 
 # ---------------------------------------------------------------------------
 # WeightedLinearPolicy
 # ---------------------------------------------------------------------------
 
+@register_policy
 class WeightedLinearPolicy(BasePolicy):
     """
     Linear policy with one output head per entry in head_names.
@@ -101,6 +160,10 @@ class WeightedLinearPolicy(BasePolicy):
         WeightedLinearPolicy(obs_spec, head_names, weights_file)
         WeightedLinearPolicy.from_cfg(cfg, obs_spec, head_names)
     """
+
+    POLICY_TYPE = "hill_climbing"
+    LOOP_TYPE = "hill_climbing"
+    VALID_POLICY_PARAMS: ClassVar[frozenset] = frozenset()
 
     def __init__(
         self,
@@ -257,11 +320,21 @@ class WeightedLinearPolicy(BasePolicy):
             logger.info("[WeightedLinearPolicy] initialised random weights → %s", self._weights_file)
         return cfg
 
+    @classmethod
+    def _construct_or_resume(cls, *, obs_spec, head_names, discrete_actions,
+                             weights_file, policy_params, re_initialize) -> "WeightedLinearPolicy":
+        if re_initialize and os.path.exists(weights_file):
+            os.remove(weights_file)
+            logger.info("[WeightedLinearPolicy] removed existing weights file for re-initialization: %s",
+                        weights_file)
+        return cls(obs_spec, head_names, weights_file)
+
 
 # ---------------------------------------------------------------------------
 # NeuralNetPolicy
 # ---------------------------------------------------------------------------
 
+@register_policy
 class NeuralNetPolicy(BasePolicy):
     """
     Small MLP policy trained via hill-climbing (same loop as WeightedLinearPolicy).
@@ -271,6 +344,10 @@ class NeuralNetPolicy(BasePolicy):
     Pure numpy, no external ML framework required.
     Weights serialized to YAML as nested lists.
     """
+
+    POLICY_TYPE = "neural_net"
+    LOOP_TYPE = "hill_climbing"
+    VALID_POLICY_PARAMS: ClassVar[frozenset] = frozenset({"hidden_sizes"})
 
     def __init__(
         self,
@@ -336,6 +413,20 @@ class NeuralNetPolicy(BasePolicy):
             "weights":      [w.tolist() for w in self._weights],
             "biases":       [b.tolist() for b in self._biases],
         }
+
+    @classmethod
+    def _construct_or_resume(cls, *, obs_spec, head_names, discrete_actions,
+                             weights_file, policy_params, re_initialize) -> "NeuralNetPolicy":
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as f:
+                loaded_cfg = yaml.safe_load(f)
+            cfg = loaded_cfg if isinstance(loaded_cfg, dict) else {}
+            if cfg.get("policy_type") == "neural_net":
+                logger.info("[NeuralNetPolicy] loaded from %s", weights_file)
+                return cls.from_cfg(cfg, obs_spec)
+        hidden = policy_params.get("hidden_sizes", [16, 16])
+        logger.info("[NeuralNetPolicy] initialised random weights (hidden=%s)", hidden)
+        return cls(obs_spec, action_dim=len(head_names), hidden_sizes=hidden)
 
 
 # ---------------------------------------------------------------------------
@@ -460,6 +551,7 @@ class QTablePolicy(BasePolicy):
 # EpsilonGreedyPolicy
 # ---------------------------------------------------------------------------
 
+@register_policy
 class EpsilonGreedyPolicy(QTablePolicy):
     """
     Tabular Q-learning with epsilon-greedy exploration.
@@ -468,6 +560,10 @@ class EpsilonGreedyPolicy(QTablePolicy):
     Q-values are updated online via the Bellman equation after every env step.
     Epsilon decays each episode.
     """
+
+    POLICY_TYPE = "epsilon_greedy"
+    LOOP_TYPE = "q_learning"
+    VALID_POLICY_PARAMS: ClassVar[frozenset] = frozenset({"epsilon", "n_bins", "epsilon_decay", "epsilon_min", "alpha", "gamma"})
 
     def __init__(
         self,
@@ -507,11 +603,34 @@ class EpsilonGreedyPolicy(QTablePolicy):
             "n_states_visited": self.n_states_visited,
         }
 
+    @classmethod
+    def _construct_or_resume(cls, *, obs_spec, head_names, discrete_actions,
+                             weights_file, policy_params, re_initialize) -> "EpsilonGreedyPolicy":
+        epsilon = policy_params.get("epsilon", 1.0)
+        if os.path.exists(weights_file) and not re_initialize:
+            with open(weights_file) as f:
+                saved_cfg = yaml.safe_load(f) or {}
+            epsilon = float(saved_cfg.get("epsilon", epsilon))
+        policy = cls(
+            obs_spec=obs_spec,
+            discrete_actions=discrete_actions,
+            n_bins=policy_params.get("n_bins", 3),
+            epsilon=epsilon,
+            epsilon_decay=policy_params.get("epsilon_decay", 0.995),
+            epsilon_min=policy_params.get("epsilon_min", 0.05),
+            alpha=policy_params.get("alpha", 0.1),
+            gamma=policy_params.get("gamma", 0.99),
+        )
+        if os.path.exists(weights_file) and not re_initialize:
+            policy._load_table(weights_file)
+        return policy
+
 
 # ---------------------------------------------------------------------------
 # MCTSPolicy  (UCT-style online learner)
 # ---------------------------------------------------------------------------
 
+@register_policy
 class MCTSPolicy(QTablePolicy):
     """
     UCT-inspired online Q-learner.
@@ -522,6 +641,10 @@ class MCTSPolicy(QTablePolicy):
     NOTE: True MCTS requires env cloning.  This is a UCT-style approximation
     that builds value/count tables incrementally over real episodes.
     """
+
+    POLICY_TYPE = "mcts"
+    LOOP_TYPE = "q_learning"
+    VALID_POLICY_PARAMS: ClassVar[frozenset] = frozenset({"c", "alpha", "gamma", "n_bins"})
 
     def __init__(
         self,
@@ -557,11 +680,27 @@ class MCTSPolicy(QTablePolicy):
             "n_states_visited": self.n_states_visited,
         }
 
+    @classmethod
+    def _construct_or_resume(cls, *, obs_spec, head_names, discrete_actions,
+                             weights_file, policy_params, re_initialize) -> "MCTSPolicy":
+        policy = cls(
+            obs_spec=obs_spec,
+            discrete_actions=discrete_actions,
+            c=policy_params.get("c", 1.41),
+            alpha=policy_params.get("alpha", 0.1),
+            gamma=policy_params.get("gamma", 0.99),
+            n_bins=policy_params.get("n_bins", 3),
+        )
+        if os.path.exists(weights_file) and not re_initialize:
+            policy._load_table(weights_file)
+        return policy
+
 
 # ---------------------------------------------------------------------------
 # GeneticPolicy
 # ---------------------------------------------------------------------------
 
+@register_policy
 class GeneticPolicy(BasePolicy):
     """
     Evolutionary policy: a population of WeightedLinearPolicy instances.
@@ -575,6 +714,10 @@ class GeneticPolicy(BasePolicy):
     Inference always uses the champion (best individual seen so far).
     `save()` writes the champion in WeightedLinearPolicy YAML format.
     """
+
+    POLICY_TYPE = "genetic"
+    LOOP_TYPE = "genetic"
+    VALID_POLICY_PARAMS: ClassVar[frozenset] = frozenset({"population_size", "elite_k", "mutation_scale", "mutation_share", "eval_episodes"})
 
     def __init__(
         self,
@@ -709,3 +852,29 @@ class GeneticPolicy(BasePolicy):
         """Save champion in WeightedLinearPolicy YAML format for analytics compatibility."""
         if self._champion is not None:
             self._champion.save(path)
+
+    @classmethod
+    def _construct_or_resume(cls, *, obs_spec, head_names, discrete_actions,
+                             weights_file, policy_params, re_initialize) -> "GeneticPolicy":
+        pop_size = policy_params.get("population_size", 10)
+        elite_k  = policy_params.get("elite_k", 3)
+        policy   = cls(
+            obs_spec        = obs_spec,
+            head_names      = head_names,
+            population_size = pop_size,
+            elite_k         = elite_k,
+            mutation_scale  = policy_params.get("mutation_scale",
+                              policy_params.get("_mutation_scale_fallback", 0.1)),
+            mutation_share  = policy_params.get("mutation_share",
+                              policy_params.get("_mutation_share_fallback", 1.0)),
+            eval_episodes   = policy_params.get("eval_episodes", 1),
+        )
+        if os.path.exists(weights_file) and not re_initialize:
+            champion = WeightedLinearPolicy(obs_spec, head_names, weights_file)
+            policy.initialize_from_champion(champion)
+            logger.info("[GeneticPolicy] seeded population from champion at %s",
+                        weights_file)
+        else:
+            policy.initialize_random()
+            logger.info("[GeneticPolicy] random population of %d", pop_size)
+        return policy

--- a/framework/training.py
+++ b/framework/training.py
@@ -39,6 +39,7 @@ from framework.policies import (
     MCTSPolicy,
     GeneticPolicy,
     POLICY_REGISTRY,
+    trainer_state_path as _trainer_state_path_canonical,
 )
 from framework.obs_spec import ObsSpec
 from framework.run_config import GameSpec, RunConfig, ProbeSpec, WarmupSpec, PolicyExtras
@@ -50,12 +51,7 @@ _TRACE_SAMPLE_EVERY = 2   # record position every N steps
 
 
 def _trainer_state_path(weights_file: str) -> str:
-    """Return the trainer-state checkpoint path alongside the weights file.
-
-    e.g. experiments/a03/my_run/policy_weights.yaml
-         → experiments/a03/my_run/trainer_state.npz
-    """
-    return os.path.join(os.path.dirname(os.path.abspath(weights_file)), "trainer_state.npz")
+    return _trainer_state_path_canonical(weights_file)
 
 
 # ---------------------------------------------------------------------------

--- a/framework/training.py
+++ b/framework/training.py
@@ -38,6 +38,7 @@ from framework.policies import (
     EpsilonGreedyPolicy,
     MCTSPolicy,
     GeneticPolicy,
+    POLICY_REGISTRY,
 )
 from framework.obs_spec import ObsSpec
 from framework.run_config import GameSpec, RunConfig, ProbeSpec, WarmupSpec, PolicyExtras
@@ -89,96 +90,23 @@ def _make_policy(
 ) -> BasePolicy:
     """Construct the appropriate policy given type, obs_spec, and hyperparams.
 
-    extra_policy_types maps policy_type names to zero-arg factory callables.
-    This lets game-specific policy types (e.g. 'neural_dqn', 'cmaes') be
-    injected without the framework importing from games/.
+    Consults POLICY_REGISTRY first; falls back to extra_policy_types for
+    game-registered policies not yet migrated to the registry.
     """
-
-    if policy_type == "hill_climbing":
-        if re_initialize and os.path.exists(weights_file):
-            os.remove(weights_file)
-            logger.info("[WeightedLinearPolicy] removed existing weights file for re-initialization: %s",
-                        weights_file)
-        return WeightedLinearPolicy(obs_spec, head_names, weights_file)
-
-    elif policy_type == "neural_net":
-        if os.path.exists(weights_file) and not re_initialize:
-            with open(weights_file) as f:
-                loaded_cfg = yaml.safe_load(f)
-            cfg = loaded_cfg if isinstance(loaded_cfg, dict) else {}
-            if cfg.get("policy_type") == "neural_net":
-                logger.info("[NeuralNetPolicy] loaded from %s", weights_file)
-                return NeuralNetPolicy.from_cfg(cfg, obs_spec)
-        hidden = policy_params.get("hidden_sizes", [16, 16])
-        logger.info("[NeuralNetPolicy] initialised random weights (hidden=%s)", hidden)
-        return NeuralNetPolicy(obs_spec, action_dim=len(head_names),
-                               hidden_sizes=hidden)
-
-    elif policy_type == "epsilon_greedy":
-        epsilon = policy_params.get("epsilon", 1.0)
-        if os.path.exists(weights_file) and not re_initialize:
-            with open(weights_file) as f:
-                saved_cfg = yaml.safe_load(f) or {}
-            epsilon = float(saved_cfg.get("epsilon", epsilon))
-        policy = EpsilonGreedyPolicy(
-            obs_spec=obs_spec,
-            discrete_actions=discrete_actions,
-            n_bins=policy_params.get("n_bins", 3),
-            epsilon=epsilon,
-            epsilon_decay=policy_params.get("epsilon_decay", 0.995),
-            epsilon_min=policy_params.get("epsilon_min", 0.05),
-            alpha=policy_params.get("alpha", 0.1),
-            gamma=policy_params.get("gamma", 0.99),
+    cls = POLICY_REGISTRY.get(policy_type)
+    if cls is not None:
+        return cls.make(
+            obs_spec=obs_spec, head_names=head_names,
+            discrete_actions=discrete_actions, weights_file=weights_file,
+            policy_params=policy_params, re_initialize=re_initialize,
         )
-        if os.path.exists(weights_file) and not re_initialize:
-            policy._load_table(weights_file)
-        return policy
-
-    elif policy_type == "mcts":
-        policy = MCTSPolicy(
-            obs_spec=obs_spec,
-            discrete_actions=discrete_actions,
-            c=policy_params.get("c", 1.41),
-            alpha=policy_params.get("alpha", 0.1),
-            gamma=policy_params.get("gamma", 0.99),
-            n_bins=policy_params.get("n_bins", 3),
-        )
-        if os.path.exists(weights_file) and not re_initialize:
-            policy._load_table(weights_file)
-        return policy
-
-    elif policy_type == "genetic":
-        pop_size = policy_params.get("population_size", 10)
-        elite_k  = policy_params.get("elite_k", 3)
-        policy   = GeneticPolicy(
-            obs_spec       = obs_spec,
-            head_names     = head_names,
-            population_size = pop_size,
-            elite_k        = elite_k,
-            mutation_scale = policy_params.get("mutation_scale",
-                             policy_params.get("_mutation_scale_fallback", 0.1)),
-            mutation_share = policy_params.get("mutation_share",
-                             policy_params.get("_mutation_share_fallback", 1.0)),
-            eval_episodes  = policy_params.get("eval_episodes", 1),
-        )
-        if os.path.exists(weights_file) and not re_initialize:
-            champion = WeightedLinearPolicy(obs_spec, head_names, weights_file)
-            policy.initialize_from_champion(champion)
-            logger.info("[GeneticPolicy] seeded population from champion at %s",
-                        weights_file)
-        else:
-            policy.initialize_random()
-            logger.info("[GeneticPolicy] random population of %d", pop_size)
-        return policy
-
-    elif extra_policy_types and policy_type in extra_policy_types:
+    if extra_policy_types and policy_type in extra_policy_types:
         return extra_policy_types[policy_type]()
-
-    else:
-        raise ValueError(
-            f"Unknown policy_type: {policy_type!r}. "
-            "Choose from: hill_climbing, neural_net, epsilon_greedy, mcts, genetic"
-        )
+    raise ValueError(
+        f"Unknown policy_type: {policy_type!r}. "
+        f"Registered: {sorted(POLICY_REGISTRY)}; "
+        f"extras: {sorted(extra_policy_types or [])}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1302,35 +1230,27 @@ def train_rl(
 
     _extra_dispatch = extra_loop_dispatch or {}
 
-    if policy_type in ("hill_climbing", "neural_net"):
+    loop_type = (best_policy.LOOP_TYPE if best_policy.POLICY_TYPE
+                 else _extra_dispatch.get(policy_type))
+
+    if loop_type == "hill_climbing" or loop_type is None:
         best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop(
             env=env, policy=best_policy, n_sims=n_sims,
             mutation_scale=mutation_scale, mutation_share=mutation_share,
             best_reward=best_reward, weights_file=weights_file,
             adaptive_mutation=adaptive_mutation, patience=patience, **kw,
         )
-    elif policy_type in ("epsilon_greedy", "mcts"):
+    elif loop_type == "q_learning":
         best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop_q_learning(
             env=env, policy=best_policy, n_episodes=n_sims,
             weights_file=weights_file, patience=patience, **kw,
         )
-    elif policy_type == "genetic":
-        best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop_genetic(
-            env=env, policy=best_policy,  # type: ignore[arg-type]
-            n_generations=n_sims, weights_file=weights_file,
-            patience=patience, adaptive_mutation=adaptive_mutation, **kw,
-        )
-    elif _extra_dispatch.get(policy_type) == "q_learning":
-        best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop_q_learning(
-            env=env, policy=best_policy, n_episodes=n_sims,
-            weights_file=weights_file, patience=patience, **kw,
-        )
-    elif _extra_dispatch.get(policy_type) == "cmaes":
+    elif loop_type == "cmaes":
         best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop_cmaes(
             env=env, policy=best_policy,
             n_generations=n_sims, weights_file=weights_file, patience=patience, **kw,
         )
-    elif _extra_dispatch.get(policy_type) == "genetic":
+    elif loop_type == "genetic":
         best_policy, best_reward, greedy_sims, early_stopped, early_stop_sim = _greedy_loop_genetic(
             env=env, policy=best_policy,  # type: ignore[arg-type]
             n_generations=n_sims, weights_file=weights_file,

--- a/tests/README.md
+++ b/tests/README.md
@@ -25,6 +25,7 @@
   - [test\_utils.py — math/state-extraction utils](#test_utilspy--mathstate-extraction-utils)
   - [test\_track.py — centreline geometry helpers](#test_trackpy--centreline-geometry-helpers)
   - [test\_version.py — `code_version()` + git revision reporting](#test_versionpy--code_version--git-revision-reporting)
+  - [test\_policy\_registry.py — `POLICY_REGISTRY` + `BasePolicy` registry machinery](#test_policy_registrypy--policy_registry--basepolicy-registry-machinery)
 - [TMNF policies](#tmnf-policies)
   - [test\_weighted\_linear\_policy.py — linear `WeightedLinearPolicy`](#test_weighted_linear_policypy--linear-weightedlinearpolicy)
   - [test\_neural\_net\_policy.py — pure-numpy MLP policy](#test_neural_net_policypy--pure-numpy-mlp-policy)
@@ -267,6 +268,17 @@ behaviour of the actual `train_rl()` loop end-to-end on a real env.
 - when run inside a git repo: matches `<version>+g<sha7>[.dirty]` shape
 - `code_version()` is cached (identical return on repeated calls)
 - when `git` is unavailable: `git_revision()` returns `(None, False)` and `code_version()` falls back to bare `PACKAGE_VERSION`
+
+### test_policy_registry.py — `POLICY_REGISTRY` + `BasePolicy` registry machinery
+- `register_policy` raises on duplicate `POLICY_TYPE`
+- `register_policy` raises when `POLICY_TYPE == ""`
+- All five built-ins (`hill_climbing`, `neural_net`, `epsilon_greedy`, `mcts`, `genetic`) are registered after importing `framework.policies`
+- Each registered class maps to the correct concrete class
+- Each registered class has `LOOP_TYPE` in `{"hill_climbing", "q_learning", "cmaes", "genetic"}`
+- `_validate_params` raises on unknown keys when `VALID_POLICY_PARAMS` is non-empty
+- `_validate_params` is a no-op when `VALID_POLICY_PARAMS` is empty
+- `_validate_params` accepts all valid keys without raising
+- `_make_policy("hill_climbing", ...)` returns a `WeightedLinearPolicy` via the registry path
 
 ## TMNF policies
 

--- a/tests/test_policy_registry.py
+++ b/tests/test_policy_registry.py
@@ -1,0 +1,113 @@
+"""Tests for the POLICY_REGISTRY and BasePolicy registry-related machinery."""
+import pytest
+
+from framework.policies import (
+    POLICY_REGISTRY,
+    BasePolicy,
+    EpsilonGreedyPolicy,
+    GeneticPolicy,
+    MCTSPolicy,
+    NeuralNetPolicy,
+    WeightedLinearPolicy,
+    register_policy,
+)
+
+
+_VALID_LOOP_TYPES = {"hill_climbing", "q_learning", "cmaes", "genetic"}
+_EXPECTED_BUILT_INS = {"hill_climbing", "neural_net", "epsilon_greedy", "mcts", "genetic"}
+
+
+def test_all_five_built_ins_registered():
+    assert _EXPECTED_BUILT_INS <= set(POLICY_REGISTRY)
+
+
+def test_registered_loop_types_are_valid():
+    for name, cls in POLICY_REGISTRY.items():
+        assert cls.LOOP_TYPE in _VALID_LOOP_TYPES, (
+            f"{name}: LOOP_TYPE={cls.LOOP_TYPE!r} not in {_VALID_LOOP_TYPES}"
+        )
+
+
+def test_built_in_policy_types():
+    assert POLICY_REGISTRY["hill_climbing"] is WeightedLinearPolicy
+    assert POLICY_REGISTRY["neural_net"] is NeuralNetPolicy
+    assert POLICY_REGISTRY["epsilon_greedy"] is EpsilonGreedyPolicy
+    assert POLICY_REGISTRY["mcts"] is MCTSPolicy
+    assert POLICY_REGISTRY["genetic"] is GeneticPolicy
+
+
+def test_register_policy_raises_on_duplicate():
+    class _Dup(BasePolicy):
+        POLICY_TYPE = "hill_climbing"
+        def __call__(self, obs): ...
+        def to_cfg(self): ...
+
+    with pytest.raises(ValueError, match="Duplicate policy_type"):
+        register_policy(_Dup)
+
+
+def test_register_policy_raises_on_empty_policy_type():
+    class _Empty(BasePolicy):
+        POLICY_TYPE = ""
+        def __call__(self, obs): ...
+        def to_cfg(self): ...
+
+    with pytest.raises(ValueError, match="must set POLICY_TYPE"):
+        register_policy(_Empty)
+
+
+def test_validate_params_raises_on_unknown_key():
+    class _ValidatedPolicy(BasePolicy):
+        POLICY_TYPE = "_test_validated"
+        VALID_POLICY_PARAMS = frozenset({"lr", "gamma"})
+        def __call__(self, obs): ...
+        def to_cfg(self): ...
+
+    with pytest.raises(ValueError, match="no effect"):
+        _ValidatedPolicy._validate_params({"lr": 0.01, "unknown_key": 99})
+
+
+def test_validate_params_noop_on_empty_valid_set():
+    class _UnvalidatedPolicy(BasePolicy):
+        POLICY_TYPE = "_test_unvalidated"
+        VALID_POLICY_PARAMS = frozenset()
+        def __call__(self, obs): ...
+        def to_cfg(self): ...
+
+    _UnvalidatedPolicy._validate_params({"any_key": 1, "another": 2})
+
+
+def test_validate_params_accepts_valid_keys():
+    class _StrictPolicy(BasePolicy):
+        POLICY_TYPE = "_test_strict"
+        VALID_POLICY_PARAMS = frozenset({"lr", "gamma"})
+        def __call__(self, obs): ...
+        def to_cfg(self): ...
+
+    _StrictPolicy._validate_params({"lr": 0.001})
+    _StrictPolicy._validate_params({})
+
+
+def test_make_policy_uses_registry_for_hill_climbing(tmp_path):
+    """_make_policy('hill_climbing', ...) returns a WeightedLinearPolicy via registry."""
+    from framework.training import _make_policy
+    from framework.obs_spec import ObsSpec, ObsDim
+    import numpy as np
+
+    obs_spec = ObsSpec([
+        ObsDim("speed", 50.0, "speed in m/s"),
+        ObsDim("offset", 5.0, "lateral offset in m"),
+    ])
+    discrete_actions = np.zeros((9, 3), dtype=np.float32)
+    weights_file = str(tmp_path / "weights.yaml")
+
+    policy = _make_policy(
+        policy_type="hill_climbing",
+        obs_spec=obs_spec,
+        head_names=["steer", "accel", "brake"],
+        discrete_actions=discrete_actions,
+        weights_file=weights_file,
+        policy_params={},
+        re_initialize=False,
+    )
+    assert isinstance(policy, WeightedLinearPolicy)


### PR DESCRIPTION
- Add POLICY_TYPE, LOOP_TYPE, VALID_POLICY_PARAMS class-level attributes to BasePolicy
- Add _validate_params, make, and _construct_or_resume classmethods to BasePolicy
- Add POLICY_REGISTRY dict, register_policy decorator, and trainer_state_path helper to framework/policies.py
- Decorate five built-in policies (WeightedLinearPolicy, NeuralNetPolicy, EpsilonGreedyPolicy, MCTSPolicy, GeneticPolicy) with @register_policy and implement _construct_or_resume on each
- Rewrite _make_policy in framework/training.py to consult registry first, fall back to extra_policy_types
- Update greedy-loop dispatch to read LOOP_TYPE from policy instance for registered policies
- Add tests/test_policy_registry.py (9 tests); update tests/README.md and CHANGELOG.md

https://claude.ai/code/session_01RyTCUEdz7FCe2mMKm8bTng

<!--
One template for all PRs.
Keep only the section(s) that apply to this PR and delete the rest.
-->

## Summary

<!-- 1–3 bullets on what changed and why -->

-
-

## Related issues

<!-- Add links like: "Closes #123" / "Refs #456" -->

## Validation

<!-- Commands or manual checks you ran -->

```bash
PYTHONPATH=. poetry run python -m pytest tests/ \
    --ignore=tests/test_env_termination.py \
    --ignore=tests/test_grid_search.py \
    --ignore=tests/integration/
```

## Bug fix details (delete this section if not a bug fix)

- Problem:
- Root cause:
- Fix:

## Feature details (delete this section if not a feature)

- User problem:
- Proposed solution:
- Trade-offs / follow-ups:

## Refactor / docs / chore details (delete this section if not applicable)

- What changed:
- Why this is safe:

## Checklist
### AI usage

- [ ] No AI was used to write this code
- [ ] AI was used to write/generate some or all of this code

**If AI was used:** Please describe which AI tool(s) and model(s) were used (e.g., Claude Opus, ChatGPT, etc.):
<!-- e.g. "Claude Sonnet 4.6 for initial skeleton + types" -->

**Human involvement:**

<!-- Describe what human review/changes happened: validation of AI output, manual edits, testing, etc. -->

## Screenshots / plots (optional)

<!-- For training-loop, reward, or analytics changes: drop in the
     before/after plots from experiments/<...>/results/. -->

## Notes for the reviewer

- [ ] Updated `README.md` if user-visible behaviour, install steps, or CLI flags changed
- [ ] Updated `CLAUDE.md` if architecture, config knobs, or training-loop semantics changed
- [ ] Updated the relevant `games/<name>/README.md` for per-game changes
- [ ] Updated `tests/README.md` if tests were added, removed, or substantially changed (required by the repo's test-suite contract)
- [ ] Added an entry under `## [Unreleased]` in `CHANGELOG.md` for any user- or developer-visible change (new feature, new config key, breaking change, bug fix, dependency change). Trivial commits — experiment dumps, formatting, no-op refactors — can be skipped.
- [ ] New config keys appear in the relevant `config/*.yaml` master file with a sensible default
- [ ] Scope is limited to this issue/PR
- [ ] Tests updated where needed
- [ ] Docs updated where needed
- [ ] No secrets, large binaries, or experiment outputs committed