### PR TITLE
SC2: add SelfPlayManager with exact/mutated/top_n opponent modes (issue #345)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+### Added
+- SC2 self-play now supports three opponent-selection modes (issue #345).
+  Set `self_play_mode` in `training_params.yaml` (default `"exact"`):
+  - `"exact"` — opponent is an exact snapshot of the current champion,
+    refreshed every generation (original behaviour, now explicit).
+  - `"mutated"` — opponent is a slightly mutated copy of the champion;
+    mutation strength controlled by `self_play_mutation_scale` (default
+    inherits `mutation_scale`).
+  - `"top_n"` — opponent is drawn uniformly at random from a pool of the
+    top-N champions seen so far (pool capacity set by `self_play_top_n`,
+    default 5); weakest pool entry is replaced when a stronger champion
+    arrives.
+  Implemented in `framework/self_play.py` (`SelfPlayManager`); the
+  opponent is refreshed at the end of each generation in all four greedy
+  loops (`hill_climbing`, `q_learning`, `cmaes`, `genetic`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ formatting, internal refactors with no behaviour change — can be skipped.
 - SC2 self-play now supports three opponent-selection modes (issue #345).
   Set `self_play_mode` in `training_params.yaml` (default `"exact"`):
   - `"exact"` — opponent is an exact snapshot of the current champion,
-    refreshed every generation (original behaviour, now explicit).
+    refreshed every generation (previously opponent was set once at run start).
   - `"mutated"` — opponent is a slightly mutated copy of the champion;
     mutation strength controlled by `self_play_mutation_scale` (default
     inherits `mutation_scale`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,9 @@ formatting, internal refactors with no behaviour change — can be skipped.
 ### Added
 - SC2 self-play now supports three opponent-selection modes (issue #345).
   Set `self_play_mode` in `training_params.yaml` (default `"exact"`):
-  - `"exact"` — opponent is an exact snapshot of the current champion,
-    refreshed every generation (previously opponent was set once at run start).
+  - `"exact"` — opponent is a fresh snapshot of the current champion,
+    refreshed every generation (previously the opponent was set only once
+    at run start and never updated).
   - `"mutated"` — opponent is a slightly mutated copy of the champion;
     mutation strength controlled by `self_play_mutation_scale` (default
     inherits `mutation_scale`).

--- a/framework/self_play.py
+++ b/framework/self_play.py
@@ -70,10 +70,7 @@ class SelfPlayManager:
         seed: int | None = None,
     ) -> None:
         if mode not in SELF_PLAY_MODES:
-            raise ValueError(
-                f"Unknown self_play_mode {mode!r}; "
-                f"must be one of {sorted(SELF_PLAY_MODES)}"
-            )
+            raise ValueError(f"Unknown self_play_mode {mode!r}; must be one of {sorted(SELF_PLAY_MODES)}")
         self._mode = mode
         self._mutation_scale = float(mutation_scale)
         self._top_n = max(1, int(top_n))

--- a/framework/self_play.py
+++ b/framework/self_play.py
@@ -1,0 +1,203 @@
+"""Self-play opponent management for multi-agent RL training.
+
+Three modes
+-----------
+exact :
+    Opponent is always an exact snapshot of the current champion policy.
+    Refreshed at the end of each training generation / episode.
+mutated :
+    Opponent is a slightly mutated copy of the current champion.
+    Mutation strength is controlled by *mutation_scale*.
+    Refreshed at the end of each training generation / episode.
+top_n :
+    Maintains a pool of up to *top_n* historical champion snapshots.
+    The pool grows whenever the champion improves; when at capacity the
+    weakest snapshot is replaced if the new champion scores higher.
+    A uniformly random pool member is selected as opponent each generation.
+
+Usage
+-----
+In the training loop::
+
+    manager = SelfPlayManager(mode="top_n", top_n=5)
+    env.set_opponent_policy(manager.build_initial_opponent(policy))
+
+    for gen in range(n_generations):
+        rewards = evaluate(policy)
+        improved = policy.update(rewards)
+        new_opp = manager.step(policy, improved)
+        if new_opp is not None:
+            env.set_opponent_policy(new_opp)
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from typing import Any
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+#: Valid self_play_mode values.
+SELF_PLAY_MODES: frozenset[str] = frozenset({"exact", "mutated", "top_n"})
+
+
+class SelfPlayManager:
+    """Manages the opponent policy for self-play training.
+
+    Parameters
+    ----------
+    mode :
+        One of ``"exact"``, ``"mutated"``, or ``"top_n"``.
+    mutation_scale :
+        Std-dev of Gaussian weight perturbation applied in ``"mutated"``
+        mode.  Ignored for the other modes.
+    top_n :
+        Maximum pool size for ``"top_n"`` mode.  Must be ≥ 1.  Ignored
+        for ``"exact"`` and ``"mutated"``.
+    seed :
+        Optional integer RNG seed for reproducibility (controls pool
+        sampling in ``"top_n"`` mode).
+    """
+
+    def __init__(
+        self,
+        mode: str = "exact",
+        mutation_scale: float = 0.05,
+        top_n: int = 5,
+        seed: int | None = None,
+    ) -> None:
+        if mode not in SELF_PLAY_MODES:
+            raise ValueError(
+                f"Unknown self_play_mode {mode!r}; "
+                f"must be one of {sorted(SELF_PLAY_MODES)}"
+            )
+        self._mode = mode
+        self._mutation_scale = float(mutation_scale)
+        self._top_n = max(1, int(top_n))
+        # Pool entries: (score: float, callable: Any)
+        self._pool: list[tuple[float, Any]] = []
+        self._rng = np.random.default_rng(seed)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @property
+    def mode(self) -> str:
+        """The active self-play mode."""
+        return self._mode
+
+    def build_initial_opponent(self, policy: Any) -> Any:
+        """Build the initial opponent at the start of a training run.
+
+        Also seeds the pool (``"top_n"`` mode) with the initial policy
+        snapshot so the very first generation has a valid opponent.
+
+        Parameters
+        ----------
+        policy :
+            The primary training policy before any training has occurred.
+
+        Returns
+        -------
+        Any
+            A callable ``(obs) -> action`` suitable for
+            ``env.set_opponent_policy()``.
+        """
+        return self.step(policy, improved=True)
+
+    def step(self, policy: Any, improved: bool) -> Any:
+        """Update the opponent pool and return the next opponent callable.
+
+        Call this once per training generation *after* the policy has
+        been updated for that generation.
+
+        Parameters
+        ----------
+        policy :
+            The primary training policy (post-update).
+        improved :
+            Whether the champion score improved this generation.
+
+        Returns
+        -------
+        Any
+            A callable ``(obs) -> action``.  For ``"top_n"`` mode this
+            is ``None`` only when the pool is empty (which cannot happen
+            after :meth:`build_initial_opponent` has been called).
+        """
+        if self._mode == "exact":
+            return self._snapshot_callable(policy)
+        if self._mode == "mutated":
+            return self._mutated_snapshot(policy)
+        # top_n
+        if improved or not self._pool:
+            self._update_pool(policy)
+        return self._pick_from_pool()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _snapshot_callable(self, policy: Any) -> Any:
+        """Return a lightweight callable snapshot of the policy's champion.
+
+        When the policy wrapper (e.g. ``SC2GeneticPolicy``) carries a
+        ``_champion`` attribute that is itself callable (e.g.
+        ``SC2MultiHeadLinearPolicy``), we deepcopy that individual rather
+        than the whole population wrapper to avoid the cost of copying an
+        entire population every generation.
+        """
+        champion = getattr(policy, "_champion", None)
+        if champion is not None and callable(champion):
+            return copy.deepcopy(champion)
+        return copy.deepcopy(policy)
+
+    def _mutated_snapshot(self, policy: Any) -> Any:
+        """Return a mutated copy of the current champion.
+
+        Uses the champion's ``mutated(scale, share)`` method when
+        available (e.g. ``SC2MultiHeadLinearPolicy``).  Falls back to a
+        plain deepcopy for policies without a ``mutated`` method.
+        """
+        champion = getattr(policy, "_champion", None)
+        if champion is not None and hasattr(champion, "mutated"):
+            return champion.mutated(scale=self._mutation_scale, share=1.0)
+        if hasattr(policy, "mutated"):
+            return policy.mutated(scale=self._mutation_scale)
+        return self._snapshot_callable(policy)
+
+    def _update_pool(self, policy: Any) -> None:
+        """Add a champion snapshot to the pool, evicting the weakest entry
+        when at capacity."""
+        score = float(getattr(policy, "champion_reward", float("-inf")))
+        snap = self._snapshot_callable(policy)
+        entry: tuple[float, Any] = (score, snap)
+        if len(self._pool) < self._top_n:
+            self._pool.append(entry)
+            logger.debug(
+                "[SelfPlay/top_n] added champion (score=%.1f); pool %d/%d",
+                score,
+                len(self._pool),
+                self._top_n,
+            )
+        else:
+            worst_idx = min(range(len(self._pool)), key=lambda i: self._pool[i][0])
+            if score > self._pool[worst_idx][0]:
+                logger.debug(
+                    "[SelfPlay/top_n] replaced pool[%d] (score %.1f → %.1f)",
+                    worst_idx,
+                    self._pool[worst_idx][0],
+                    score,
+                )
+                self._pool[worst_idx] = entry
+
+    def _pick_from_pool(self) -> Any | None:
+        """Return a uniformly random callable from the pool."""
+        if not self._pool:
+            return None
+        idx = int(self._rng.integers(len(self._pool)))
+        return self._pool[idx][1]

--- a/framework/self_play.py
+++ b/framework/self_play.py
@@ -200,4 +200,4 @@ class SelfPlayManager:
         if not self._pool:
             return None
         idx = int(self._rng.integers(len(self._pool)))
-        return self._pool[idx][1]
+        return copy.deepcopy(self._pool[idx][1])

--- a/framework/self_play.py
+++ b/framework/self_play.py
@@ -196,7 +196,13 @@ class SelfPlayManager:
                 self._pool[worst_idx] = entry
 
     def _pick_from_pool(self) -> Any | None:
-        """Return a uniformly random callable from the pool."""
+        """Return a deepcopy of a uniformly random pool entry.
+
+        A fresh copy is returned on every call so stateful opponents (e.g.
+        LSTM policies whose hidden state evolves during ``__call__``) always
+        start from a clean snapshot and pool entries are never mutated by
+        the opponent's own execution.
+        """
         if not self._pool:
             return None
         idx = int(self._rng.integers(len(self._pool)))

--- a/framework/training.py
+++ b/framework/training.py
@@ -765,6 +765,7 @@ def _greedy_loop(
     live_monitor: Any = None,
     patience: int = 0,
     log_stats_every_n_sims: int = 0,
+    self_play_manager: Any = None,
 ) -> GreedyLoopResult:
     """ES gradient-estimation loop for WeightedLinearPolicy / NeuralNetPolicy."""
     ADAPT_WINDOW = 20
@@ -819,6 +820,10 @@ def _greedy_loop(
                     logger.info("  >> %s", verdict)
                     if log_stats_every_n_sims > 0 and sim % log_stats_every_n_sims == 0:
                         _log_periodic_stats(ep.info, sim)
+                if self_play_manager is not None:
+                    _new_opp = self_play_manager.step(best_policy, improved)
+                    if _new_opp is not None:
+                        env.set_opponent_policy(_new_opp)
                 improvement_history.append(improved)
                 _maybe_adapt_scale(
                     improvement_history,
@@ -1096,6 +1101,7 @@ def _greedy_loop_cmaes(
     patience: int = 0,
     evaluator: Any = None,
     log_stats_every_n_sims: int = 0,
+    self_play_manager: Any = None,
 ) -> GreedyLoopResult:
     """CMA-ES loop: sample λ offspring, evaluate each for eval_episodes episodes, update distribution.
 
@@ -1218,6 +1224,11 @@ def _greedy_loop_cmaes(
                 if log_stats_every_n_sims > 0 and gen % log_stats_every_n_sims == 0:
                     _log_periodic_stats(last_info, gen)
 
+            if self_play_manager is not None:
+                _new_opp = self_play_manager.step(policy, improved)
+                if _new_opp is not None:
+                    env.set_opponent_policy(_new_opp)
+
             greedy_sims.append(
                 GreedySimResult(
                     sim=gen,
@@ -1277,6 +1288,7 @@ def _greedy_loop_q_learning(
     live_monitor: Any = None,
     patience: int = 0,
     log_stats_every_n_sims: int = 0,
+    self_play_manager: Any = None,
 ) -> GreedyLoopResult:
     """Q-learning greedy loop for epsilon_greedy and ucb_q policy types."""
     best_reward = float("-inf")
@@ -1326,6 +1338,11 @@ def _greedy_loop_q_learning(
                 best_info_logged = ep.info
             elif log_stats_every_n_sims > 0 and episode % log_stats_every_n_sims == 0:
                 _log_periodic_stats(ep.info, episode)
+
+            if self_play_manager is not None:
+                _new_opp = self_play_manager.step(policy, improved)
+                if _new_opp is not None:
+                    env.set_opponent_policy(_new_opp)
 
             greedy_sims.append(
                 GreedySimResult(
@@ -1388,6 +1405,7 @@ def _greedy_loop_genetic(
     adaptive_mutation: bool = True,
     evaluator: Any = None,
     log_stats_every_n_sims: int = 0,
+    self_play_manager: Any = None,
 ) -> GreedyLoopResult:
     """Genetic algorithm loop: N_pop episodes per generation.
 
@@ -1511,6 +1529,11 @@ def _greedy_loop_genetic(
                 logger.info("  >> %s", verdict)
                 if log_stats_every_n_sims > 0 and gen % log_stats_every_n_sims == 0:
                     _log_periodic_stats(last_info, gen)
+
+            if self_play_manager is not None:
+                _new_opp = self_play_manager.step(policy, improved)
+                if _new_opp is not None:
+                    env.set_opponent_policy(_new_opp)
 
             # --- adaptive mutation (1/5 success rule over recent window) ---
             improvement_history.append(improved)
@@ -1856,15 +1879,27 @@ def train_rl(
     loop_type = best_policy.LOOP_TYPE
 
     # ── self-play opponent wiring ─────────────────────────────────────────────
-    # When the env supports self-play (e.g. SC2 with self_play=True), inject a
-    # copy of the current policy as the opponent.  The opponent's weights are
-    # snapshotted once here; individual training loops may refresh it.
+    # When the env supports self-play (e.g. SC2 with self_play=True), build a
+    # SelfPlayManager for the requested mode and inject the initial opponent.
+    # The greedy loops refresh the opponent at the end of each generation.
+    _self_play_manager: Any = None
     if hasattr(env, "set_opponent_policy") and training_params.get("self_play"):
-        import copy as _copy
+        from framework.self_play import SelfPlayManager
 
-        _opponent = _copy.deepcopy(best_policy)
-        env.set_opponent_policy(_opponent)
-        logger.info("Self-play enabled: opponent initialised from current policy weights.")
+        _sp_mode = str(training_params.get("self_play_mode", "exact"))
+        _sp_mutation_scale = float(training_params.get("self_play_mutation_scale", mutation_scale))
+        _sp_top_n = int(training_params.get("self_play_top_n", 5))
+        _self_play_manager = SelfPlayManager(
+            mode=_sp_mode,
+            mutation_scale=_sp_mutation_scale,
+            top_n=_sp_top_n,
+        )
+        _initial_opponent = _self_play_manager.build_initial_opponent(best_policy)
+        env.set_opponent_policy(_initial_opponent)
+        logger.info(
+            "Self-play enabled: mode=%r, opponent initialised from current policy weights.",
+            _sp_mode,
+        )
 
     # ── intra-run parallel evaluation (issue #229) ────────────────────────────
     evaluator = _maybe_build_evaluator(
@@ -1890,6 +1925,7 @@ def train_rl(
                 adaptive_mutation=adaptive_mutation,
                 patience=patience,
                 log_stats_every_n_sims=log_stats_every_n_sims,
+                self_play_manager=_self_play_manager,
                 **kw,
             )
         elif loop_type == "q_learning":
@@ -1900,6 +1936,7 @@ def train_rl(
                 weights_file=weights_file,
                 patience=patience,
                 log_stats_every_n_sims=log_stats_every_n_sims,
+                self_play_manager=_self_play_manager,
                 **kw,
             )
         elif loop_type == "cmaes":
@@ -1911,6 +1948,7 @@ def train_rl(
                 patience=patience,
                 evaluator=evaluator,
                 log_stats_every_n_sims=log_stats_every_n_sims,
+                self_play_manager=_self_play_manager,
                 **kw,
             )
         elif loop_type == "genetic":
@@ -1923,6 +1961,7 @@ def train_rl(
                 adaptive_mutation=adaptive_mutation,
                 evaluator=evaluator,
                 log_stats_every_n_sims=log_stats_every_n_sims,
+                self_play_manager=_self_play_manager,
                 **kw,  # type: ignore[arg-type]
             )
         elif loop_type == "sb3":

--- a/framework/training.py
+++ b/framework/training.py
@@ -971,6 +971,11 @@ def _greedy_loop(
                 if log_stats_every_n_sims > 0 and sim % log_stats_every_n_sims == 0:
                     _log_periodic_stats(best_ep.info, sim)
 
+            if self_play_manager is not None:
+                _new_opp = self_play_manager.step(best_policy, improved)
+                if _new_opp is not None:
+                    env.set_opponent_policy(_new_opp)
+
             improvement_history.append(improved)
             if adaptive_mutation and len(improvement_history) == ADAPT_WINDOW and sim % ADAPT_WINDOW == 0:
                 p = sum(improvement_history) / ADAPT_WINDOW

--- a/games/sc2/config/training_params.yaml
+++ b/games/sc2/config/training_params.yaml
@@ -68,11 +68,22 @@ minimap_layers: []                          # optional minimap channels (sc2_cnn
 # obs_spec_preset: minigame
 enable_belief: false   # set true to activate fog-of-war belief obs + scouting reward
 
-# Self-play — when true, the agent plays against a clone of itself instead
-# of the built-in bot.  The opponent's weights are copied from the primary
-# policy at the start of each episode, mimicking AlphaGo-style self-play.
-# Only meaningful on ladder maps (1v1); ignored on minigames.
+# Self-play — when true, the agent plays against another copy of itself
+# instead of the built-in bot.  Only meaningful on ladder maps (1v1);
+# ignored on minigames.
+#
+# self_play_mode controls how the opponent is chosen each generation:
+#   exact   — opponent is always an exact copy of the current champion
+#             (default; equivalent to the original single-deepcopy behaviour)
+#   mutated — opponent is a slightly mutated copy of the current champion;
+#             mutation strength set by self_play_mutation_scale
+#   top_n   — opponent rotates through a pool of the top-N champions seen
+#             so far (up to self_play_top_n entries); the weakest entry is
+#             replaced when a new, stronger champion beats it
 self_play: false
+# self_play_mode: exact          # exact | mutated | top_n  (default: exact)
+# self_play_mutation_scale: 0.05 # Gaussian noise std for mutated mode
+# self_play_top_n: 5             # pool capacity for top_n mode
 
 # APM limiting — constrains the agent to at most max_apm real actions per
 # minute, using a rolling token-bucket so the budget is spread across time

--- a/games/sc2/config/training_params.yaml
+++ b/games/sc2/config/training_params.yaml
@@ -74,7 +74,7 @@ enable_belief: false   # set true to activate fog-of-war belief obs + scouting r
 #
 # self_play_mode controls how the opponent is chosen each generation:
 #   exact   — opponent is always an exact copy of the current champion
-#             (default; equivalent to the original single-deepcopy behaviour)
+#             (default; refreshed each generation)
 #   mutated — opponent is a slightly mutated copy of the current champion;
 #             mutation strength set by self_play_mutation_scale
 #   top_n   — opponent rotates through a pool of the top-N champions seen

--- a/games/sc2/config/training_params.yaml
+++ b/games/sc2/config/training_params.yaml
@@ -73,8 +73,8 @@ enable_belief: false   # set true to activate fog-of-war belief obs + scouting r
 # ignored on minigames.
 #
 # self_play_mode controls how the opponent is chosen each generation:
-#   exact   — opponent is always an exact copy of the current champion
-#             (default; refreshed each generation)
+#   exact   — opponent is a fresh snapshot of the current champion, taken
+#             each generation so it always mirrors the latest weights (default)
 #   mutated — opponent is a slightly mutated copy of the current champion;
 #             mutation strength set by self_play_mutation_scale
 #   top_n   — opponent rotates through a pool of the top-N champions seen

--- a/tests/README.md
+++ b/tests/README.md
@@ -70,6 +70,7 @@
   - [test\_sc2\_eval.py — `--eval` evaluation mode](#test_sc2_evalpy----eval-evaluation-mode)
   - [test\_sc2\_play.py — `play_sc2.py` script](#test_sc2_playpy--play_sc2py-script)
   - [test\_sc2\_simple64\_training.py — Simple64 ladder integration](#test_sc2_simple64_trainingpy--simple64-ladder-integration)
+  - [test\_sc2\_self\_play.py — `SelfPlayManager` (three self-play opponent modes)](#test_sc2_self_playpy--selfplaymanager-three-self-play-opponent-modes)
   - [test\_sc2\_analytics.py — SC2-specific analytics plots and flags](#test_sc2_analyticspy--sc2-specific-analytics-plots-and-flags)
 - [Rocket League](#rocket-league)
   - [test\_rocket\_league\_obs\_spec.py — Rocket League observation spec (142-dim)](#test_rocket_league_obs_specpy--rocket-league-observation-spec-142-dim)
@@ -582,7 +583,9 @@ training-loop iteration against a mocked env, plus trainer-state save/load
 round-trips for cmaes and neural_dqn; and the SC2-specific analytics module
 (`SUPPORTS_THROTTLE`/`SUPPORTS_PATH` flags, action-frequency breakdown, obs
 feature averages, spatial heatmap, outcome breakdown, and the full
-`save_experiment_results` integration including that no racing plots appear).
+`save_experiment_results` integration including that no racing plots appear);
+and `SelfPlayManager` — all three opponent modes (`exact`, `mutated`, `top_n`),
+pool growth/eviction semantics, and wiring through `train_rl`.
 
 **Not tested.** PySC2 against the actual Blizzard SC2 binary; real
 1v1 games against the built-in bot; minimap rendering; the deferred
@@ -759,6 +762,12 @@ handful of iterations only).
 - Per-policy on Simple64: epsilon_greedy / ucb_q / sc2_neural_dqn shape+update / sc2_cmaes sample+update / sc2_reinforce shape+episode / sc2_lstm shape / sc2_lstm-evolution sample+update
 - Training loops (mocked env): sc2_genetic / sc2_cmaes / sc2_neural_dqn / sc2_reinforce / sc2_lstm
 - Trainer state roundtrips: sc2_cmaes / sc2_neural_dqn
+
+### test_sc2_self_play.py — `SelfPlayManager` (three self-play opponent modes)
+- `TestSelfPlayManagerExactMode`: invalid mode raises / `build_initial_opponent` returns a callable / `step` returns a fresh callable every generation regardless of `improved`
+- `TestSelfPlayManagerMutatedMode`: `step` calls `mutated()` on the champion when available / falls back to deepcopy when policy has no `mutated` method
+- `TestSelfPlayManagerTopNMode`: pool grows on improvement / capped at `top_n` / weakest entry replaced by a stronger champion / no pool update when not improved and pool is non-empty / callable returned from pool / weak champion does not displace a stronger pool entry
+- `TestTrainRLSelfPlayModes`: verifies that all three modes (`exact`, `mutated`, `top_n`) wire a `SelfPlayManager` through `train_rl` and that the genetic greedy loop receives the correct `self_play_manager` kwarg
 
 ### test_sc2_analytics.py — SC2-specific analytics plots and flags
 - `SUPPORTS_THROTTLE=False` / `SUPPORTS_PATH=False` flags

--- a/tests/README.md
+++ b/tests/README.md
@@ -767,6 +767,7 @@ handful of iterations only).
 - `TestSelfPlayManagerExactMode`: invalid mode raises / `build_initial_opponent` returns a callable / `step` returns a fresh callable every generation regardless of `improved`
 - `TestSelfPlayManagerMutatedMode`: `step` calls `mutated()` on the champion when available / falls back to deepcopy when policy has no `mutated` method
 - `TestSelfPlayManagerTopNMode`: pool grows on improvement / capped at `top_n` / weakest entry replaced by a stronger champion / no pool update when not improved and pool is non-empty / callable returned from pool / weak champion does not displace a stronger pool entry
+- `TestGreedyLoopCmaesWithSelfPlay`: `_greedy_loop_cmaes` calls `manager.step()` once per generation and forwards the returned opponent to `env.set_opponent_policy()`; without a manager `set_opponent_policy` is never called
 - `TestTrainRLSelfPlayModes`: verifies that all three modes (`exact`, `mutated`, `top_n`) wire a `SelfPlayManager` through `train_rl` and that the genetic greedy loop receives the correct `self_play_manager` kwarg
 
 ### test_sc2_analytics.py — SC2-specific analytics plots and flags

--- a/tests/test_cmaes_policy.py
+++ b/tests/test_cmaes_policy.py
@@ -3,7 +3,7 @@
 import os
 import tempfile
 import unittest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 
@@ -369,6 +369,51 @@ class TestCMAESEvalEpisodes(unittest.TestCase):
                 os.unlink(wf)
 
         self.assertEqual(reset_count[0], pop_size * eval_episodes)
+
+    def test_self_play_manager_refreshes_opponent(self):
+        from framework.training import _greedy_loop_cmaes
+
+        policy = _make_tmnf_policy(population_size=2, initial_sigma=0.3, eval_episodes=1)
+        policy.initialize_random()
+
+        class _Env:
+            def __init__(self):
+                self.set_opponent_policy = MagicMock()
+
+            def reset(self):
+                return np.zeros(BASE_OBS_DIM, dtype=np.float32), {}
+
+            def step(self, action):
+                info = {"track_progress": 0.5, "laps_completed": 0, "pos_x": 0.0, "pos_z": 0.0}
+                return (np.zeros(BASE_OBS_DIM, dtype=np.float32), 1.0, True, False, info)
+
+            def get_episode_time_limit(self):
+                return None
+
+            def set_episode_time_limit(self, _):
+                pass
+
+        env = _Env()
+        manager = MagicMock()
+        new_opp = MagicMock()
+        manager.step.return_value = new_opp
+
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            wf = f.name
+        try:
+            loop = _greedy_loop_cmaes(
+                env=env,
+                policy=policy,
+                n_generations=1,
+                weights_file=wf,
+                self_play_manager=manager,
+            )
+        finally:
+            if os.path.exists(wf):
+                os.unlink(wf)
+
+        manager.step.assert_called_once_with(policy, loop.greedy_sims[0].improved)
+        env.set_opponent_policy.assert_called_once_with(new_opp)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sc2_self_play.py
+++ b/tests/test_sc2_self_play.py
@@ -644,6 +644,7 @@ class TestGreedyLoopCmaesWithSelfPlay(unittest.TestCase):
     def _make_mock_cmaes_policy(self, champion_reward=0.0):
         """Return a minimal CMA-ES-like policy stub."""
         from unittest.mock import MagicMock
+
         import numpy as np
 
         policy = MagicMock()
@@ -659,12 +660,14 @@ class TestGreedyLoopCmaesWithSelfPlay(unittest.TestCase):
 
     def test_self_play_manager_step_called_each_gen(self):
         """Manager.step() is called once per generation and env.set_opponent_policy updated."""
-        import numpy as np
-        import tempfile
         import os
-        from unittest.mock import MagicMock, call
-        from framework.training import _greedy_loop_cmaes
+        import tempfile
+        from unittest.mock import MagicMock
+
+        import numpy as np
+
         from framework.self_play import SelfPlayManager
+        from framework.training import _greedy_loop_cmaes
 
         policy = self._make_mock_cmaes_policy(champion_reward=1.0)
 
@@ -698,10 +701,12 @@ class TestGreedyLoopCmaesWithSelfPlay(unittest.TestCase):
 
     def test_no_self_play_manager_no_set_opponent(self):
         """Without a manager, set_opponent_policy is never called."""
-        import numpy as np
-        import tempfile
         import os
+        import tempfile
         from unittest.mock import MagicMock
+
+        import numpy as np
+
         from framework.training import _greedy_loop_cmaes
 
         policy = self._make_mock_cmaes_policy()

--- a/tests/test_sc2_self_play.py
+++ b/tests/test_sc2_self_play.py
@@ -449,5 +449,261 @@ class TestTrainRLSelfPlayWiring(unittest.TestCase):
         self.assertIsNotNone(opp_arg)
 
 
+# ---------------------------------------------------------------------------
+# SelfPlayManager unit tests
+# ---------------------------------------------------------------------------
+
+
+class _CallablePolicy:
+    """Minimal stand-in for a policy with champion_reward and mutated()."""
+
+    def __init__(self, reward: float = 0.0):
+        self.champion_reward = reward
+        self._champion = self  # policy is its own champion for simplicity
+        self.mutated_called = False
+
+    def __call__(self, obs):
+        return np.zeros(4, dtype=np.float32)
+
+    def mutated(self, scale: float = 0.1, share: float = 1.0) -> "_CallablePolicy":
+        self.mutated_called = True
+        child = _CallablePolicy(self.champion_reward)
+        return child
+
+
+class TestSelfPlayManagerExactMode(unittest.TestCase):
+    """SelfPlayManager in 'exact' mode always returns a snapshot of champion."""
+
+    def test_invalid_mode_raises(self):
+        from framework.self_play import SelfPlayManager
+
+        with self.assertRaises(ValueError):
+            SelfPlayManager(mode="unknown")
+
+    def test_build_initial_opponent_returns_callable(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="exact")
+        policy = _CallablePolicy(reward=10.0)
+        opp = manager.build_initial_opponent(policy)
+        self.assertIsNotNone(opp)
+        self.assertTrue(callable(opp))
+
+    def test_step_always_returns_new_snapshot(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="exact")
+        policy = _CallablePolicy(reward=5.0)
+        opp1 = manager.step(policy, improved=False)
+        opp2 = manager.step(policy, improved=True)
+        # Both should be callable; they are independent copies, not the same object.
+        self.assertIsNotNone(opp1)
+        self.assertIsNotNone(opp2)
+        self.assertIsNot(opp1, opp2)
+
+    def test_step_no_improvement_still_refreshes(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="exact")
+        policy = _CallablePolicy(reward=3.0)
+        opp = manager.step(policy, improved=False)
+        self.assertIsNotNone(opp)
+
+
+class TestSelfPlayManagerMutatedMode(unittest.TestCase):
+    """SelfPlayManager in 'mutated' mode calls champion.mutated()."""
+
+    def test_mutated_mode_calls_mutated(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="mutated", mutation_scale=0.1)
+        policy = _CallablePolicy(reward=1.0)
+        opp = manager.step(policy, improved=True)
+        # _CallablePolicy.mutated() sets mutated_called on the champion.
+        self.assertTrue(policy._champion.mutated_called)
+        self.assertIsNotNone(opp)
+
+    def test_mutated_fallback_when_no_mutated_method(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="mutated", mutation_scale=0.1)
+
+        class _NoMutated:
+            champion_reward = 2.0
+
+            def __call__(self, obs):
+                return np.zeros(4)
+
+        policy = _NoMutated()
+        # Should not raise; falls back to deepcopy.
+        opp = manager.step(policy, improved=True)
+        self.assertIsNotNone(opp)
+
+
+class TestSelfPlayManagerTopNMode(unittest.TestCase):
+    """SelfPlayManager in 'top_n' mode maintains a pool of top champions."""
+
+    def test_pool_grows_on_each_improvement(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="top_n", top_n=3, seed=0)
+        policy = _CallablePolicy(reward=1.0)
+        manager.build_initial_opponent(policy)
+        self.assertEqual(len(manager._pool), 1)
+
+        policy.champion_reward = 2.0
+        manager.step(policy, improved=True)
+        self.assertEqual(len(manager._pool), 2)
+
+        policy.champion_reward = 3.0
+        manager.step(policy, improved=True)
+        self.assertEqual(len(manager._pool), 3)
+
+    def test_pool_capped_at_top_n(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="top_n", top_n=2, seed=0)
+        policy = _CallablePolicy(reward=1.0)
+        manager.build_initial_opponent(policy)
+        policy.champion_reward = 2.0
+        manager.step(policy, improved=True)
+        # Pool at capacity now.
+        policy.champion_reward = 3.0
+        manager.step(policy, improved=True)
+        self.assertEqual(len(manager._pool), 2)
+
+    def test_weakest_replaced_on_new_champion(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="top_n", top_n=2, seed=0)
+        policy = _CallablePolicy(reward=1.0)
+        manager.build_initial_opponent(policy)  # pool: [(1.0, …)]
+        policy.champion_reward = 2.0
+        manager.step(policy, improved=True)  # pool: [(1.0, …), (2.0, …)]
+        # Now a stronger champion arrives.
+        policy.champion_reward = 5.0
+        manager.step(policy, improved=True)
+        # The weakest (score=1.0) should have been evicted.
+        scores = [score for score, _ in manager._pool]
+        self.assertNotIn(1.0, scores)
+        self.assertIn(5.0, scores)
+
+    def test_no_update_when_not_improved_and_pool_full(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="top_n", top_n=2, seed=0)
+        policy = _CallablePolicy(reward=1.0)
+        manager.build_initial_opponent(policy)
+        policy.champion_reward = 2.0
+        manager.step(policy, improved=True)  # pool full
+        # No improvement; pool should stay the same.
+        initial_scores = [s for s, _ in manager._pool]
+        policy.champion_reward = 2.0
+        manager.step(policy, improved=False)
+        final_scores = [s for s, _ in manager._pool]
+        self.assertEqual(initial_scores, final_scores)
+
+    def test_step_returns_callable_from_pool(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="top_n", top_n=3, seed=42)
+        policy = _CallablePolicy(reward=1.0)
+        manager.build_initial_opponent(policy)
+        opp = manager.step(policy, improved=False)
+        self.assertIsNotNone(opp)
+        self.assertTrue(callable(opp))
+
+    def test_weak_champion_does_not_replace_stronger_pool_entry(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="top_n", top_n=2, seed=0)
+        policy = _CallablePolicy(reward=10.0)
+        manager.build_initial_opponent(policy)
+        policy.champion_reward = 9.0
+        manager.step(policy, improved=True)  # pool: [(10, …), (9, …)]
+        # A weaker "improved" champion (e.g. score=1.0) should NOT evict
+        # any existing entry since it is not stronger than any pool member.
+        policy.champion_reward = 1.0
+        manager.step(policy, improved=True)
+        scores = [s for s, _ in manager._pool]
+        self.assertNotIn(1.0, scores)
+
+
+class TestTrainRLSelfPlayModes(unittest.TestCase):
+    """train_rl passes SelfPlayManager to the genetic loop when self_play is set."""
+
+    @patch("framework.training._greedy_loop_genetic")
+    @patch("framework.training._maybe_build_evaluator", return_value=None)
+    @patch("framework.training.make_live_monitor", return_value=None)
+    def _run_with_mode(self, mode, _mock_lm, _mock_eval, mock_loop):
+        from framework.run_config import GameSpec, RunConfig
+        from framework.training import GreedyLoopResult, train_rl
+        from games.sc2.actions import DISCRETE_ACTIONS
+        from games.sc2.obs_spec import get_spec
+
+        obs_spec = get_spec("Simple64")
+        mock_env = MagicMock()
+        mock_loop.return_value = GreedyLoopResult(
+            policy=MagicMock(),
+            best_reward=0.0,
+            greedy_sims=[],
+            early_stopped=False,
+            early_stop_sim=None,
+        )
+        training_params = {
+            "policy_type": "sc2_genetic",
+            "n_sims": 1,
+            "speed": 1.0,
+            "in_game_episode_s": 10.0,
+            "mutation_scale": 0.05,
+            "mutation_share": 1.0,
+            "adaptive_mutation": False,
+            "patience": 0,
+            "log_stats_every_n_sims": 0,
+            "self_play": True,
+            "self_play_mode": mode,
+            "policy_params": {
+                "population_size": 2,
+                "elite_k": 1,
+                "eval_episodes": 1,
+                "mutation_scale": 0.1,
+                "mutation_share": 0.3,
+            },
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            game = GameSpec(
+                experiment_name="test_mode",
+                track="sc2_Simple64",
+                make_env_fn=lambda: mock_env,
+                obs_spec=obs_spec,
+                head_names=["fn_idx", "x", "y", "queue"],
+                discrete_actions=DISCRETE_ACTIONS,
+                weights_file=os.path.join(tmpdir, "w.yaml"),
+                reward_config_file="",
+                save_results_fn=lambda *a, **kw: None,
+                game_name="sc2",
+            )
+            config = RunConfig.from_training_params(training_params)
+            train_rl(game, config, no_interrupt=True)
+
+        # set_opponent_policy called for initial opponent.
+        mock_env.set_opponent_policy.assert_called()
+        # The genetic loop received a self_play_manager kwarg.
+        call_kwargs = mock_loop.call_args[1]
+        self.assertIn("self_play_manager", call_kwargs)
+        manager = call_kwargs["self_play_manager"]
+        self.assertIsNotNone(manager)
+        self.assertEqual(manager.mode, mode)
+
+    def test_exact_mode_wired(self):
+        self._run_with_mode("exact")
+
+    def test_mutated_mode_wired(self):
+        self._run_with_mode("mutated")
+
+    def test_top_n_mode_wired(self):
+        self._run_with_mode("top_n")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sc2_self_play.py
+++ b/tests/test_sc2_self_play.py
@@ -638,6 +638,90 @@ class TestSelfPlayManagerTopNMode(unittest.TestCase):
         self.assertNotIn(1.0, scores)
 
 
+class TestGreedyLoopCmaesWithSelfPlay(unittest.TestCase):
+    """_greedy_loop_cmaes calls self_play_manager.step() each generation."""
+
+    def _make_mock_cmaes_policy(self, champion_reward=0.0):
+        """Return a minimal CMA-ES-like policy stub."""
+        from unittest.mock import MagicMock
+        import numpy as np
+
+        policy = MagicMock()
+        policy.champion_reward = champion_reward
+        policy.sigma = 0.1
+        # sample_population returns two individuals
+        ind = MagicMock()
+        ind.__call__ = MagicMock(return_value=np.zeros(4, dtype=np.float32))
+        policy.sample_population.return_value = [ind, ind]
+        # update_distribution returns True (improved) on first call
+        policy.update_distribution.side_effect = [True, False, False]
+        return policy
+
+    def test_self_play_manager_step_called_each_gen(self):
+        """Manager.step() is called once per generation and env.set_opponent_policy updated."""
+        import numpy as np
+        import tempfile
+        import os
+        from unittest.mock import MagicMock, call
+        from framework.training import _greedy_loop_cmaes
+        from framework.self_play import SelfPlayManager
+
+        policy = self._make_mock_cmaes_policy(champion_reward=1.0)
+
+        # Minimal env stub
+        obs = np.zeros(15, dtype=np.float32)
+        mock_env = MagicMock()
+        mock_env.get_episode_time_limit.return_value = None
+        mock_env.reset.return_value = (obs, {})
+        mock_env.step.return_value = (obs, 1.0, True, False, {"episode_reward_components": {}})
+
+        manager = MagicMock(spec=SelfPlayManager)
+        new_opp = MagicMock()
+        manager.step.return_value = new_opp
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            weights_file = os.path.join(tmpdir, "w.yaml")
+            _greedy_loop_cmaes(
+                env=mock_env,
+                policy=policy,
+                n_generations=3,
+                weights_file=weights_file,
+                self_play_manager=manager,
+            )
+
+        # step() called once per generation
+        self.assertEqual(manager.step.call_count, 3)
+        # env.set_opponent_policy updated each time with the returned opponent
+        self.assertEqual(mock_env.set_opponent_policy.call_count, 3)
+        for c in mock_env.set_opponent_policy.call_args_list:
+            self.assertIs(c[0][0], new_opp)
+
+    def test_no_self_play_manager_no_set_opponent(self):
+        """Without a manager, set_opponent_policy is never called."""
+        import numpy as np
+        import tempfile
+        import os
+        from unittest.mock import MagicMock
+        from framework.training import _greedy_loop_cmaes
+
+        policy = self._make_mock_cmaes_policy()
+        obs = np.zeros(15, dtype=np.float32)
+        mock_env = MagicMock()
+        mock_env.get_episode_time_limit.return_value = None
+        mock_env.reset.return_value = (obs, {})
+        mock_env.step.return_value = (obs, 0.5, True, False, {})
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _greedy_loop_cmaes(
+                env=mock_env,
+                policy=policy,
+                n_generations=2,
+                weights_file=os.path.join(tmpdir, "w.yaml"),
+            )
+
+        mock_env.set_opponent_policy.assert_not_called()
+
+
 class TestTrainRLSelfPlayModes(unittest.TestCase):
     """train_rl passes SelfPlayManager to the genetic loop when self_play is set."""
 

--- a/tests/test_sc2_self_play.py
+++ b/tests/test_sc2_self_play.py
@@ -613,6 +613,15 @@ class TestSelfPlayManagerTopNMode(unittest.TestCase):
         self.assertIsNotNone(opp)
         self.assertTrue(callable(opp))
 
+    def test_step_returns_fresh_copy_from_pool(self):
+        from framework.self_play import SelfPlayManager
+
+        manager = SelfPlayManager(mode="top_n", top_n=3, seed=0)
+        policy = _CallablePolicy(reward=1.0)
+        manager.build_initial_opponent(policy)
+        opp = manager.step(policy, improved=False)
+        self.assertIsNot(opp, manager._pool[0][1])
+
     def test_weak_champion_does_not_replace_stronger_pool_entry(self):
         from framework.self_play import SelfPlayManager
 


### PR DESCRIPTION
Introduces `framework/self_play.py` with `SelfPlayManager` (three modes:
exact snapshot, mutated copy, top-N champion pool) and wires it into all
four greedy loops in `framework/training.py` so the opponent is refreshed
each generation rather than only at run start.  New `self_play_mode`,
`self_play_mutation_scale`, and `self_play_top_n` config keys documented in
`games/sc2/config/training_params.yaml`.

Closes #345

https://claude.ai/code/session_019eXVADn2AzDnmgbTT5Edsx