### PR TITLE
Claude/debug issue 276 zzi ky

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,16 +17,27 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
-
----
-
-## [0.1.1] - 2026-05-20
+### Fixed
+- SC2: agents on BuildMarines, Simple64, and every other non-movement map were
+  unable to train units, construct buildings, or issue any race-specific command
+  because `FUNCTION_IDS` only contained 6 entries (movement + harvest).
+  `FUNCTION_IDS` now covers all 118 Terran, Protoss, and Zerg build / train /
+  morph / ability commands used in standard PySC2 play (fn_idx 0–117).
+  `SPATIAL_FN_IDS` is auto-derived as the frozenset of fn_ids whose names end in
+  `_screen` or `_minimap` (55 entries); every spatial function now gets a full
+  `N×N` (`SCREEN_GRID_RESOLUTION²`, default 8×8 = 64 rows) block in
+  `DISCRETE_ACTIONS`, giving a uniform `[command × location]` layout (3 583 rows
+  total).  Race gating (`RACE_FUNCTION_IDS`, `fn_ids_for_race()`, private
+  `_TERRAN_FN_IDS` / `_PROTOSS_FN_IDS` / `_ZERG_FN_IDS` sets) ensures that
+  agents only ever see the actions valid for their race — this permanent mask is
+  applied in every SC2 policy's `__call__` before the per-step
+  `available_fn_ids` mask.  All four multi-head SC2 policies
+  (`SC2GeneticPolicy`, `SC2CMAESPolicy`, `SC2LSTMEvolutionPolicy`, and the
+  `SC2MultiHeadLinearPolicy` base) accept and propagate a `race` parameter.
+  `N_FUNCTION_IDS` grows from 6 to 118 automatically; existing weight files
+  migrate cleanly via the zero-default path.  (Closes #276)
 
 ### Documentation
-- `README.md` now links directly to the
-  `good first issue` filter, `CONTRIBUTING.md` documents the canonical
-  issue-label taxonomy, and the shared issue template now applies the
-  default `triage` label on newly opened issues.
 - PR template (`.github/PULL_REQUEST_TEMPLATE.md`) now carries a
   `Closes #<issue>` line near the top so PRs auto-close their issue on
   merge.  `CLAUDE.md` gains a **Pull requests** section requiring every
@@ -51,16 +62,6 @@ formatting, internal refactors with no behaviour change — can be skipped.
     descriptions to match the issue #253 unit-position tracking fix.
 
 ### Added
-- New post-merge workflow `.github/workflows/auto-version-bump.yml` that
-  automatically runs after a PR is merged into `main`, infers release bump
-  type from PR-template checkboxes (`Patch` default, `Minor`, `Major`),
-  computes the next SemVer, and runs `scripts/release.py --no-tag` to bump
-  `pyproject.toml` + `framework/version.py` and roll `## [Unreleased]` into
-  a dated version section.
-- Analytics reports now surface code version tags more prominently:
-  single-run `results.md` includes a dedicated **Code Version** block, and
-  grid-search `summary.md` includes a **Code Versions** section plus a
-  per-experiment `Code version` stat row.
 - Optional live training GUI (`--live-gui`) for both `main.py` and
   `grid_search.py`. The window updates during training (not post-run only):
   - reward-component bar chart per step with a 5-step rolling average, plus
@@ -374,6 +375,3 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ### Fixed
 - Test dependency wiring and a batch of failing tests (#100).
-
----
-

--- a/games/sc2/actions.py
+++ b/games/sc2/actions.py
@@ -19,15 +19,40 @@ The framework's discrete-action policies still see fixed-shape rows; the
 client (``games.sc2.client``) is responsible for translating each row into
 a real ``actions.FunctionCall`` at execution time.
 
-Layout (issue #122 / #127)
---------------------------
-- Row 0 is ``no_op`` (issue #127): tabular policies must be able to elect to
-  do nothing — necessary so units can shoot while standing still, etc.
-- Row 1 is ``select_army``: a near-universal precondition for issuing orders
-  to the player's army.  Also the warmup action.
-- Rows 2..N-1 are ``Move_screen`` calls at the centres of an N×N grid (where
-  N == ``SCREEN_GRID_RESOLUTION``).  At resolution 8 this gives 64 unique
-  cells covering the screen at one-cell-per-8-pixels granularity.
+Layout (issue #276)
+--------------------
+Function IDs are processed in ascending order.  Spatial fn_ids (names ending
+in ``_screen`` or ``_minimap``) receive a full N×N grid of target rows; all
+other fn_ids (quick-cast, select_army, no_op, …) receive a single centre row.
+This gives a uniform **[command × location]** structure: all spatial commands
+have identical positional coverage.
+
+Function-ID encoding
+--------------------
+Names in ``FUNCTION_IDS`` must be valid ``pysc2.lib.actions.FUNCTIONS``
+attribute names.  Unknown names resolve to ``no_op`` gracefully via
+``getattr(..., no_op)`` — a wrong name is a silent no-op, never a crash.
+
+Action-call encoding by fn_name pattern (see ``action_to_function_call``)
+--------------------------------------------------------------------------
+- ``no_op``                  → ``FunctionCall(fn_id, [])``
+- ``select_army`` / ``select_idle_worker``
+                             → ``FunctionCall(fn_id, [[0]])``
+- ``select_point_screen``    → ``FunctionCall(fn_id, [[0], [sx, sy]])``
+- ``select_rect_screen``     → ``FunctionCall(fn_id, [[0], [sx,sy],[sx,sy]])``
+  (degenerate rect = single-point click)
+- names ending in ``_quick`` (all train/morph/ability quick-casts)
+                             → ``FunctionCall(fn_id, [[queue]])``
+- everything else (``_screen`` / ``_minimap`` spatial)
+                             → ``FunctionCall(fn_id, [[queue], [sx, sy]])``
+
+Race gating
+-----------
+``fn_ids_for_race(race)`` returns the subset of ``FUNCTION_IDS`` keys
+applicable to *race* (``"terran"``, ``"protoss"``, ``"zerg"``,
+``"random"``).  Policies that know their race can permanently mask the
+irrelevant fn_idx scores to ``-inf`` so the agent never wastes capacity
+learning that a Terran cannot build a Hatchery.
 """
 
 from __future__ import annotations
@@ -40,23 +65,238 @@ import numpy as np
 # ---------------------------------------------------------------------------
 # Indices are stable; the env client resolves them to PySC2 function ids at
 # call time so we don't need pysc2 imported at framework level.
+#
+# Names must match pysc2.lib.actions.FUNCTIONS attributes exactly.
+# An incorrect name degrades silently to no_op (never a crash).
 
 FUNCTION_IDS = {
-    0: "no_op",                         # actions.FUNCTIONS.no_op
-    1: "select_army",                   # actions.FUNCTIONS.select_army
-    2: "Move_screen",                   # actions.FUNCTIONS.Move_screen
-    3: "Attack_screen",                 # actions.FUNCTIONS.Attack_screen
-    4: "select_idle_worker",            # actions.FUNCTIONS.select_idle_worker
-    5: "Harvest_Gather_screen",         # actions.FUNCTIONS.Harvest_Gather_screen
+    # --- core ---
+    0: "no_op",
+    1: "select_army",
+    2: "Move_screen",
+    3: "Attack_screen",
+    4: "select_idle_worker",
+    5: "Harvest_Gather_screen",
+    # --- issue #276 (initial 5): BuildMarines / Simple64 basics ---
+    6: "select_point_screen",
+    7: "Train_Marine_quick",
+    8: "Build_Barracks_screen",
+    9: "Build_SupplyDepot_screen",
+    10: "Train_SCV_quick",
+    # --- issue #276 (expanded): full cross-race action coverage ---
+    # movement / combat
+    11: "Move_minimap",
+    12: "Patrol_screen",
+    13: "Patrol_minimap",
+    14: "HoldPosition_quick",
+    15: "Stop_quick",
+    16: "Attack_minimap",
+    # selection / logistics
+    17: "select_rect_screen",
+    18: "Harvest_Return_quick",
+    19: "Rally_Units_screen",
+    20: "Rally_Workers_screen",
+    21: "Rally_Units_minimap",
+    22: "Rally_Workers_minimap",
+    # === Terran buildings ===
+    23: "Build_CommandCenter_screen",
+    24: "Build_Refinery_screen",
+    25: "Build_EngineeringBay_screen",
+    26: "Build_Factory_screen",
+    27: "Build_Armory_screen",
+    28: "Build_Bunker_screen",
+    29: "Build_MissileTurret_screen",
+    30: "Build_Starport_screen",
+    31: "Build_GhostAcademy_screen",
+    32: "Build_FusionCore_screen",
+    33: "Build_TechLab_quick",
+    34: "Build_Reactor_quick",
+    # === Terran training ===
+    35: "Train_Marauder_quick",
+    36: "Train_Ghost_quick",
+    37: "Train_Hellion_quick",
+    38: "Train_SiegeTank_quick",
+    39: "Train_Medivac_quick",
+    40: "Train_Viking_quick",
+    41: "Train_Raven_quick",
+    42: "Train_Banshee_quick",
+    43: "Train_Battlecruiser_quick",
+    44: "Train_Cyclone_quick",
+    45: "Train_Thor_quick",
+    46: "Train_Liberator_quick",
+    # === Terran unit abilities ===
+    47: "Effect_Stim_quick",
+    48: "Morph_SiegeMode_quick",
+    49: "Morph_Unsiege_quick",
+    # === Protoss buildings ===
+    50: "Build_Nexus_screen",
+    51: "Build_Pylon_screen",
+    52: "Build_Gateway_screen",
+    53: "Build_Assimilator_screen",
+    54: "Build_CyberneticsCore_screen",
+    55: "Build_Forge_screen",
+    56: "Build_PhotonCannon_screen",
+    57: "Build_RoboticsFacility_screen",
+    58: "Build_Stargate_screen",
+    59: "Build_TwilightCouncil_screen",
+    60: "Build_TemplarArchive_screen",
+    61: "Build_DarkShrine_screen",
+    62: "Build_RoboticsBay_screen",
+    63: "Build_FleetBeacon_screen",
+    64: "Build_ShieldBattery_screen",
+    # === Protoss training / morphs ===
+    65: "Train_Probe_quick",
+    66: "Train_Zealot_quick",
+    67: "Train_Stalker_quick",
+    68: "Train_Adept_quick",
+    69: "Train_HighTemplar_quick",
+    70: "Train_DarkTemplar_quick",
+    71: "Train_Sentry_quick",
+    72: "Train_Phoenix_quick",
+    73: "Train_Carrier_quick",
+    74: "Train_VoidRay_quick",
+    75: "Train_Oracle_quick",
+    76: "Train_Colossus_quick",
+    77: "Train_Immortal_quick",
+    78: "Train_Tempest_quick",
+    79: "Train_Disruptor_quick",
+    80: "Morph_Archon_quick",
+    81: "Train_Mothership_quick",
+    # === Zerg buildings ===
+    82: "Build_Hatchery_screen",
+    83: "Build_SpawningPool_screen",
+    84: "Build_Extractor_screen",
+    85: "Build_EvolutionChamber_screen",
+    86: "Build_HydraliskDen_screen",
+    87: "Build_BanelingNest_screen",
+    88: "Build_RoachWarren_screen",
+    89: "Build_Spire_screen",
+    90: "Build_InfestationPit_screen",
+    91: "Build_UltraliskCavern_screen",
+    92: "Build_CreepTumor_screen",
+    93: "Build_SpineCrawler_screen",
+    94: "Build_SporeCrawler_screen",
+    95: "Build_NydusNetwork_screen",
+    96: "Build_LurkerDen_screen",
+    # === Zerg training / morphs ===
+    97: "Train_Drone_quick",
+    98: "Train_Overlord_quick",
+    99: "Train_Zergling_quick",
+    100: "Train_Baneling_quick",
+    101: "Train_Roach_quick",
+    102: "Train_Ravager_quick",
+    103: "Train_Hydralisk_quick",
+    104: "Train_Infestor_quick",
+    105: "Train_SwarmHost_quick",
+    106: "Train_Mutalisk_quick",
+    107: "Train_Corruptor_quick",
+    108: "Train_BroodLord_quick",
+    109: "Train_Viper_quick",
+    110: "Train_Ultralisk_quick",
+    111: "Train_Lurker_quick",
+    112: "Train_Queen_quick",
+    113: "Morph_Lair_quick",
+    114: "Morph_Hive_quick",
+    115: "Morph_Overseer_quick",
+    116: "Morph_GreaterSpire_quick",
+    117: "Morph_BroodLord_quick",
 }
+
+# ---------------------------------------------------------------------------
+# Spatial fn_id set — actions that take a screen or minimap point argument.
+# These get a full N×N grid in DISCRETE_ACTIONS; all others get one row.
+# ---------------------------------------------------------------------------
+
+SPATIAL_FN_IDS: frozenset[int] = frozenset(
+    fn_idx
+    for fn_idx, name in FUNCTION_IDS.items()
+    if name.endswith("_screen") or name.endswith("_minimap")
+)
+
+# ---------------------------------------------------------------------------
+# Race gating
+# ---------------------------------------------------------------------------
+# Maps race name → set of fn_idx values applicable to that race.
+# Universal actions (movement, attack, harvesting, selection) are in every set.
+# "random" includes every action (agent may be any race).
+
+_UNIVERSAL_FN_IDS: frozenset[int] = frozenset({
+    0,   # no_op
+    1,   # select_army
+    2,   # Move_screen
+    3,   # Attack_screen
+    4,   # select_idle_worker
+    5,   # Harvest_Gather_screen
+    6,   # select_point_screen
+    11,  # Move_minimap
+    12,  # Patrol_screen
+    13,  # Patrol_minimap
+    14,  # HoldPosition_quick
+    15,  # Stop_quick
+    16,  # Attack_minimap
+    17,  # select_rect_screen
+    18,  # Harvest_Return_quick
+    19,  # Rally_Units_screen
+    20,  # Rally_Workers_screen
+    21,  # Rally_Units_minimap
+    22,  # Rally_Workers_minimap
+})
+
+_TERRAN_FN_IDS: frozenset[int] = frozenset({
+    7, 8, 9, 10,           # Train_Marine, Build_Barracks, Build_SupplyDepot, Train_SCV
+    23, 24, 25, 26, 27,    # CommandCenter, Refinery, EngineeringBay, Factory, Armory
+    28, 29, 30, 31, 32,    # Bunker, MissileTurret, Starport, GhostAcademy, FusionCore
+    33, 34,                # TechLab_quick, Reactor_quick
+    35, 36, 37, 38, 39,    # Marauder, Ghost, Hellion, SiegeTank, Medivac
+    40, 41, 42, 43, 44,    # Viking, Raven, Banshee, Battlecruiser, Cyclone
+    45, 46,                # Thor, Liberator
+    47, 48, 49,            # Stim, SiegeMode, Unsiege
+})
+
+_PROTOSS_FN_IDS: frozenset[int] = frozenset({
+    50, 51, 52, 53, 54,    # Nexus, Pylon, Gateway, Assimilator, CyberneticsCore
+    55, 56, 57, 58, 59,    # Forge, PhotonCannon, RoboticsFacility, Stargate, TwilightCouncil
+    60, 61, 62, 63, 64,    # TemplarArchive, DarkShrine, RoboticsBay, FleetBeacon, ShieldBattery
+    65, 66, 67, 68, 69,    # Probe, Zealot, Stalker, Adept, HighTemplar
+    70, 71, 72, 73, 74,    # DarkTemplar, Sentry, Phoenix, Carrier, VoidRay
+    75, 76, 77, 78, 79,    # Oracle, Colossus, Immortal, Tempest, Disruptor
+    80, 81,                # Morph_Archon, Mothership
+})
+
+_ZERG_FN_IDS: frozenset[int] = frozenset({
+    82, 83, 84, 85, 86,    # Hatchery, SpawningPool, Extractor, EvolutionChamber, HydraliskDen
+    87, 88, 89, 90, 91,    # BanelingNest, RoachWarren, Spire, InfestationPit, UltraliskCavern
+    92, 93, 94, 95, 96,    # CreepTumor, SpineCrawler, SporeCrawler, NydusNetwork, LurkerDen
+    97, 98, 99, 100, 101,  # Drone, Overlord, Zergling, Baneling, Roach
+    102, 103, 104, 105,    # Ravager, Hydralisk, Infestor, SwarmHost
+    106, 107, 108, 109,    # Mutalisk, Corruptor, BroodLord, Viper
+    110, 111, 112,         # Ultralisk, Lurker, Queen
+    113, 114, 115, 116, 117,  # Morph_Lair, Hive, Overseer, GreaterSpire, BroodLord
+})
+
+RACE_FUNCTION_IDS: dict[str, frozenset[int]] = {
+    "terran":  _UNIVERSAL_FN_IDS | _TERRAN_FN_IDS,
+    "protoss": _UNIVERSAL_FN_IDS | _PROTOSS_FN_IDS,
+    "zerg":    _UNIVERSAL_FN_IDS | _ZERG_FN_IDS,
+    "random":  frozenset(FUNCTION_IDS.keys()),
+}
+
+
+def fn_ids_for_race(race: str) -> frozenset[int]:
+    """Return the fn_idx values applicable to *race*.
+
+    Falls back to all fn_ids if *race* is not one of
+    ``"terran"``, ``"protoss"``, ``"zerg"``, or ``"random"``.
+    """
+    return RACE_FUNCTION_IDS.get(race.lower(), frozenset(FUNCTION_IDS.keys()))
 
 
 # ---------------------------------------------------------------------------
 # Discrete action grid for minigame / tabular policies
 # ---------------------------------------------------------------------------
-# Resolution N gives an N×N grid of Move_screen targets at cell centres.
-# Default 8×8 = 64 cells; combined with no_op + select_army the discrete
-# action set has ``2 + N*N`` rows.
+# fn_ids are processed in ascending order.
+# Spatial fn_ids (names ending in _screen or _minimap) get an N×N grid.
+# Non-spatial fn_ids get a single centre row.
 
 SCREEN_GRID_RESOLUTION: int = 8
 
@@ -71,18 +311,21 @@ def _grid_centres(resolution: int) -> list[tuple[float, float]]:
 
 
 def _build_discrete_actions(resolution: int) -> np.ndarray:
-    """Construct the [fn_idx, x, y, queue] table for a given grid resolution.
+    """Construct the [fn_idx, x, y, queue] table.
 
-    Layout: ``[no_op, select_army, Move_screen × resolution^2]``.
+    All spatial fn_ids get an N×N grid of target rows (uniform [command ×
+    location] coverage).  Non-spatial fn_ids get a single centre row.
+    fn_ids are placed in ascending order.
     """
+    centres = _grid_centres(resolution)
     rows: list[list[float]] = []
-    # Row 0 — no_op (issue #127).  x/y unused; carry centre coords for sanity.
-    rows.append([0, 0.5, 0.5, 0])
-    # Row 1 — select_army (warmup precondition).
-    rows.append([1, 0.5, 0.5, 0])
-    # Rows 2..N²+1 — Move_screen at each cell centre.
-    for x, y in _grid_centres(resolution):
-        rows.append([2, x, y, 0])
+    for fn_idx in sorted(FUNCTION_IDS.keys()):
+        name = FUNCTION_IDS[fn_idx]
+        if name.endswith("_screen") or name.endswith("_minimap"):
+            for x, y in centres:
+                rows.append([fn_idx, x, y, 0])
+        else:
+            rows.append([fn_idx, 0.5, 0.5, 0])
     return np.array(rows, dtype=np.float32)
 
 
@@ -111,8 +354,6 @@ PROBE_ACTIONS: list[tuple[np.ndarray, str]] = [
 # ---------------------------------------------------------------------------
 # select_army is a near-universal precondition; running it on step 0 means
 # subsequent moves can target individual units without first re-selecting.
-# Even with no_op now reachable post-warmup, select_army remains the right
-# warmup so the first real policy step has units selected.
 
 WARMUP_ACTION = np.array([1, 0.5, 0.5, 0], dtype=np.float32)
 
@@ -123,11 +364,11 @@ def discrete_action_to_fn_id(cell_idx: int) -> int:
 
 
 def pysc2_ids_to_internal_fn_idx(pysc2_available_ids: set[int]) -> set[int]:
-    """Convert a set of raw PySC2 function IDs to internal fn_idx values (0-5).
+    """Convert a set of raw PySC2 function IDs to internal fn_idx values.
 
     PySC2's ``ob["available_actions"]`` contains PySC2 function IDs (e.g. 331
     for Move_screen).  Our mask logic uses the repo-internal fn_idx keys that
-    index into FUNCTION_IDS (0..5).  This converts between the two so that
+    index into FUNCTION_IDS.  This converts between the two so that
     ``build_available_actions_mask()`` receives the correct values.
 
     Imports PySC2 lazily so callers without it installed (framework code,
@@ -164,7 +405,8 @@ def action_to_function_call(action: np.ndarray, screen_size: int):
         4-vector ``[fn_idx, x, y, queue]`` produced by a policy.
     screen_size :
         Size of the screen feature layer (e.g. 64).  Used to denormalise
-        the coordinate args.
+        the coordinate args.  Minimap-targeted actions use the same
+        normalised [0, 1] coords and the same size (both are 64 by default).
 
     Returns
     -------
@@ -174,6 +416,17 @@ def action_to_function_call(action: np.ndarray, screen_size: int):
     -----
     Imports PySC2 lazily so that callers without PySC2 installed (unit
     tests, framework code) can import this module freely.
+
+    Encoding rules (see module docstring for full table):
+    - ``no_op``                → ``FunctionCall(fn_id, [])``
+    - ``select_army`` / ``select_idle_worker``
+                               → ``FunctionCall(fn_id, [[0]])``
+    - ``select_point_screen``  → ``FunctionCall(fn_id, [[0], [sx, sy]])``
+    - ``select_rect_screen``   → ``FunctionCall(fn_id, [[0], [sx,sy],[sx,sy]])``
+    - names ending in ``_quick`` (train/morph/ability)
+                               → ``FunctionCall(fn_id, [[queue]])``
+    - all other spatial actions (``_screen`` / ``_minimap``)
+                               → ``FunctionCall(fn_id, [[queue], [sx, sy]])``
     """
     from pysc2.lib import actions  # type: ignore[import-untyped]
 
@@ -188,10 +441,21 @@ def action_to_function_call(action: np.ndarray, screen_size: int):
     fn = getattr(actions.FUNCTIONS, name, actions.FUNCTIONS.no_op)
     fn_id = int(fn.id)
 
-    if name == "no_op" or name == "select_army" or name == "select_idle_worker":
-        # No spatial args; queue may not apply for instant actions.
-        if name == "select_army" or name == "select_idle_worker":
-            return actions.FunctionCall(fn_id, [[0]])
+    if name == "no_op":
         return actions.FunctionCall(fn_id, [])
-    # Spatial actions: [queued, target_screen]
+    if name in ("select_army", "select_idle_worker"):
+        return actions.FunctionCall(fn_id, [[0]])
+    if name == "select_point_screen":
+        # select_point_act=0: single-unit click (not add/toggle).
+        return actions.FunctionCall(fn_id, [[0], [sx, sy]])
+    if name == "select_rect_screen":
+        # Degenerate rect (start == end) acts as a single-point click.
+        return actions.FunctionCall(fn_id, [[0], [sx, sy], [sx, sy]])
+    if name.endswith("_quick"):
+        # All quick-cast actions (train, morph, abilities) take only a
+        # queued flag — no spatial target.
+        return actions.FunctionCall(fn_id, [[queue]])
+    # Default: spatial actions with [queued, target_screen/minimap].
+    # Covers Move_screen/minimap, Attack_screen/minimap, Patrol_screen/minimap,
+    # Harvest_Gather_screen, all Build_*_screen, Rally_*_screen/minimap, etc.
     return actions.FunctionCall(fn_id, [[queue], [sx, sy]])

--- a/games/sc2/actions.py
+++ b/games/sc2/actions.py
@@ -396,7 +396,9 @@ def build_available_actions_mask(
     )
 
 
-def action_to_function_call(action: np.ndarray, screen_size: int):
+def action_to_function_call(
+    action: np.ndarray, screen_size: int, minimap_size: int | None = None
+):
     """Translate a 4-vector action row into a PySC2 ``FunctionCall``.
 
     Parameters
@@ -405,8 +407,10 @@ def action_to_function_call(action: np.ndarray, screen_size: int):
         4-vector ``[fn_idx, x, y, queue]`` produced by a policy.
     screen_size :
         Size of the screen feature layer (e.g. 64).  Used to denormalise
-        the coordinate args.  Minimap-targeted actions use the same
-        normalised [0, 1] coords and the same size (both are 64 by default).
+        the coordinate args for ``*_screen`` actions.
+    minimap_size :
+        Size of the minimap feature layer.  Used to denormalise ``*_minimap``
+        targets.  Defaults to ``screen_size`` for backwards compatibility.
 
     Returns
     -------
@@ -434,12 +438,13 @@ def action_to_function_call(action: np.ndarray, screen_size: int):
     x_norm = float(np.clip(action[1], 0.0, 1.0))
     y_norm = float(np.clip(action[2], 0.0, 1.0))
     queue = int(np.clip(round(float(action[3])), 0, 1))
-    sx = int(x_norm * (screen_size - 1))
-    sy = int(y_norm * (screen_size - 1))
-
     name = FUNCTION_IDS.get(fn_idx, "no_op")
     fn = getattr(actions.FUNCTIONS, name, actions.FUNCTIONS.no_op)
     fn_id = int(fn.id)
+    minimap = screen_size if minimap_size is None else minimap_size
+    target_size = minimap if name.endswith("_minimap") else screen_size
+    sx = int(x_norm * (target_size - 1))
+    sy = int(y_norm * (target_size - 1))
 
     if name == "no_op":
         return actions.FunctionCall(fn_id, [])

--- a/games/sc2/adapter.py
+++ b/games/sc2/adapter.py
@@ -253,6 +253,8 @@ class SC2Adapter:
             os.path.dirname(weights_file), "trainer_state.npz",
         )
 
+        agent_race = training_params.get("agent_race", "random")
+
         def _make_sc2_genetic() -> SC2GeneticPolicy:
             pop_size = policy_params.get("population_size", 30)
             elite_k = policy_params.get("elite_k", 5)
@@ -263,6 +265,7 @@ class SC2Adapter:
                 mutation_scale=policy_params.get("mutation_scale", 0.1),
                 mutation_share=policy_params.get("mutation_share", 0.3),
                 eval_episodes=policy_params.get("eval_episodes", 2),
+                race=agent_race,
             )
             if os.path.exists(weights_file) and not re_initialize:
                 policy.initialize_from_file(weights_file)
@@ -518,12 +521,13 @@ class SC2Adapter:
                 population_size = pop_size,
                 initial_sigma   = sigma,
                 eval_episodes   = policy_params.get("eval_episodes", 2),
+                race            = agent_race,
             )
             if os.path.exists(weights_file) and not re_initialize:
                 with open(weights_file) as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 if isinstance(_cfg, dict):
-                    champion = SC2MultiHeadLinearPolicy.from_cfg(_cfg, obs_spec)
+                    champion = SC2MultiHeadLinearPolicy.from_cfg(_cfg, obs_spec, race=agent_race)
                     policy.initialize_from_champion(champion)
                     if os.path.exists(trainer_state_file):
                         try:
@@ -554,13 +558,14 @@ class SC2Adapter:
                 population_size  = pop_size,
                 initial_sigma    = sigma,
                 reset_on_episode = reset_on_episode,
+                race             = agent_race,
             )
             if os.path.exists(weights_file) and not re_initialize:
                 with open(weights_file) as _f:
                     _cfg = yaml.safe_load(_f) or {}
                 if isinstance(_cfg, dict) and _cfg.get("policy_type") == "sc2_lstm":
                     try:
-                        champion = SC2LSTMPolicy.from_cfg(_cfg, obs_spec)
+                        champion = SC2LSTMPolicy.from_cfg(_cfg, obs_spec, race=agent_race)
                         policy.initialize_from_champion(champion)
                     except (ValueError, KeyError) as exc:
                         logger.warning(

--- a/games/sc2/client.py
+++ b/games/sc2/client.py
@@ -445,7 +445,9 @@ class SC2Client:
         """
         from pysc2.lib import actions as pysc2_actions  # type: ignore[import-untyped]
 
-        fn_call = action_to_function_call(action, self._screen_size)
+        fn_call = action_to_function_call(
+            action, self._screen_size, self._minimap_size
+        )
 
         fn_idx = int(action[0])
         fn_name = FUNCTION_IDS.get(fn_idx, "no_op")

--- a/games/sc2/sc2_policies.py
+++ b/games/sc2/sc2_policies.py
@@ -3,8 +3,8 @@
 SC2MultiHeadLinearPolicy
     Multi-output linear policy for SC2.  Two weight matrices are maintained:
 
-    * **fn_idx head** — shape ``(N_FUNCTION_IDS, obs_dim)`` → 6 scores, one per
-      available function ID.  ``argmax`` gives the selected function.
+    * **fn_idx head** — shape ``(N_FUNCTION_IDS, obs_dim)`` → one score per
+      function ID.  ``argmax`` gives the selected function.
     * **spatial head** — shape ``(2, obs_dim)`` → two scalar scores fed
       through a sigmoid to produce continuous ``(x, y) ∈ [0, 1]²`` screen
       coordinates (issue #122).  Continuous output lets the policy target
@@ -603,7 +603,7 @@ class SC2REINFORCEPolicy(BasePolicy):
     The network has a **shared trunk** (hidden FC layers + ReLU) followed by
     two independent linear output heads:
 
-    * **fn_head** — 6 logits, softmax → ``fn_idx ∈ {0…5}``; unavailable
+    * **fn_head** — ``N_FUNCTION_IDS`` logits, softmax → ``fn_idx``; unavailable
       function IDs are masked to ``-∞`` before sampling.
     * **spatial_head** — 2 logits, sigmoid → continuous (x, y) ∈ [0, 1]²
       screen coordinates (issue #122).
@@ -1616,7 +1616,7 @@ class SC2LSTMPolicy:
         obj._obs_dim          = obs_spec.dim
         obj._scales           = obs_spec.scales
         obj._reset_on_episode = bool(cfg.get("reset_on_episode", True))
-        obj._race             = cfg.get("race", race)
+        obj._race             = race
         obj._race_fn_ids      = fn_ids_for_race(obj._race)
         obj._available_fn_ids = None
         obj._W_f   = np.array(cfg["W_f"],   dtype=np.float32)

--- a/games/sc2/sc2_policies.py
+++ b/games/sc2/sc2_policies.py
@@ -35,7 +35,7 @@ import yaml
 
 from framework.obs_spec import ObsSpec
 from framework.policies import BasePolicy, GeneticPolicy
-from games.sc2.actions import DISCRETE_ACTIONS, FUNCTION_IDS
+from games.sc2.actions import DISCRETE_ACTIONS, FUNCTION_IDS, fn_ids_for_race
 from games.sc2.obs_spec import SC2_MINIGAME_OBS_SPEC
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 #: Number of function IDs exposed by the SC2 action set.
-N_FUNCTION_IDS: int = len(FUNCTION_IDS)   # 6
+N_FUNCTION_IDS: int = len(FUNCTION_IDS)
 
 #: Number of rows in the spatial (x, y) sigmoid head.
 N_SPATIAL_ROWS: int = 2
@@ -86,6 +86,11 @@ class SC2MultiHeadLinearPolicy:
         Weight matrix of shape ``(N_SPATIAL_ROWS, obs_dim)`` whose rows are
         the linear-projection coefficients for ``x`` and ``y`` respectively.
         If *None* a random initialisation is used.
+    race :
+        Agent race (``"terran"``, ``"protoss"``, ``"zerg"``, or
+        ``"random"``).  fn_ids outside the race's applicable set are
+        permanently masked to ``-inf`` so the policy never selects them.
+        Defaults to ``"random"`` (all fn_ids enabled).
     """
 
     def __init__(
@@ -93,6 +98,7 @@ class SC2MultiHeadLinearPolicy:
         obs_spec: ObsSpec,
         fn_weights: np.ndarray | None = None,
         spatial_weights: np.ndarray | None = None,
+        race: str = "random",
     ) -> None:
         self._obs_spec = obs_spec
         obs_dim = obs_spec.dim
@@ -109,8 +115,13 @@ class SC2MultiHeadLinearPolicy:
             else rng.standard_normal((N_SPATIAL_ROWS, obs_dim)).astype(np.float32)
         )
 
-        # Cache of available fn_ids from the most recent on_episode_start() /
-        # update() call.  None means all functions are available (no masking).
+        # Permanent race mask — fn_ids outside the race's applicable set are
+        # always masked, regardless of what PySC2 reports as available.
+        self._race: str = race
+        self._race_fn_ids: frozenset[int] = fn_ids_for_race(race)
+
+        # Per-step cache of fn_ids from the most recent on_episode_start() /
+        # update() call.  None means all functions are available.
         self._available_fn_ids: set[int] | None = None
 
     # ------------------------------------------------------------------
@@ -136,14 +147,16 @@ class SC2MultiHeadLinearPolicy:
         fn_scores = self._fn_weights @ norm_obs   # (N_FUNCTION_IDS,)
         sp_scores = self._sp_weights @ norm_obs   # (2,) — raw x and y logits
 
-        # Mask unavailable function IDs so argmax never selects them.
-        if self._available_fn_ids is not None:
-            for i in range(N_FUNCTION_IDS):
-                if i not in self._available_fn_ids:
-                    fn_scores[i] = -np.inf
-            # If all scored to -inf (empty set), fall back to no_op (idx 0).
-            if not np.any(np.isfinite(fn_scores)):
-                fn_scores[0] = 0.0
+        # Apply permanent race mask and per-step availability mask.
+        for i in range(N_FUNCTION_IDS):
+            if i not in self._race_fn_ids:
+                fn_scores[i] = -np.inf
+            elif self._available_fn_ids is not None and i not in self._available_fn_ids:
+                fn_scores[i] = -np.inf
+        # If all masked (e.g. race set is empty or nothing available), fall
+        # back to no_op (idx 0) which is always a valid PySC2 action.
+        if not np.any(np.isfinite(fn_scores)):
+            fn_scores[0] = 0.0
 
         fn_idx = int(np.argmax(fn_scores))
         x      = _sigmoid(float(sp_scores[0]))
@@ -187,7 +200,12 @@ class SC2MultiHeadLinearPolicy:
             yaml.dump(self.to_cfg(), f, default_flow_style=False, sort_keys=False)
 
     @classmethod
-    def from_cfg(cls, cfg: dict, obs_spec: ObsSpec) -> "SC2MultiHeadLinearPolicy":
+    def from_cfg(
+        cls,
+        cfg: dict,
+        obs_spec: ObsSpec,
+        race: str = "random",
+    ) -> "SC2MultiHeadLinearPolicy":
         """Reconstruct a policy from a ``to_cfg()`` dict.
 
         Unknown keys and missing observation features default to 0.0 so that
@@ -197,6 +215,11 @@ class SC2MultiHeadLinearPolicy:
         to all-zero ``x_weights`` / ``y_weights`` because the old 9-cell
         argmax encoding has no meaningful projection onto the new continuous
         head.
+
+        The *race* parameter gates which fn_ids are active at inference time;
+        it does not affect which weights are loaded (all rows are always
+        restored from the file so the champion can be evaluated under any race
+        without losing weights).
         """
         names   = obs_spec.names
         obs_dim = obs_spec.dim
@@ -214,14 +237,20 @@ class SC2MultiHeadLinearPolicy:
             for j, n in enumerate(names):
                 sp_weights[i, j] = float(row_cfg.get(n, 0.0))
 
-        return cls(obs_spec, fn_weights=fn_weights, spatial_weights=sp_weights)
+        return cls(obs_spec, fn_weights=fn_weights, spatial_weights=sp_weights,
+                   race=race)
 
     @classmethod
-    def load(cls, path: str, obs_spec: ObsSpec) -> "SC2MultiHeadLinearPolicy":
+    def load(
+        cls,
+        path: str,
+        obs_spec: ObsSpec,
+        race: str = "random",
+    ) -> "SC2MultiHeadLinearPolicy":
         """Load from a YAML file written by :meth:`save`."""
         with open(path) as f:
             cfg = yaml.safe_load(f) or {}
-        return cls.from_cfg(cfg, obs_spec)
+        return cls.from_cfg(cfg, obs_spec, race=race)
 
     # ------------------------------------------------------------------
     # Flat-weight interface (for CMA-ES interoperability)
@@ -243,7 +272,8 @@ class SC2MultiHeadLinearPolicy:
         fn_size    = N_FUNCTION_IDS * obs_dim
         fn_weights = flat[:fn_size].reshape(N_FUNCTION_IDS, obs_dim).astype(np.float32)
         sp_weights = flat[fn_size:].reshape(N_SPATIAL_ROWS, obs_dim).astype(np.float32)
-        return SC2MultiHeadLinearPolicy(self._obs_spec, fn_weights, sp_weights)
+        return SC2MultiHeadLinearPolicy(self._obs_spec, fn_weights, sp_weights,
+                                        race=self._race)
 
     # ------------------------------------------------------------------
     # Mutation
@@ -346,6 +376,7 @@ class SC2GeneticPolicy(GeneticPolicy):
         mutation_scale: float = 0.1,
         mutation_share: float = 0.3,
         eval_episodes: int = 2,
+        race: str = "random",
     ) -> None:
         # Pass the flat row-names as head_names so the parent's
         # initialize_random() builds the correct {row_name}_weights keys.
@@ -358,6 +389,7 @@ class SC2GeneticPolicy(GeneticPolicy):
             mutation_share  = mutation_share,
             eval_episodes   = eval_episodes,
         )
+        self._race = race
 
     # ------------------------------------------------------------------
     # Individual factory — override to use SC2MultiHeadLinearPolicy
@@ -365,7 +397,7 @@ class SC2GeneticPolicy(GeneticPolicy):
 
     def _make_member(self, cfg: dict) -> SC2MultiHeadLinearPolicy:  # type: ignore[override]
         """Build an SC2MultiHeadLinearPolicy from a ``to_cfg()`` dict."""
-        return SC2MultiHeadLinearPolicy.from_cfg(cfg, self._obs_spec)
+        return SC2MultiHeadLinearPolicy.from_cfg(cfg, self._obs_spec, race=self._race)
 
     # ------------------------------------------------------------------
     # Population seed from a saved champion file
@@ -373,7 +405,7 @@ class SC2GeneticPolicy(GeneticPolicy):
 
     def initialize_from_file(self, path: str) -> None:
         """Load champion from YAML and seed the population by mutation."""
-        champion = SC2MultiHeadLinearPolicy.load(path, self._obs_spec)
+        champion = SC2MultiHeadLinearPolicy.load(path, self._obs_spec, race=self._race)
         self.initialize_from_champion(champion)
         logger.info("[SC2GeneticPolicy] seeded population from champion at %s", path)
 
@@ -414,11 +446,12 @@ class SC2GeneticPolicy(GeneticPolicy):
             mutation_scale  = float(cfg.get("mutation_scale", 0.1)),
             mutation_share  = float(cfg.get("mutation_share", 0.3)),
             eval_episodes   = int(cfg.get("eval_episodes", 2)),
+            race            = cfg.get("race", "random"),
         )
         champion_cfg = cfg.get("champion_weights")
         if champion_cfg and isinstance(champion_cfg, dict):
             policy._champion = SC2MultiHeadLinearPolicy.from_cfg(
-                champion_cfg, obs_spec
+                champion_cfg, obs_spec, race=policy._race
             )
             policy._champion_reward = float(cfg.get("champion_reward", float("-inf")))
         return policy
@@ -560,7 +593,7 @@ class _GradEntry(NamedTuple):
     h_last:             np.ndarray # shared trunk output (h_dim,)
     fn_probs:           np.ndarray # softmax fn probabilities after masking (N_FUNCTION_IDS,)
     fn_idx:             int        # sampled function index
-    sp_sig:             np.ndarray # (2,) = sigmoid(sp_logits) = [x, y] ∈ [0,1]²
+    sp_sig:             np.ndarray # (2,) = sigmoid(sp_logits) = [x, y] ∈[0,1]²
     fn_mask:            np.ndarray # bool mask: True = available fn (N_FUNCTION_IDS,)
 
 
@@ -1041,9 +1074,12 @@ class SC2CMAESPolicy:
         initial_sigma: float = 0.5,
         eval_episodes: int = 2,
         seed: int | None = None,
+        race: str = "random",
     ) -> None:
         self._obs_spec       = obs_spec
         self._lam            = int(population_size)
+        self._race: str                  = race
+        self._race_fn_ids: frozenset[int] = fn_ids_for_race(race)
         self._eval_episodes  = max(1, int(eval_episodes))
         n                    = (N_FUNCTION_IDS + N_SPATIAL_ROWS) * obs_spec.dim
         self._n              = n
@@ -1138,7 +1174,7 @@ class SC2CMAESPolicy:
         # lazily so __init__ stays free of the policy construction cost.
         cached = self.__dict__.get("_template_cache")
         if cached is None:
-            cached = SC2MultiHeadLinearPolicy(self._obs_spec)
+            cached = SC2MultiHeadLinearPolicy(self._obs_spec, race=self._race)
             self.__dict__["_template_cache"] = cached
         return cached
 
@@ -1234,9 +1270,11 @@ class SC2CMAESPolicy:
 
     def _build_fn_mask(self, available_fn_ids: set[int] | None) -> np.ndarray:
         mask = np.ones(N_FUNCTION_IDS, dtype=bool)
-        if available_fn_ids is not None:
-            for i in range(N_FUNCTION_IDS):
-                mask[i] = i in available_fn_ids
+        for i in range(N_FUNCTION_IDS):
+            if i not in self._race_fn_ids:
+                mask[i] = False
+            elif available_fn_ids is not None and i not in available_fn_ids:
+                mask[i] = False
         if not mask.any():
             mask[0] = True
         return mask
@@ -1371,12 +1409,15 @@ class SC2LSTMPolicy:
         hidden_size: int = 64,
         reset_on_episode: bool = True,
         seed: int | None = None,
+        race: str = "random",
     ) -> None:
         self._obs_spec        = obs_spec
         self._hidden_size     = hidden_size
         self._obs_dim         = obs_spec.dim
         self._scales          = obs_spec.scales
         self._reset_on_episode = reset_on_episode
+        self._race: str                  = race
+        self._race_fn_ids: frozenset[int] = fn_ids_for_race(race)
 
         h    = hidden_size
         c_in = h + self._obs_dim
@@ -1444,6 +1485,8 @@ class SC2LSTMPolicy:
         obj._obs_dim          = self._obs_dim
         obj._scales           = self._scales
         obj._reset_on_episode = self._reset_on_episode
+        obj._race             = self._race
+        obj._race_fn_ids      = self._race_fn_ids
         obj._rng              = np.random.default_rng()
         obj._available_fn_ids = None
 
@@ -1514,11 +1557,12 @@ class SC2LSTMPolicy:
         fn_logits   = out[:N_FUNCTION_IDS].copy().astype(np.float64)
         sp_logits   = out[N_FUNCTION_IDS:].astype(np.float64)
 
-        # Available-actions masking on fn head.
-        if self._available_fn_ids is not None:
-            for k in range(N_FUNCTION_IDS):
-                if k not in self._available_fn_ids:
-                    fn_logits[k] = -np.inf
+        # Permanent race mask + per-step available-actions mask.
+        for k in range(N_FUNCTION_IDS):
+            if k not in self._race_fn_ids:
+                fn_logits[k] = -np.inf
+            elif self._available_fn_ids is not None and k not in self._available_fn_ids:
+                fn_logits[k] = -np.inf
         if not np.isfinite(fn_logits).any():
             fn_logits[0] = 0.0  # fallback to no_op
 
@@ -1565,13 +1609,15 @@ class SC2LSTMPolicy:
             yaml.dump(self.to_cfg(), f, default_flow_style=False, sort_keys=False)
 
     @classmethod
-    def from_cfg(cls, cfg: dict, obs_spec: ObsSpec) -> "SC2LSTMPolicy":
+    def from_cfg(cls, cfg: dict, obs_spec: ObsSpec, race: str = "random") -> "SC2LSTMPolicy":
         obj = object.__new__(cls)
         obj._obs_spec         = obs_spec
         obj._hidden_size      = int(cfg["hidden_size"])
         obj._obs_dim          = obs_spec.dim
         obj._scales           = obs_spec.scales
         obj._reset_on_episode = bool(cfg.get("reset_on_episode", True))
+        obj._race             = cfg.get("race", race)
+        obj._race_fn_ids      = fn_ids_for_race(obj._race)
         obj._available_fn_ids = None
         obj._W_f   = np.array(cfg["W_f"],   dtype=np.float32)
         obj._b_f   = np.array(cfg["b_f"],   dtype=np.float32)
@@ -1624,17 +1670,20 @@ class SC2LSTMEvolutionPolicy:
         initial_sigma: float = 0.03,
         reset_on_episode: bool = True,
         seed: int | None = None,
+        race: str = "random",
     ) -> None:
         self._lam             = int(population_size)
         self._sigma           = float(initial_sigma)
         self._obs_spec        = obs_spec
         self._reset_on_episode = reset_on_episode
         self._rng             = np.random.default_rng(seed)
+        self._race            = race
 
         self._template  = SC2LSTMPolicy(
             obs_spec         = obs_spec,
             hidden_size      = hidden_size,
             reset_on_episode = reset_on_episode,
+            race             = race,
         )
         self._flat_dim  = self._template.flat_dim
         self._mean      = self._template.to_flat().astype(np.float64)
@@ -1763,6 +1812,7 @@ class SC2LSTMEvolutionPolicy:
             "hidden_size":      self._template._hidden_size,
             "reset_on_episode": self._reset_on_episode,
             "obs_dim":          self._obs_spec.dim,
+            "race":             self._race,
             "sigma":            self._sigma,
             "champion_reward":  float(self._champion_reward),
         }

--- a/tests/README.md
+++ b/tests/README.md
@@ -491,6 +491,7 @@ handful of iterations only).
 - probe actions count=5 / shape (4,) / include no_op; warmup shape (4,) / is select_army; function_ids table complete
 - SPATIAL_FN_IDS contains exactly the fn_ids whose names end in `_screen` or `_minimap`
 - `TestRaceGating` (9 tests): all four race keys exist in RACE_FUNCTION_IDS; each race's ids are a subset of FUNCTION_IDS; random race = all fn_ids; race-specific sets (_TERRAN / _PROTOSS / _ZERG) are pairwise disjoint; unknown race falls back to all fn_ids; Terran has Build_Barracks_screen (8) not Build_Nexus_screen (50); Protoss has Build_Nexus_screen (50) not Build_Barracks_screen (8); Zerg has Build_Hatchery_screen (82) not Build_Barracks_screen (8); all three named races include Move_screen (2) and no_op (0)
+- `TestActionToFunctionCall`: fake PySC2 module validates encoding branches — `_quick` emits queue-only args, `select_point_screen` and `select_rect_screen` emit screen coords, `_minimap` actions scale with `minimap_size` (not `screen_size`), and `_screen` actions keep using `screen_size`
 
 ### test_sc2_reward.py — SC2 reward calc
 - defaults; from_yaml; unknown raises; loads bundled config
@@ -569,7 +570,7 @@ handful of iterations only).
 - Action: shape (4,) / fn_idx in [0, N_FUNCTION_IDS) / x,y in [0,1] / hidden state advances after step
 - Masking: never selects unavailable fn / set via on_episode_start info / updated via update kwargs / fallback to no_op when all masked
 - Hidden state reset: reset_on_episode=True zeros state on episode start + end / reset_on_episode=False carries state across resets
-- Serialisation: to_cfg / from_cfg round-trip lossless / save / load round-trip / policy_type = "sc2_lstm"
+- Serialisation: to_cfg / from_cfg round-trip lossless / save / load round-trip / policy_type = "sc2_lstm" / explicit `race=` argument to `from_cfg` takes precedence over any stored cfg race
 - Evolution: population size / individuals are SC2LSTMPolicy / call raises before generation / champion set after one generation / σ adapts / wrong reward count raises / flat_dim mismatch raises / initialize_from_champion sets mean / on_episode_start forwarded to champion / save writes yaml / trainer-state round-trip / dim mismatch raises
 
 ### test_sc2_genetic_policy.py — `SC2MultiHeadLinearPolicy` + genetic trainer

--- a/tests/README.md
+++ b/tests/README.md
@@ -45,7 +45,7 @@
   - [test\_torcs\_analytics.py — TORCS plots/report](#test_torcs_analyticspy--torcs-plotsreport)
 - [SC2](#sc2)
   - [test\_sc2\_obs\_spec.py — SC2 obs spec](#test_sc2_obs_specpy--sc2-obs-spec)
-  - [test\_sc2\_actions.py — discrete action grid](#test_sc2_actionspy--discrete-action-grid)
+  - [test\_sc2\_actions.py — discrete action grid + race gating](#test_sc2_actionspy--discrete-action-grid--race-gating)
   - [test\_sc2\_reward.py — SC2 reward calc](#test_sc2_rewardpy--sc2-reward-calc)
   - [test\_sc2\_client.py — PySC2 client wrapper](#test_sc2_clientpy--pysc2-client-wrapper)
   - [test\_sc2\_env.py — SC2 env wrapper](#test_sc2_envpy--sc2-env-wrapper)
@@ -148,7 +148,6 @@ worker mechanics are unit-tested with a dummy env.
 - summary table: progress / finish-time / dash-on-no-finish / lateral-offset columns
 - `plot_gs_reward_trajectories`: chart written by `save_grid_summary` / referenced in summary.md / no crash with empty sims
 - `save_grid_summary` task-metric plugin: default uses track progress with `.4f` format; custom fn replaces label+value; custom fn drives ranking; explicit `task_metric_fmt` overrides format independently of fn
-- version visibility: `_summary_md` writes a dedicated `Code Version` block for single-run reports; `save_grid_summary` writes a `Code Versions` section and per-experiment `Code version` stat row
 - `plot_reward_component_breakdown`: renders to file / skips when no component data / skips when no sims / skips when all-zero / positive-only / negative-only / partial-None sims use zero for missing keys
 
 ### test_belief.py — fog-of-war belief encoder
@@ -433,13 +432,16 @@ section because both the minigame and Simple64 ladder paths,
 plus six policy variants and three obs encodings (flat / dict / spatial),
 have to be covered.
 
-**Tested.** All three observation specs (15-dim minigame, 45-dim ladder,
-97-dim rich) and the get-spec dispatch; the minimap enemy centroid
+**Tested.** All three observation specs (15-dim minigame, 46-dim ladder,
+103-dim rich) and the get-spec dispatch; the minimap enemy centroid
 (`minimap_enemy_cx/cy`) that enables the policy to locate the beacon even
 when it is off the current camera view (beacon-idling fix); the `_action_to_call`
 no-spam fix (blocked Move_screen issues select_army once, then no_op on
-consecutive blocked steps); the 9-cell discrete action grid
-(centre = `select_army`, others = `Move_screen`); the SC2 reward calculator
+consecutive blocked steps); the 118-entry `FUNCTION_IDS` table and the
+`DISCRETE_ACTIONS` uniform `[command × location]` grid (3 583 rows: every
+spatial fn_id gets a full 8×8 = 64-cell block, every non-spatial fn_id gets 1
+row); `SPATIAL_FN_IDS` derivation; race gating (`RACE_FUNCTION_IDS`,
+`fn_ids_for_race()`, pairwise-disjoint race-specific sets); the SC2 reward calculator
 (score delta, win bonus, loss penalty, economy weight, idle penalty, step
 penalty); the SC2 client wrapper (flat-obs construction, score-delta
 threading, player_relative centroid, terminal-outcome handling, ladder
@@ -481,9 +483,14 @@ handful of iterations only).
 - rich spec contains new rich-only feature names (selected_avg_shields/energy, screen_visibility_frac, screen_unit_density_aa_mean, self_weapon_cooldown_mean); not present in ladder
 - alert_count present in ladder and rich; absent from minigame
 
-### test_sc2_actions.py — discrete action grid
-- shape / dtype / xy in unit square; centre = select_army; others = move_screen
-- probe actions count / shape; warmup shape / select_army; function_ids table complete
+### test_sc2_actions.py — discrete action grid + race gating
+- `TestSC2Actions`: shape (`_N_SPATIAL × N² + _N_NON_SPATIAL` rows, 4 cols) / dtype float32 / x+y in unit square
+- row 0 = no_op; row 1 = select_army; fn_idx_row_layout — each fn_id has N² rows if spatial, 1 row otherwise, in ascending fn_idx order
+- spatial actions span unit square (x and y both reach near 0 and near 1) for every spatial fn_id
+- Move_screen cells unique (scoped to the Move_screen N² block, not all of DISCRETE_ACTIONS)
+- probe actions count=5 / shape (4,) / include no_op; warmup shape (4,) / is select_army; function_ids table complete
+- SPATIAL_FN_IDS contains exactly the fn_ids whose names end in `_screen` or `_minimap`
+- `TestRaceGating` (9 tests): all four race keys exist in RACE_FUNCTION_IDS; each race's ids are a subset of FUNCTION_IDS; random race = all fn_ids; race-specific sets (_TERRAN / _PROTOSS / _ZERG) are pairwise disjoint; unknown race falls back to all fn_ids; Terran has Build_Barracks_screen (8) not Build_Nexus_screen (50); Protoss has Build_Nexus_screen (50) not Build_Barracks_screen (8); Zerg has Build_Hatchery_screen (82) not Build_Barracks_screen (8); all three named races include Move_screen (2) and no_op (0)
 
 ### test_sc2_reward.py — SC2 reward calc
 - defaults; from_yaml; unknown raises; loads bundled config

--- a/tests/test_sc2_actions.py
+++ b/tests/test_sc2_actions.py
@@ -7,18 +7,25 @@ from games.sc2.actions import (
     DISCRETE_ACTIONS,
     FUNCTION_IDS,
     PROBE_ACTIONS,
+    RACE_FUNCTION_IDS,
     SCREEN_GRID_RESOLUTION,
+    SPATIAL_FN_IDS,
     WARMUP_ACTION,
+    fn_ids_for_race,
 )
 
 
-_EXPECTED_ROWS = 2 + SCREEN_GRID_RESOLUTION ** 2  # no_op + select_army + N×N grid
+_N = SCREEN_GRID_RESOLUTION
+_N2 = _N ** 2
+# Spatial fn_ids get N² rows; non-spatial get 1 row each.
+_N_SPATIAL = len(SPATIAL_FN_IDS)
+_N_NON_SPATIAL = len(FUNCTION_IDS) - _N_SPATIAL
+_EXPECTED_ROWS = _N_SPATIAL * _N2 + _N_NON_SPATIAL
 
 
 class TestSC2Actions(unittest.TestCase):
 
     def test_discrete_actions_shape(self):
-        # 2 special rows (no_op, select_army) + N×N Move_screen grid.
         self.assertEqual(DISCRETE_ACTIONS.shape, (_EXPECTED_ROWS, 4))
 
     def test_discrete_actions_dtype(self):
@@ -31,33 +38,63 @@ class TestSC2Actions(unittest.TestCase):
         self.assertTrue(np.all((ys >= 0.0) & (ys <= 1.0)))
 
     def test_row_zero_is_no_op(self):
-        """Issue #127: row 0 must be no_op so tabular policies can idle."""
+        """Issue #127: row 0 must be no_op (fn_idx 0 is first in sorted order
+        and non-spatial → single row at row 0)."""
         self.assertEqual(int(DISCRETE_ACTIONS[0, 0]), 0)
 
     def test_row_one_is_select_army(self):
-        """Row 1 is the select_army precondition action."""
+        """fn_idx 1 (select_army) is non-spatial → single row at row 1."""
         self.assertEqual(int(DISCRETE_ACTIONS[1, 0]), 1)
 
-    def test_grid_rows_are_move_screen(self):
-        """Rows 2..N-1 must all be Move_screen (fn_idx == 2)."""
-        for i in range(2, _EXPECTED_ROWS):
-            self.assertEqual(int(DISCRETE_ACTIONS[i, 0]), 2,
-                             f"row {i} expected Move_screen")
+    def test_fn_idx_row_layout(self):
+        """Each fn_id has the correct number of DISCRETE_ACTIONS rows.
 
-    def test_move_screen_cells_span_unit_square(self):
-        """The N×N grid must cover the screen — issue #122 fix."""
-        move_xs = DISCRETE_ACTIONS[2:, 1]
-        move_ys = DISCRETE_ACTIONS[2:, 2]
-        # Cell centres at resolution 8 land at 0.0625 and 0.9375 (extremes).
-        self.assertLessEqual(float(move_xs.min()), 0.1)
-        self.assertGreaterEqual(float(move_xs.max()), 0.9)
-        self.assertLessEqual(float(move_ys.min()), 0.1)
-        self.assertGreaterEqual(float(move_ys.max()), 0.9)
+        Spatial fn_ids (names ending in _screen or _minimap) get N² rows;
+        all others get 1 row.  fn_ids appear in ascending index order.
+        """
+        row = 0
+        for fn_idx in sorted(FUNCTION_IDS.keys()):
+            name = FUNCTION_IDS[fn_idx]
+            if fn_idx in SPATIAL_FN_IDS:
+                expected_rows = _N2
+            else:
+                expected_rows = 1
+            for offset in range(expected_rows):
+                self.assertEqual(
+                    int(DISCRETE_ACTIONS[row + offset, 0]), fn_idx,
+                    f"row {row + offset}: expected fn_idx={fn_idx} ({name}), "
+                    f"offset {offset}/{expected_rows}",
+                )
+            row += expected_rows
+        self.assertEqual(row, len(DISCRETE_ACTIONS),
+                         "All rows accounted for")
+
+    def test_spatial_actions_span_unit_square(self):
+        """Spatial grid rows must cover the screen — derived from issue #122."""
+        for fn_idx in sorted(SPATIAL_FN_IDS):
+            # Find the first row for this fn_id.
+            offset = sum(
+                _N2 if i in SPATIAL_FN_IDS else 1
+                for i in sorted(FUNCTION_IDS.keys()) if i < fn_idx
+            )
+            xs = DISCRETE_ACTIONS[offset:offset + _N2, 1]
+            ys = DISCRETE_ACTIONS[offset:offset + _N2, 2]
+            name = FUNCTION_IDS[fn_idx]
+            self.assertLessEqual(float(xs.min()), 0.1,
+                                 f"{name}: x grid doesn't reach near 0")
+            self.assertGreaterEqual(float(xs.max()), 0.9,
+                                    f"{name}: x grid doesn't reach near 1")
+            self.assertLessEqual(float(ys.min()), 0.1,
+                                 f"{name}: y grid doesn't reach near 0")
+            self.assertGreaterEqual(float(ys.max()), 0.9,
+                                    f"{name}: y grid doesn't reach near 1")
 
     def test_move_screen_cells_are_unique(self):
         """Each (x, y) cell appears exactly once in the Move_screen rows."""
-        coords = {(float(r[1]), float(r[2])) for r in DISCRETE_ACTIONS[2:]}
-        self.assertEqual(len(coords), SCREEN_GRID_RESOLUTION ** 2)
+        # Move_screen is fn_idx 2; fn_idx 0 and 1 are non-spatial (1 row each).
+        coords = {(float(r[1]), float(r[2]))
+                  for r in DISCRETE_ACTIONS[2:2 + _N2]}
+        self.assertEqual(len(coords), _N2)
 
     def test_probe_actions_count(self):
         self.assertEqual(len(PROBE_ACTIONS), 5)
@@ -79,8 +116,8 @@ class TestSC2Actions(unittest.TestCase):
         self.assertEqual(int(WARMUP_ACTION[0]), 1)
 
     def test_function_ids_table_is_complete(self):
-        # Indices used by DISCRETE_ACTIONS / PROBE_ACTIONS / WARMUP_ACTION must
-        # exist in the FUNCTION_IDS lookup so the client can resolve them.
+        """fn_idx values used in DISCRETE_ACTIONS / PROBE_ACTIONS / WARMUP_ACTION
+        must exist in FUNCTION_IDS so the client can resolve them."""
         used = set()
         for row in DISCRETE_ACTIONS:
             used.add(int(row[0]))
@@ -89,6 +126,79 @@ class TestSC2Actions(unittest.TestCase):
         used.add(int(WARMUP_ACTION[0]))
         for fn_idx in used:
             self.assertIn(fn_idx, FUNCTION_IDS, f"missing fn_idx={fn_idx}")
+
+    def test_spatial_fn_ids_are_screen_or_minimap(self):
+        """SPATIAL_FN_IDS contains exactly the fn_ids whose names end in
+        _screen or _minimap."""
+        expected = frozenset(
+            fn_idx for fn_idx, name in FUNCTION_IDS.items()
+            if name.endswith("_screen") or name.endswith("_minimap")
+        )
+        self.assertEqual(SPATIAL_FN_IDS, expected)
+
+
+# ---------------------------------------------------------------------------
+# Race gating tests
+# ---------------------------------------------------------------------------
+
+class TestRaceGating(unittest.TestCase):
+
+    def test_race_keys_exist(self):
+        for race in ("terran", "protoss", "zerg", "random"):
+            self.assertIn(race, RACE_FUNCTION_IDS)
+
+    def test_race_fn_ids_are_subsets_of_function_ids(self):
+        all_ids = frozenset(FUNCTION_IDS.keys())
+        for race, ids in RACE_FUNCTION_IDS.items():
+            self.assertTrue(ids <= all_ids,
+                            f"{race} has fn_ids outside FUNCTION_IDS: "
+                            f"{ids - all_ids}")
+
+    def test_random_race_includes_all(self):
+        self.assertEqual(fn_ids_for_race("random"), frozenset(FUNCTION_IDS.keys()))
+
+    def test_race_sets_are_disjoint_from_each_other_for_race_specific(self):
+        """Race-specific (non-universal) fn_ids must not overlap between races."""
+        from games.sc2.actions import (
+            _TERRAN_FN_IDS, _PROTOSS_FN_IDS, _ZERG_FN_IDS,
+        )
+        self.assertFalse(_TERRAN_FN_IDS & _PROTOSS_FN_IDS,
+                         "Terran and Protoss-specific fn_ids overlap")
+        self.assertFalse(_TERRAN_FN_IDS & _ZERG_FN_IDS,
+                         "Terran and Zerg-specific fn_ids overlap")
+        self.assertFalse(_PROTOSS_FN_IDS & _ZERG_FN_IDS,
+                         "Protoss and Zerg-specific fn_ids overlap")
+
+    def test_fn_ids_for_race_unknown_falls_back_to_all(self):
+        self.assertEqual(fn_ids_for_race("unknown_race"),
+                         frozenset(FUNCTION_IDS.keys()))
+
+    def test_terran_has_barracks_not_nexus(self):
+        terran_ids = fn_ids_for_race("terran")
+        # Build_Barracks_screen is fn_idx 8 (Terran)
+        self.assertIn(8, terran_ids)
+        # Build_Nexus_screen is fn_idx 50 (Protoss)
+        self.assertNotIn(50, terran_ids)
+
+    def test_protoss_has_nexus_not_barracks(self):
+        protoss_ids = fn_ids_for_race("protoss")
+        self.assertIn(50, protoss_ids)   # Build_Nexus_screen
+        self.assertNotIn(8, protoss_ids)  # Build_Barracks_screen
+
+    def test_zerg_has_hatchery_not_barracks(self):
+        zerg_ids = fn_ids_for_race("zerg")
+        self.assertIn(82, zerg_ids)   # Build_Hatchery_screen
+        self.assertNotIn(8, zerg_ids)  # Build_Barracks_screen
+
+    def test_all_races_include_move_screen(self):
+        for race in ("terran", "protoss", "zerg"):
+            self.assertIn(2, fn_ids_for_race(race),
+                          f"{race} missing Move_screen")
+
+    def test_all_races_include_no_op(self):
+        for race in ("terran", "protoss", "zerg"):
+            self.assertIn(0, fn_ids_for_race(race),
+                          f"{race} missing no_op")
 
 
 if __name__ == "__main__":

--- a/tests/test_sc2_actions.py
+++ b/tests/test_sc2_actions.py
@@ -1,5 +1,8 @@
 """Tests for the SC2 action definitions."""
+import sys
+import types
 import unittest
+from unittest.mock import patch
 
 import numpy as np
 
@@ -11,6 +14,7 @@ from games.sc2.actions import (
     SCREEN_GRID_RESOLUTION,
     SPATIAL_FN_IDS,
     WARMUP_ACTION,
+    action_to_function_call,
     fn_ids_for_race,
 )
 
@@ -199,6 +203,60 @@ class TestRaceGating(unittest.TestCase):
         for race in ("terran", "protoss", "zerg"):
             self.assertIn(0, fn_ids_for_race(race),
                           f"{race} missing no_op")
+
+
+class _FakeFunctionCall:
+    def __init__(self, function: int, arguments: list[list[int]]) -> None:
+        self.function = function
+        self.arguments = arguments
+
+
+def _fake_pysc2_modules() -> dict[str, types.ModuleType]:
+    pysc2_mod = types.ModuleType("pysc2")
+    lib_mod = types.ModuleType("pysc2.lib")
+    actions_mod = types.ModuleType("pysc2.lib.actions")
+    actions_mod.FunctionCall = _FakeFunctionCall
+    functions = types.SimpleNamespace()
+    for fn_idx, name in FUNCTION_IDS.items():
+        setattr(functions, name, types.SimpleNamespace(id=1000 + fn_idx))
+    actions_mod.FUNCTIONS = functions
+    return {
+        "pysc2": pysc2_mod,
+        "pysc2.lib": lib_mod,
+        "pysc2.lib.actions": actions_mod,
+    }
+
+
+class TestActionToFunctionCall(unittest.TestCase):
+    def test_quick_action_uses_queue_only(self):
+        with patch.dict(sys.modules, _fake_pysc2_modules()):
+            action = np.array([7, 0.2, 0.4, 1.0], dtype=np.float32)  # Train_Marine_quick
+            call = action_to_function_call(action, screen_size=64)
+        self.assertEqual(call.arguments, [[1]])
+
+    def test_select_point_screen_uses_screen_coords(self):
+        with patch.dict(sys.modules, _fake_pysc2_modules()):
+            action = np.array([6, 1.0, 0.0, 0.0], dtype=np.float32)  # select_point_screen
+            call = action_to_function_call(action, screen_size=64)
+        self.assertEqual(call.arguments, [[0], [63, 0]])
+
+    def test_select_rect_screen_uses_degenerate_rect(self):
+        with patch.dict(sys.modules, _fake_pysc2_modules()):
+            action = np.array([17, 0.5, 0.5, 0.0], dtype=np.float32)  # select_rect_screen
+            call = action_to_function_call(action, screen_size=64)
+        self.assertEqual(call.arguments, [[0], [31, 31], [31, 31]])
+
+    def test_minimap_action_uses_minimap_size(self):
+        with patch.dict(sys.modules, _fake_pysc2_modules()):
+            action = np.array([11, 1.0, 1.0, 0.0], dtype=np.float32)  # Move_minimap
+            call = action_to_function_call(action, screen_size=64, minimap_size=32)
+        self.assertEqual(call.arguments, [[0], [31, 31]])
+
+    def test_screen_action_uses_screen_size(self):
+        with patch.dict(sys.modules, _fake_pysc2_modules()):
+            action = np.array([2, 1.0, 1.0, 0.0], dtype=np.float32)  # Move_screen
+            call = action_to_function_call(action, screen_size=64, minimap_size=32)
+        self.assertEqual(call.arguments, [[0], [63, 63]])
 
 
 if __name__ == "__main__":

--- a/tests/test_sc2_client.py
+++ b/tests/test_sc2_client.py
@@ -607,7 +607,7 @@ class TestSC2ClientActionFallback(unittest.TestCase):
         from games.sc2 import client as client_mod
         # action_to_function_call also imports pysc2 internally; replace it
         # with a stub that returns a FakeFunctionCall with the obvious mapping.
-        def _fake_action_to_call(action, screen_size):
+        def _fake_action_to_call(action, screen_size, minimap_size=None):
             fn_idx = int(action[0])
             fn_id = {
                 0: _FakeFunctions.no_op.id,
@@ -1304,7 +1304,7 @@ class TestSC2ClientLastFnIdx(unittest.TestCase):
         self.addCleanup(patcher.stop)
 
         from games.sc2 import client as client_mod
-        def _fake_atfc(action, screen_size):
+        def _fake_atfc(action, screen_size, minimap_size=None):
             fn_idx = int(action[0])
             fn_id = {
                 0: _FakeFunctions.no_op.id,

--- a/tests/test_sc2_lstm_policy.py
+++ b/tests/test_sc2_lstm_policy.py
@@ -283,6 +283,19 @@ class TestSC2LSTMPolicySerialisation(unittest.TestCase):
         cfg = p.to_cfg()
         self.assertEqual(cfg["policy_type"], "sc2_lstm")
 
+    def test_from_cfg_uses_explicit_race_over_cfg_race(self):
+        p = SC2LSTMPolicy(
+            obs_spec=SC2_MINIGAME_OBS_SPEC,
+            hidden_size=16,
+            reset_on_episode=True,
+            race="terran",
+            seed=0,
+        )
+        cfg = p.to_cfg()
+        cfg["race"] = "terran"
+        p2 = SC2LSTMPolicy.from_cfg(cfg, SC2_MINIGAME_OBS_SPEC, race="protoss")
+        self.assertEqual(p2._race, "protoss")
+
 
 # ---------------------------------------------------------------------------
 # SC2LSTMEvolutionPolicy


### PR DESCRIPTION
This pull request makes significant improvements to the StarCraft II (SC2) action handling and policy code, expanding the supported action space, introducing robust race-specific action masking, and standardizing the encoding and decoding of actions. The changes ensure that agents can only select valid actions for their race, provide uniform coverage for spatial actions, and improve maintainability by centralizing action definitions and encoding rules.

**Action space expansion and standardization:**

* The `FUNCTION_IDS` mapping in `actions.py` has been greatly expanded to cover a comprehensive set of SC2 actions across all races, and its documentation now clarifies naming and fallback behavior for unknown actions.
* The discrete action grid is now built by iterating all function IDs, assigning an N×N grid of target locations to spatial actions (those ending in `_screen` or `_minimap`), and a single center row to non-spatial actions, ensuring uniform [command × location] coverage.

**Race-specific action masking:**

* New logic and data structures (`RACE_FUNCTION_IDS`, `fn_ids_for_race`) allow policies to mask out actions not applicable to the agent's race, preventing invalid actions and improving learning efficiency.
* The agent's race is now passed through adapter and policy initialization code, ensuring that only valid actions are enabled for each agent. [[1]](diffhunk://#diff-945354caf763cfd3b8c25c6349b7011b1254b2b47719e421c0d97d297ffa312bR256-R257) [[2]](diffhunk://#diff-945354caf763cfd3b8c25c6349b7011b1254b2b47719e421c0d97d297ffa312bR268) [[3]](diffhunk://#diff-945354caf763cfd3b8c25c6349b7011b1254b2b47719e421c0d97d297ffa312bR524-R530) [[4]](diffhunk://#diff-945354caf763cfd3b8c25c6349b7011b1254b2b47719e421c0d97d297ffa312bR561-R568) [[5]](diffhunk://#diff-5d7e9078096fc86b0fe4700e3d1aaef36ed1053ded9e396db59dd46c335269d5R89-R101)

**Action encoding/decoding improvements:**

* The `action_to_function_call` function now uses a clear, pattern-based encoding table for mapping internal actions to PySC2 function calls, handling all major action types consistently and robustly. [[1]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L22-R55) [[2]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176R419-R429) [[3]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L191-R460)
* Documentation throughout `actions.py` has been updated to reflect the new action layout, encoding rules, and race gating logic. [[1]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L22-R55) [[2]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L167-R409)

**Codebase maintenance:**

* The number of function IDs is now dynamically computed, and imports have been updated to include new utilities. [[1]](diffhunk://#diff-5d7e9078096fc86b0fe4700e3d1aaef36ed1053ded9e396db59dd46c335269d5L38-R38) [[2]](diffhunk://#diff-5d7e9078096fc86b0fe4700e3d1aaef36ed1053ded9e396db59dd46c335269d5L48-R48)
* Minor docstring and comment updates clarify the role of warmup actions and the default action grid. [[1]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L114-L115) [[2]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L126-R371)

These changes collectively make the SC2 agent codebase more robust, extensible, and easier to maintain.

**References:**
- [[1]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L22-R55) [[2]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176R68-R299) [[3]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L74-R328) [[4]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L114-L115) [[5]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L126-R371) [[6]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L167-R409) [[7]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176R419-R429) [[8]](diffhunk://#diff-62b2459b3537cc1ef964c4a70ba3599de6e2ba8297090e2022783663978ed176L191-R460)
- [[1]](diffhunk://#diff-945354caf763cfd3b8c25c6349b7011b1254b2b47719e421c0d97d297ffa312bR256-R257) [[2]](diffhunk://#diff-945354caf763cfd3b8c25c6349b7011b1254b2b47719e421c0d97d297ffa312bR268) [[3]](diffhunk://#diff-945354caf763cfd3b8c25c6349b7011b1254b2b47719e421c0d97d297ffa312bR524-R530) [[4]](diffhunk://#diff-945354caf763cfd3b8c25c6349b7011b1254b2b47719e421c0d97d297ffa312bR561-R568)
- [[1]](diffhunk://#diff-5d7e9078096fc86b0fe4700e3d1aaef36ed1053ded9e396db59dd46c335269d5L38-R38) [[2]](diffhunk://#diff-5d7e9078096fc86b0fe4700e3d1aaef36ed1053ded9e396db59dd46c335269d5L48-R48) [[3]](diffhunk://#diff-5d7e9078096fc86b0fe4700e3d1aaef36ed1053ded9e396db59dd46c335269d5R89-R101)

Closes #276 

## Summary

## Validation

<!-- Commands or manual checks you ran -->

```bash
PYTHONPATH=. poetry run python -m pytest tests/ \
    --ignore=tests/test_env_termination.py \
    --ignore=tests/test_grid_search.py \
    --ignore=tests/integration/
```

## Bug fix details (delete this section if not a bug fix)

- Problem:
- Root cause:
- Fix:

## Feature details (delete this section if not a feature)

- User problem:
- Proposed solution:
- Trade-offs / follow-ups:

## Refactor / docs / chore details (delete this section if not applicable)

- What changed:
- Why this is safe:

## Checklist
### Release bump type

- [x] Patch (default)
- [ ] Minor
- [ ] Major

### AI usage

- [ ] No AI was used to write this code
- [ ] AI was used to write/generate some or all of this code

**If AI was used:** Please describe which AI tool(s) and model(s) were used (e.g., Claude Opus, ChatGPT, etc.):
<!-- e.g. "Claude Sonnet 4.6 for initial skeleton + types" -->

**Human involvement:**

<!-- Describe what human review/changes happened: validation of AI output, manual edits, testing, etc. -->

## Screenshots / plots (optional)

<!-- For training-loop, reward, or analytics changes: drop in the
     before/after plots from experiments/<...>/results/. -->

## Notes for the reviewer

- [ ] Updated `README.md` if user-visible behaviour, install steps, or CLI flags changed
- [ ] Updated `CLAUDE.md` if architecture, config knobs, or training-loop semantics changed
- [ ] Updated the relevant `games/<name>/README.md` for per-game changes
- [ ] Updated `tests/README.md` if tests were added, removed, or substantially changed (required by the repo's test-suite contract)
- [ ] Added an entry under `## [Unreleased]` in `CHANGELOG.md` for any user- or developer-visible change (new feature, new config key, breaking change, bug fix, dependency change). Trivial commits — experiment dumps, formatting, no-op refactors — can be skipped.
- [ ] New config keys appear in the relevant `config/*.yaml` master file with a sensible default
- [ ] Scope is limited to this issue/PR
- [ ] Tests updated where needed
- [ ] Docs updated where needed
- [ ] No secrets, large binaries, or experiment outputs committed
