### PR TITLE
Stagger local-worker launches to avoid SC2 map-file race (#254)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ formatting, internal refactors with no behaviour change — can be skipped.
 ## [Unreleased]
 
 ### Fixed
+- `grid_search.py --distribute --local-workers N` no longer races on the
+  SC2 `.SC2Map` files when several workers boot simultaneously (issue
+  #254). Consecutive local workers are now launched with a cascading
+  delay: the first starts immediately, the second waits 5 s, the third
+  waits another 5 s, and so on. Tunable via the new
+  `--local-worker-stagger` CLI flag or `distribute.local_worker_stagger`
+  config key (default `5.0`; set to `0` to disable).
 - `move_exploration_bonus` exploit: bonus now tracks actual unit centroid
   positions on an 8×8 screen grid rather than move command targets, so
   spamming `Move_screen` to many locations without moving units yields no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,28 @@ formatting, internal refactors with no behaviour change — can be skipped.
 ## [Unreleased]
 
 ### Fixed
-- `grid_search.py --distribute --local-workers N` no longer races on the
-  SC2 `.SC2Map` files when several workers boot simultaneously (issue
-  #254). Consecutive local workers are now launched with a cascading
-  delay: the first starts immediately, the second waits 5 s, the third
-  waits another 5 s, and so on. Tunable via the new
-  `--local-worker-stagger` CLI flag or `distribute.local_worker_stagger`
-  config key (default `5.0`; set to `0` to disable).
+- SC2 `.SC2Map` file race when multiple PySC2 binaries boot on the same
+  host (issue #254). `games.sc2.client.SC2Client._make_sc2_env` now
+  routes every `SC2Env` construction through a cross-process
+  *map-access gate* (`games.sc2.map_access_gate.acquire_map_access_slot`)
+  that enforces a minimum 5 s gap between consecutive grants. This
+  covers not only the initial worker launches but every subsequent
+  SC2 reboot — distributed local workers picking up successive
+  experiments, intra-run parallel-eval workers (`n_workers > 1`), and
+  any future SC2 multi-instance scenarios. The gate uses an
+  `fcntl.flock`-serialised timestamp file under the system temp dir
+  and is tunable via two env vars:
+  - `GAMER_AI_SC2_MAP_GAP_S` — gap in seconds (default `5.0`; set to
+    `0` to disable, e.g. for single-process runs).
+  - `GAMER_AI_SC2_MAP_LOCK_PATH` — custom timestamp-file path (mainly
+    useful for tests).
+
+  As a complementary defence-in-depth, `grid_search.py --distribute
+  --local-workers N` also launches the local worker subprocesses with a
+  cascading 5 s delay (first immediate, second waits 5 s, third waits
+  another 5 s, …). Tunable via the new `--local-worker-stagger` CLI
+  flag or `distribute.local_worker_stagger` config key (default `5.0`;
+  set to `0` to disable).
 - `move_exploration_bonus` exploit: bonus now tracks actual unit centroid
   positions on an 8×8 screen grid rather than move command targets, so
   spamming `Move_screen` to many locations without moving units yields no

--- a/README.md
+++ b/README.md
@@ -346,6 +346,20 @@ attempting to read the same `.SC2Map` file simultaneously, which can fail
 with a "map not found" error. Tune via `--local-worker-stagger S` or
 `distribute.local_worker_stagger` (set to `0` to disable).
 
+In addition, every SC2 binary boot — across all workers, parallel-eval
+processes, and successive experiments within a worker — is gated by
+`games.sc2.map_access_gate.acquire_map_access_slot`, which holds an
+`fcntl.flock` on a shared timestamp file under the system temp dir and
+ensures a minimum 5 s gap between consecutive map reads. The launch
+stagger covers the *initial* burst; the gate covers every reboot
+thereafter for the lifetime of the grid-search run. Tune the gate via
+two env vars:
+
+- `GAMER_AI_SC2_MAP_GAP_S` — minimum seconds between SC2 map reads
+  (default `5.0`; set to `0` to disable, e.g. for single-process runs).
+- `GAMER_AI_SC2_MAP_LOCK_PATH` — custom timestamp-file path (mainly
+  for tests).
+
 ---
 
 ## Azure worker VMs

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ Useful flags:
 | `--re-initialize` | off | Ignore existing weights files |
 | `--log-level LEVEL` | `INFO` | `DEBUG`/`INFO`/`WARNING`/`ERROR` |
 | `--local-workers N` *(coordinator flag)* | `0` | Auto-launch `N` local worker subprocesses in distributed mode |
+| `--local-worker-stagger S` *(coordinator flag)* | `5.0` | Seconds between consecutive local-worker launches (cascading delay); also `distribute.local_worker_stagger` in the config. Set to `0` to disable. Prevents PySC2 binaries from racing on the same `.SC2Map` file (issue #254). |
 
 The worker polls `GET /work`, runs the returned combo locally, then posts the resulting `ExperimentData` to `POST /result`. It exits once the coordinator reports every item complete.
 
@@ -337,6 +338,13 @@ This launches three `distributed.worker` subprocesses (`local-1..N`) against
 `http://127.0.0.1:<port>`. Each worker runs one experiment at a time and PySC2
 spawns a separate SC2 process per worker, so combinations are processed in
 parallel on the same host.
+
+Workers are launched with a 5-second cascading stagger by default (issue
+#254): the first starts immediately, the second waits 5 s, the third waits
+another 5 s, and so on. This prevents the PySC2 binaries from all
+attempting to read the same `.SC2Map` file simultaneously, which can fail
+with a "map not found" error. Tune via `--local-worker-stagger S` or
+`distribute.local_worker_stagger` (set to `0` to disable).
 
 ---
 

--- a/games/sc2/client.py
+++ b/games/sc2/client.py
@@ -377,6 +377,12 @@ class SC2Client:
         if not _absl_flags.FLAGS.is_parsed():
             _absl_flags.FLAGS([''])
 
+        # Issue #254: serialise map-file reads across all SC2 binaries
+        # running on this host (distributed local workers, parallel-eval
+        # workers, etc.) so they don't race on the same .SC2Map file.
+        from games.sc2.map_access_gate import acquire_map_access_slot
+        acquire_map_access_slot()
+
         if self._play_mode:
             # Human (via SC2 UI) vs AI agent.  PySC2 only takes step actions
             # for Agent slots; Human actions come from the game client directly.

--- a/games/sc2/map_access_gate.py
+++ b/games/sc2/map_access_gate.py
@@ -1,0 +1,154 @@
+"""Cross-process gate enforcing a minimum gap between SC2 map-file accesses.
+
+Workaround for issue #254: when multiple PySC2 binaries boot at roughly
+the same time (typically a ``grid_search.py --distribute --local-workers
+N`` run, or an intra-run ``n_workers > 1`` pool) they race to read the
+same ``.SC2Map`` file and one or more of them occasionally fails with a
+"map not found" error.
+
+The Popen-time stagger in ``grid_search._launch_local_workers`` only
+spaces out the *initial* subprocess launches; every subsequent SC2Env
+construction in those workers (one per experiment for distributed
+workers, plus every parallel-eval worker startup) hits the race again.
+This module guarantees a minimum gap between every SC2Env construction
+on the same host, for the full lifetime of the grid-search run.
+
+Usage::
+
+    from games.sc2.map_access_gate import acquire_map_access_slot
+    acquire_map_access_slot()        # blocks if needed, then returns
+    sc2_env.SC2Env(...)              # safe to boot now
+
+Behaviour:
+
+* Maintains a single timestamp file (path from
+  ``GAMER_AI_SC2_MAP_LOCK_PATH``, default ``<tempdir>/gamer-ai-sc2-map-access.lock``)
+  storing the wall-clock time of the most recent grant.
+* Each caller takes an exclusive ``fcntl.flock`` on the file, computes
+  ``wait = (last + gap_s) - now``, sleeps that long if positive, writes
+  the new ``now`` timestamp, and releases the lock.
+* Because the sleep happens *while holding the lock*, callers are
+  serialised: the next caller cannot read a stale timestamp and skip the
+  wait.
+* The gap defaults to 5.0 s and can be overridden per-process via
+  ``GAMER_AI_SC2_MAP_GAP_S`` or per-call via the ``gap_s`` argument. A
+  value of ``0`` disables the gate entirely (no I/O, no sleep).
+
+Cross-platform: ``fcntl`` is POSIX-only. On Windows the gate falls back
+to an unconditional ``sleep(gap_s)`` (single-process best-effort) and
+logs a warning — the multi-worker SC2 scenario this fixes runs on Linux
+in practice (see ``CLAUDE.md`` SC2 setup notes).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+import time
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GAP_S = 5.0
+_DEFAULT_LOCK_BASENAME = "gamer-ai-sc2-map-access.lock"
+
+
+def _default_lock_path() -> str:
+    return os.path.join(tempfile.gettempdir(), _DEFAULT_LOCK_BASENAME)
+
+
+def _resolve_lock_path(explicit: str | None) -> str:
+    if explicit is not None:
+        return explicit
+    return os.environ.get("GAMER_AI_SC2_MAP_LOCK_PATH", _default_lock_path())
+
+
+def _resolve_gap_s(explicit: float | None) -> float:
+    if explicit is not None:
+        return float(explicit)
+    raw = os.environ.get("GAMER_AI_SC2_MAP_GAP_S")
+    if raw is None:
+        return DEFAULT_GAP_S
+    try:
+        v = float(raw)
+        if v < 0:
+            raise ValueError
+        return v
+    except ValueError:
+        logger.warning(
+            "GAMER_AI_SC2_MAP_GAP_S=%r is not a non-negative float; "
+            "using default %.1fs",
+            raw, DEFAULT_GAP_S,
+        )
+        return DEFAULT_GAP_S
+
+
+def acquire_map_access_slot(
+    gap_s: float | None = None,
+    lock_path: str | None = None,
+    *,
+    _sleep: Callable[[float], None] = time.sleep,
+    _now: Callable[[], float] = time.time,
+) -> float:
+    """Block until ``gap_s`` seconds have elapsed since the last grant.
+
+    Returns the number of seconds spent waiting (``0.0`` when the gate
+    fired with no contention). The ``_sleep`` and ``_now`` keyword
+    arguments are test seams.
+    """
+    resolved_gap = _resolve_gap_s(gap_s)
+    if resolved_gap <= 0:
+        return 0.0
+
+    resolved_path = _resolve_lock_path(lock_path)
+    parent = os.path.dirname(resolved_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+
+    try:
+        import fcntl  # POSIX-only
+    except ImportError:
+        logger.warning(
+            "fcntl unavailable (Windows?) — falling back to unconditional "
+            "%.1fs sleep before SC2Env construction. Multi-process "
+            "map-access serialisation is best-effort on this platform.",
+            resolved_gap,
+        )
+        _sleep(resolved_gap)
+        return resolved_gap
+
+    with open(resolved_path, "a+") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            f.seek(0)
+            content = f.read().strip()
+            try:
+                last = float(content) if content else 0.0
+            except ValueError:
+                last = 0.0
+
+            now = _now()
+            wait = (last + resolved_gap) - now
+            if wait > 0:
+                logger.info(
+                    "SC2 map-access gate: waiting %.1fs to maintain %.1fs "
+                    "gap since last access at %.3f",
+                    wait, resolved_gap, last,
+                )
+                _sleep(wait)
+                now = _now()
+            else:
+                wait = 0.0
+
+            f.seek(0)
+            f.truncate()
+            f.write(f"{now}\n")
+            f.flush()
+            try:
+                os.fsync(f.fileno())
+            except OSError:
+                pass
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    return max(wait, 0.0)

--- a/games/sc2/map_access_gate.py
+++ b/games/sc2/map_access_gate.py
@@ -128,6 +128,17 @@ def acquire_map_access_slot(
                 last = 0.0
 
             now = _now()
+            # Clamp against backwards wall-clock jumps (NTP correction,
+            # manual `date` adjustment): if the stored timestamp is in
+            # the future, treat it as "now" so we never sleep longer
+            # than `resolved_gap`.
+            if last > now:
+                logger.warning(
+                    "SC2 map-access gate: stored timestamp %.3f is in the "
+                    "future (now=%.3f); clamping to now to recover from clock skew",
+                    last, now,
+                )
+                last = now
             wait = (last + resolved_gap) - now
             if wait > 0:
                 logger.info(

--- a/grid_search.py
+++ b/grid_search.py
@@ -830,9 +830,14 @@ def main() -> None:
         if args.local_worker_stagger is not None:
             local_worker_stagger = args.local_worker_stagger
         else:
-            local_worker_stagger = float(
-                distribute_cfg.get("local_worker_stagger", 5.0)
-            )
+            raw_stagger = distribute_cfg.get("local_worker_stagger", 5.0)
+            try:
+                local_worker_stagger = float(raw_stagger)
+            except (TypeError, ValueError):
+                parser.error(
+                    f"distribute.local_worker_stagger must be a non-negative "
+                    f"number, got {raw_stagger!r}"
+                )
         if local_worker_stagger < 0:
             parser.error("--local-worker-stagger must be >= 0")
         token = args.token or os.environ.get("TMNF_GRID_TOKEN") or str(_uuid.uuid4())

--- a/grid_search.py
+++ b/grid_search.py
@@ -441,6 +441,7 @@ def _run_distributed(
     heartbeat_timeout: float,
     game_name: str,
     local_workers: int = 0,
+    local_worker_start_stagger_s: float = 5.0,
     no_interrupt: bool = False,
     re_initialize: bool = False,
 ) -> list[tuple[str, Any]]:
@@ -477,6 +478,7 @@ def _run_distributed(
             local_workers=local_workers,
             no_interrupt=no_interrupt,
             re_initialize=re_initialize,
+            start_stagger_s=local_worker_start_stagger_s,
         )
         logger.info(
             "Coordinator ready on port %d — start workers with:\n"
@@ -522,18 +524,30 @@ def _launch_local_workers(
     local_workers: int,
     no_interrupt: bool,
     re_initialize: bool,
+    start_stagger_s: float = 5.0,
 ) -> list[subprocess.Popen]:
-    """Start local worker subprocesses for distributed mode."""
+    """Start local worker subprocesses for distributed mode.
+
+    ``start_stagger_s`` introduces a cascading delay between consecutive
+    worker launches (issue #254): the first worker starts immediately,
+    the second waits ``start_stagger_s`` seconds, the third waits another
+    ``start_stagger_s`` seconds, and so on.  This prevents the SC2 binaries
+    spawned by each worker from racing to read the same ``.SC2Map`` file
+    on disk at the same instant, which can fail with a "map not found"
+    error when several PySC2 instances boot simultaneously.  Set to ``0``
+    to disable.
+    """
     if local_workers <= 0:
         return []
 
     coordinator_url = f"http://127.0.0.1:{coordinator_port}"
     procs: list[subprocess.Popen] = []
     logger.info(
-        "Launching %d local worker process(es) for game=%s at %s",
+        "Launching %d local worker process(es) for game=%s at %s (stagger=%.1fs)",
         local_workers,
         game_name,
         coordinator_url,
+        start_stagger_s,
     )
     try:
         for i in range(local_workers):
@@ -555,6 +569,8 @@ def _launch_local_workers(
             if re_initialize:
                 cmd.append("--re-initialize")
             procs.append(subprocess.Popen(cmd))
+            if i < local_workers - 1 and start_stagger_s > 0:
+                sleep(start_stagger_s)
     except Exception:
         _stop_local_workers(procs)
         raise
@@ -719,6 +735,16 @@ def main() -> None:
         "Useful for running multiple SC2 instances on one machine.",
     )
     parser.add_argument(
+        "--local-worker-stagger",
+        type=float,
+        default=None,
+        metavar="S",
+        help="Seconds to wait between launching consecutive local workers "
+        "(default: 5.0, or value from config distribute.local_worker_stagger). "
+        "Prevents parallel SC2 binaries from racing on the same .SC2Map file "
+        "(issue #254). Set to 0 to disable.",
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -801,6 +827,14 @@ def main() -> None:
         hb_timeout = args.heartbeat_timeout or distribute_cfg.get(
             "heartbeat_timeout", 60.0
         )
+        if args.local_worker_stagger is not None:
+            local_worker_stagger = args.local_worker_stagger
+        else:
+            local_worker_stagger = float(
+                distribute_cfg.get("local_worker_stagger", 5.0)
+            )
+        if local_worker_stagger < 0:
+            parser.error("--local-worker-stagger must be >= 0")
         token = args.token or os.environ.get("TMNF_GRID_TOKEN") or str(_uuid.uuid4())
         if not (args.token or os.environ.get("TMNF_GRID_TOKEN")):
             token_preview = f"{token[:8]}..." if len(token) > 8 else "[redacted]"
@@ -818,6 +852,7 @@ def main() -> None:
             heartbeat_timeout=hb_timeout,
             game_name=game_name,
             local_workers=local_workers,
+            local_worker_start_stagger_s=local_worker_stagger,
             no_interrupt=args.no_interrupt,
             re_initialize=args.re_initialize,
         )

--- a/tests/README.md
+++ b/tests/README.md
@@ -204,6 +204,12 @@ worker mechanics are unit-tested with a dummy env.
 - BeamNG: experiment_dir / build_probe = None
 - AssettoCorsa: experiment_dir / build_probe = None
 
+### test_sc2_map_access_gate.py — Cross-process SC2 map-access serialiser (issue #254)
+- single-process: first call returns 0 wait / second call within gap waits remainder / second call after gap waits 0 / `gap_s=0` short-circuits with no I/O / negative `gap_s` treated as disabled / corrupt or empty timestamp file treated as "no prior access"
+- env-var configuration: `GAMER_AI_SC2_MAP_LOCK_PATH` overrides lock path / `GAMER_AI_SC2_MAP_GAP_S` overrides gap / invalid value falls back to default with warning / negative value falls back to default / `0` disables the gate
+- multi-process: three concurrent fork()-spawned workers are serialised so each consecutive grant is ≥ `gap_s` apart (POSIX-only)
+- real-clock integration: a single end-to-end call against the real `time.sleep` / `time.time` confirms the test-seam wiring matches actual behaviour
+
 ### test_grid_search.py — Cartesian-product expansion + naming
 - expansion: no variation / single training axis / single reward axis / cartesian product / fixed params preserved
 - flat dict: contains varied / no-flat-key when not varied

--- a/tests/README.md
+++ b/tests/README.md
@@ -208,7 +208,7 @@ worker mechanics are unit-tested with a dummy env.
 - expansion: no variation / single training axis / single reward axis / cartesian product / fixed params preserved
 - flat dict: contains varied / no-flat-key when not varied
 - naming: no varied / single varied / negative-float `n` prefix / multiple varied / unknown key passthrough
-- local distributed helpers: launching expected `distributed.worker` subprocess commands / launch-failure cleanup for already-started workers / best-effort worker shutdown (graceful terminate + timeout kill) / non-negative integer parsing used for `--local-workers` and `distribute.local_workers`
+- local distributed helpers: launching expected `distributed.worker` subprocess commands / cascading start-stagger between consecutive worker spawns (issue #254; first immediate, subsequent wait `start_stagger_s` each) / no stagger sleep when `start_stagger_s=0` / launch-failure cleanup for already-started workers / best-effort worker shutdown (graceful terminate + timeout kill) / non-negative integer parsing used for `--local-workers` and `distribute.local_workers`
 - abbreviation coverage: every default game `training_params.yaml` + `reward_config.yaml` key has a short folder-name abbreviation; all promoted top-level policy params do too
 - nested policy_params: passthrough / top-level promoted / top-level overrides nested / all keys mapped / correct names
 - promoted-keys: no params returns empty / lstm hidden_size / reinforce baseline / genetic mutation_scale + mutation_share / keys in map with correct names

--- a/tests/README.md
+++ b/tests/README.md
@@ -205,7 +205,7 @@ worker mechanics are unit-tested with a dummy env.
 - AssettoCorsa: experiment_dir / build_probe = None
 
 ### test_sc2_map_access_gate.py — Cross-process SC2 map-access serialiser (issue #254)
-- single-process: first call returns 0 wait / second call within gap waits remainder / second call after gap waits 0 / `gap_s=0` short-circuits with no I/O / negative `gap_s` treated as disabled / corrupt or empty timestamp file treated as "no prior access"
+- single-process: first call returns 0 wait / second call within gap waits remainder / second call after gap waits 0 / `gap_s=0` short-circuits with no I/O / negative `gap_s` treated as disabled / corrupt or empty timestamp file treated as "no prior access" / future timestamp clamped to now (clock-skew robustness)
 - env-var configuration: `GAMER_AI_SC2_MAP_LOCK_PATH` overrides lock path / `GAMER_AI_SC2_MAP_GAP_S` overrides gap / invalid value falls back to default with warning / negative value falls back to default / `0` disables the gate
 - multi-process: three concurrent fork()-spawned workers are serialised so each consecutive grant is ≥ `gap_s` apart (POSIX-only)
 - real-clock integration: a single end-to-end call against the real `time.sleep` / `time.time` confirms the test-seam wiring matches actual behaviour

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,3 +14,9 @@ _tests_dir = os.path.dirname(__file__)
 for _p in (_tmnf_dir, _tests_dir):
     if _p not in sys.path:
         sys.path.insert(0, _p)
+
+# Disable the SC2 map-access gate by default in tests so unit tests that
+# touch SC2Client._make_sc2_env don't sleep 5s of real wall-clock time
+# (issue #254). Tests that exercise the gate itself override this via
+# monkeypatch or pass gap_s explicitly.
+os.environ.setdefault("GAMER_AI_SC2_MAP_GAP_S", "0")

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -279,6 +279,7 @@ class TestLocalDistributedWorkers:
             local_workers=2,
             no_interrupt=True,
             re_initialize=True,
+            start_stagger_s=0,
         )
 
         assert len(procs) == 2
@@ -291,6 +292,71 @@ class TestLocalDistributedWorkers:
             assert "--no-interrupt" in cmd
             assert "--re-initialize" in cmd
             assert f"local-{i}" in cmd
+
+    def test_launch_local_workers_cascading_stagger_between_spawns(
+        self, monkeypatch
+    ):
+        """Issue #254: each worker after the first waits ``start_stagger_s``
+        seconds before launching, so SC2 binaries don't race on the same
+        ``.SC2Map`` file at boot."""
+        spawn_order: list[str] = []
+
+        class _DummyProc:
+            def __init__(self, cmd):
+                self.cmd = cmd
+
+        def _fake_popen(cmd):
+            spawn_order.append(("popen", cmd[cmd.index("--worker-id") + 1]))
+            return _DummyProc(cmd)
+
+        sleep_calls: list[float] = []
+
+        def _fake_sleep(s):
+            spawn_order.append(("sleep", s))
+            sleep_calls.append(s)
+
+        monkeypatch.setattr("grid_search.subprocess.Popen", _fake_popen)
+        monkeypatch.setattr("grid_search.sleep", _fake_sleep)
+
+        procs = _launch_local_workers(
+            coordinator_port=5555,
+            token="tok",
+            game_name="sc2",
+            local_workers=3,
+            no_interrupt=False,
+            re_initialize=False,
+            start_stagger_s=5.0,
+        )
+
+        assert len(procs) == 3
+        # 3 spawns + 2 sleeps (no sleep after the last spawn)
+        assert sleep_calls == [5.0, 5.0]
+        assert spawn_order == [
+            ("popen", "local-1"),
+            ("sleep", 5.0),
+            ("popen", "local-2"),
+            ("sleep", 5.0),
+            ("popen", "local-3"),
+        ]
+
+    def test_launch_local_workers_no_sleep_when_stagger_zero(self, monkeypatch):
+        monkeypatch.setattr(
+            "grid_search.subprocess.Popen", lambda cmd: type("P", (), {"cmd": cmd})()
+        )
+
+        sleep_calls: list[float] = []
+        monkeypatch.setattr("grid_search.sleep", lambda s: sleep_calls.append(s))
+
+        _launch_local_workers(
+            coordinator_port=5555,
+            token="tok",
+            game_name="sc2",
+            local_workers=3,
+            no_interrupt=False,
+            re_initialize=False,
+            start_stagger_s=0.0,
+        )
+        assert sleep_calls == []
 
     def test_launch_local_workers_cleans_up_started_procs_on_launch_error(
         self, monkeypatch
@@ -334,6 +400,7 @@ class TestLocalDistributedWorkers:
                 local_workers=2,
                 no_interrupt=False,
                 re_initialize=False,
+                start_stagger_s=0,
             )
         assert len(started) == 1
         assert started[0].terminated is True

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -299,7 +299,7 @@ class TestLocalDistributedWorkers:
         """Issue #254: each worker after the first waits ``start_stagger_s``
         seconds before launching, so SC2 binaries don't race on the same
         ``.SC2Map`` file at boot."""
-        spawn_order: list[str] = []
+        spawn_order: list[tuple[str, object]] = []
 
         class _DummyProc:
             def __init__(self, cmd):

--- a/tests/test_sc2_map_access_gate.py
+++ b/tests/test_sc2_map_access_gate.py
@@ -119,6 +119,25 @@ class TestSingleProcess:
         assert wait == 0.0
         assert sleeps == []
 
+    def test_clock_skew_future_timestamp_clamped_to_now(self, lock_path, caplog):
+        """If the stored timestamp is ahead of the current clock (e.g. NTP
+        rewinds the wall clock), the gate must clamp `last` to `now`
+        rather than sleep for the entire skew + gap_s."""
+        # Store a timestamp far in the future (simulating clock rewind).
+        with open(lock_path, "w") as f:
+            f.write("9999999999.0\n")
+
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            gap_s=5.0,
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+            _now=lambda: 1000.0,
+        )
+        # After clamping last → now, wait = (now + gap) - now = gap.
+        assert wait == pytest.approx(5.0)
+        assert sleeps == [pytest.approx(5.0)]
+
 
 class TestEnvVarConfiguration:
     def test_lock_path_env_var(self, tmp_path, monkeypatch):
@@ -223,9 +242,23 @@ class TestMultiProcess:
         ]
         for p in procs:
             p.start()
-        for p in procs:
-            p.join(timeout=15)
-            assert p.exitcode == 0
+        try:
+            for p in procs:
+                p.join(timeout=15)
+                if p.is_alive():
+                    p.terminate()
+                    p.join(timeout=2)
+                    if p.is_alive():
+                        p.kill()
+                        p.join(timeout=2)
+                    pytest.fail(f"gate worker pid={p.pid} did not finish within 15s")
+                assert p.exitcode == 0
+        finally:
+            # Defensive: ensure no stragglers leak into the rest of the test session.
+            for p in procs:
+                if p.is_alive():
+                    p.kill()
+                    p.join(timeout=2)
 
         grants = sorted(q.get_nowait() for _ in range(3))
         # Each consecutive grant must be ≥ gap apart (allow small slack

--- a/tests/test_sc2_map_access_gate.py
+++ b/tests/test_sc2_map_access_gate.py
@@ -1,0 +1,250 @@
+"""Tests for games.sc2.map_access_gate — cross-process SC2 map-access serialiser.
+
+Covers issue #254: each call to ``acquire_map_access_slot`` must block
+until at least ``gap_s`` seconds have elapsed since the previous grant,
+so concurrent PySC2 workers don't race on the same ``.SC2Map`` file.
+"""
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import time
+
+import pytest
+
+from games.sc2 import map_access_gate
+from games.sc2.map_access_gate import (
+    DEFAULT_GAP_S,
+    acquire_map_access_slot,
+)
+
+
+@pytest.fixture
+def lock_path(tmp_path):
+    return str(tmp_path / "sc2-map-access.lock")
+
+
+class TestSingleProcess:
+    def test_first_call_returns_zero_wait(self, lock_path):
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            gap_s=5.0,
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+            _now=lambda: 1000.0,
+        )
+        assert wait == 0.0
+        assert sleeps == []
+        with open(lock_path) as f:
+            assert float(f.read().strip()) == 1000.0
+
+    def test_second_call_within_gap_waits_remainder(self, lock_path):
+        # Pre-seed last access timestamp
+        with open(lock_path, "w") as f:
+            f.write("1000.0\n")
+
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            gap_s=5.0,
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+            _now=lambda: 1002.0,  # 2s after last access
+        )
+        assert wait == pytest.approx(3.0)
+        assert sleeps == [pytest.approx(3.0)]
+
+    def test_second_call_after_gap_no_wait(self, lock_path):
+        with open(lock_path, "w") as f:
+            f.write("1000.0\n")
+
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            gap_s=5.0,
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+            _now=lambda: 1010.0,
+        )
+        assert wait == 0.0
+        assert sleeps == []
+        with open(lock_path) as f:
+            assert float(f.read().strip()) == 1010.0
+
+    def test_gap_zero_short_circuits_without_io(self, tmp_path, lock_path):
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            gap_s=0.0,
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+        )
+        assert wait == 0.0
+        assert sleeps == []
+        # File should not have been touched.
+        assert not os.path.exists(lock_path)
+
+    def test_negative_gap_treated_as_disabled(self, lock_path):
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            gap_s=-1.0,
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+        )
+        assert wait == 0.0
+        assert sleeps == []
+        assert not os.path.exists(lock_path)
+
+    def test_corrupt_timestamp_treated_as_no_prior_access(self, lock_path):
+        with open(lock_path, "w") as f:
+            f.write("not-a-number\n")
+
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            gap_s=5.0,
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+            _now=lambda: 1000.0,
+        )
+        assert wait == 0.0
+        assert sleeps == []
+
+    def test_empty_lock_file_treated_as_no_prior_access(self, lock_path):
+        open(lock_path, "w").close()
+
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            gap_s=5.0,
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+            _now=lambda: 1000.0,
+        )
+        assert wait == 0.0
+        assert sleeps == []
+
+
+class TestEnvVarConfiguration:
+    def test_lock_path_env_var(self, tmp_path, monkeypatch):
+        custom = str(tmp_path / "custom.lock")
+        monkeypatch.setenv("GAMER_AI_SC2_MAP_LOCK_PATH", custom)
+        acquire_map_access_slot(
+            gap_s=5.0,
+            _sleep=lambda s: None,
+            _now=lambda: 1000.0,
+        )
+        assert os.path.exists(custom)
+
+    def test_gap_env_var(self, lock_path, monkeypatch):
+        monkeypatch.setenv("GAMER_AI_SC2_MAP_GAP_S", "2.5")
+        with open(lock_path, "w") as f:
+            f.write("1000.0\n")
+
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+            _now=lambda: 1001.0,
+        )
+        assert wait == pytest.approx(1.5)
+
+    def test_gap_env_var_invalid_falls_back_to_default(
+        self, lock_path, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("GAMER_AI_SC2_MAP_GAP_S", "garbage")
+        with open(lock_path, "w") as f:
+            f.write("1000.0\n")
+
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+            _now=lambda: 1000.0,
+        )
+        assert wait == pytest.approx(DEFAULT_GAP_S)
+        assert sleeps == [pytest.approx(DEFAULT_GAP_S)]
+
+    def test_gap_env_var_negative_falls_back_to_default(
+        self, lock_path, monkeypatch
+    ):
+        monkeypatch.setenv("GAMER_AI_SC2_MAP_GAP_S", "-1")
+        with open(lock_path, "w") as f:
+            f.write("1000.0\n")
+
+        sleeps: list[float] = []
+        acquire_map_access_slot(
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+            _now=lambda: 1000.0,
+        )
+        # Default gap (5.0) applied, so a 5s wait occurs.
+        assert sleeps == [pytest.approx(DEFAULT_GAP_S)]
+
+    def test_gap_env_var_zero_disables_gate(self, lock_path, monkeypatch):
+        monkeypatch.setenv("GAMER_AI_SC2_MAP_GAP_S", "0")
+        sleeps: list[float] = []
+        wait = acquire_map_access_slot(
+            lock_path=lock_path,
+            _sleep=sleeps.append,
+        )
+        assert wait == 0.0
+        assert sleeps == []
+        assert not os.path.exists(lock_path)
+
+
+def _gate_worker(
+    lock_path: str,
+    gap_s: float,
+    grant_queue: mp.Queue,
+) -> None:
+    """Child-process helper for multi-process serialisation test."""
+    from games.sc2.map_access_gate import acquire_map_access_slot
+
+    acquire_map_access_slot(gap_s=gap_s, lock_path=lock_path)
+    grant_queue.put(time.time())
+
+
+@pytest.mark.skipif(
+    not hasattr(__import__("os"), "fork"),
+    reason="requires POSIX fork (fcntl.flock-based serialisation)",
+)
+class TestMultiProcess:
+    def test_concurrent_workers_are_serialised_with_gap(self, lock_path):
+        """Two concurrent processes hit the gate at the same time: the
+        second must be granted ≥ gap_s after the first."""
+        gap = 1.0  # short for test runtime
+        ctx = mp.get_context("fork")
+        q: mp.Queue = ctx.Queue()
+
+        # Seed lock file with a recent timestamp so the FIRST gate call
+        # also has to wait — otherwise the test is sensitive to scheduling.
+        with open(lock_path, "w") as f:
+            f.write(f"{time.time()}\n")
+
+        procs = [
+            ctx.Process(target=_gate_worker, args=(lock_path, gap, q))
+            for _ in range(3)
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=15)
+            assert p.exitcode == 0
+
+        grants = sorted(q.get_nowait() for _ in range(3))
+        # Each consecutive grant must be ≥ gap apart (allow small slack
+        # for scheduling jitter on slow CI).
+        for earlier, later in zip(grants, grants[1:]):
+            assert later - earlier >= gap - 0.05, (
+                f"grants spaced {later - earlier:.3f}s apart, expected ≥ {gap}s"
+            )
+
+
+class TestRealSleepIntegration:
+    """One end-to-end test against the real clock to confirm the
+    test-seam wiring matches actual behaviour."""
+
+    def test_actual_clock_waits_remaining_gap(self, lock_path):
+        with open(lock_path, "w") as f:
+            f.write(f"{time.time()}\n")
+
+        t0 = time.monotonic()
+        acquire_map_access_slot(gap_s=0.3, lock_path=lock_path)
+        elapsed = time.monotonic() - t0
+        assert elapsed >= 0.25  # allow a little jitter on the low side


### PR DESCRIPTION
When running `grid_search.py --distribute --local-workers N`, multiple
worker subprocesses would boot their PySC2 binaries simultaneously and
race to read the same `.SC2Map` file, sometimes failing with a "map not
found" error. Launch consecutive local workers with a cascading delay
(default 5 s) — the first starts immediately, the second waits 5 s,
the third waits another 5 s, and so on. Tunable via the new
`--local-worker-stagger` CLI flag or `distribute.local_worker_stagger`
config key (set to 0 to disable).

https://claude.ai/code/session_017Z7MyYAHxADPo7PpmJNNcY