### PR TITLE
SC2 replay BC [2/6]: replay reader → demonstration dataset (issue #351)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,17 @@ formatting, internal refactors with no behaviour change — can be skipped.
 ## [Unreleased]
 
 ### Added
+- SC2 replay BC dataset builder at `games/sc2/replay_bc.py` (issue #351,
+  [2/6]): reads `.SC2Replay` files via the PySC2 replay API and produces
+  sequence-aware NPZ demonstration datasets (`obs`, `actions`,
+  `episode_starts`, `episode_lengths`, `episode_id`, `meta`).  Public API:
+  `iter_replays(folder)`, `replay_observations(path, ...)` (generator),
+  `build_dataset(folder, save_path, ...)`, and `load_dataset(path, ...)`.
+  Supports race filtering, winner/explicit player selection, configurable
+  `step_mul`, and a `multi_action_strategy` knob (`"first"` /
+  `"first_non_noop"`) for steps with multiple simultaneous actions.  All
+  PySC2 imports are lazy (inside function bodies) so the module is
+  importable without PySC2 installed.
 - SC2 behaviour-cloning primitives (issue #350, part 1 of #349): a new
   `function_call_to_action()` in `games/sc2/actions.py` inverts
   `action_to_function_call`, converting a PySC2 `FunctionCall` back into the

--- a/games/sc2/replay_bc.py
+++ b/games/sc2/replay_bc.py
@@ -1,0 +1,596 @@
+"""Replay behaviour-cloning dataset builder for StarCraft II (issue #351).
+
+Reads a folder of .SC2Replay files and produces a sequence-aware
+``(obs, action)`` demonstration dataset for offline behaviour cloning.
+
+Usage — build a dataset from replays::
+
+    from games.sc2.obs_spec import get_spec
+    from games.sc2.replay_bc import build_dataset, load_dataset
+
+    spec = get_spec("MoveToBeacon")
+    meta = build_dataset(
+        "my_replays/",
+        "demos.npz",
+        obs_spec=spec,
+        player_id="winner",
+        race="terran",
+        step_mul=1,
+        screen_size=64,
+        minimap_size=64,
+    )
+
+Usage — load a saved dataset::
+
+    # Flat arrays (memoryless policies, random sampling)
+    data = load_dataset("demos.npz")
+    obs, actions = data["obs"], data["actions"]
+
+    # Per-episode sequences (recurrent policies — ordered, hidden-state carry-over)
+    episodes = load_dataset("demos.npz", as_episodes=True)
+    for obs_seq, act_seq in episodes:
+        ...  # obs_seq: [T, D], act_seq: [T, 4]
+
+PySC2 imports are lazy: this module can be imported without the SC2 binary or
+PySC2 installed (matching the existing games/sc2 convention).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+from typing import Any, Iterator
+
+import numpy as np
+
+from framework.obs_spec import ObsSpec
+
+logger = logging.getLogger(__name__)
+
+_WINNER_SENTINEL = "winner"
+
+
+class _TimestepAdapter:
+    """Wraps a raw obs dict so it satisfies ``extract_flat_obs``'s protocol.
+
+    ``extract_flat_obs`` expects ``timestep.observation`` to be a dict-like
+    object (the same form returned by ``features.transform_obs``).
+    """
+
+    __slots__ = ("observation",)
+
+    def __init__(self, observation: Any) -> None:
+        self.observation = observation
+
+
+# ---------------------------------------------------------------------------
+# Public helpers
+# ---------------------------------------------------------------------------
+
+
+def iter_replays(folder: str | pathlib.Path) -> list[pathlib.Path]:
+    """Return all ``*.SC2Replay`` paths under *folder*, sorted for reproducibility."""
+    return sorted(pathlib.Path(folder).glob("*.SC2Replay"))
+
+
+def _parse_replay_info(info: Any) -> tuple[int, dict[int, str]]:
+    """Return ``(winner_player_id, {player_id: race_name})`` from a replay_info proto.
+
+    *winner_player_id* is 0 when the result is undecided (tie / crash).
+    Race strings are one of ``"terran"`` / ``"zerg"`` / ``"protoss"`` / ``"random"``.
+    """
+    _RACE_INT_TO_NAME: dict[int, str] = {
+        1: "terran",
+        2: "zerg",
+        3: "protoss",
+        4: "random",
+    }
+    winner_id = 0
+    player_races: dict[int, str] = {}
+    for pi in info.player_info:
+        pid = int(pi.player_info.player_id)
+        race = int(pi.player_info.race_actual)
+        player_races[pid] = _RACE_INT_TO_NAME.get(race, "random")
+        # result==1 → Victory
+        if hasattr(pi, "player_result") and int(pi.player_result.result) == 1:
+            winner_id = pid
+    return winner_id, player_races
+
+
+def _resolve_player_id(player_id: int | str, winner_id: int) -> int:
+    """Convert *player_id* (``"winner"`` or 1/2) to a concrete integer."""
+    if player_id == _WINNER_SENTINEL:
+        return winner_id if winner_id != 0 else 1
+    return int(player_id)
+
+
+def _pick_best_action(function_calls: list[Any], strategy: str) -> Any | None:
+    """Select one FunctionCall from a per-step list.
+
+    Parameters
+    ----------
+    function_calls:
+        Non-empty list of PySC2 ``FunctionCall`` objects for this step.
+    strategy:
+        ``"first_non_noop"`` — return the first non-no_op, falling back to
+        the first element when all are no_op.
+        ``"first"`` — always return the first element regardless of type.
+
+    Returns ``None`` when *function_calls* is empty.
+    """
+    if not function_calls:
+        return None
+    if strategy == "first":
+        return function_calls[0]
+    # "first_non_noop" (default): skip no_op (PySC2 fn id 0)
+    for fc in function_calls:
+        if int(fc.function) != 0:
+            return fc
+    return function_calls[0]
+
+
+# ---------------------------------------------------------------------------
+# Core replay reader
+# ---------------------------------------------------------------------------
+
+
+def replay_observations(
+    path: str | pathlib.Path,
+    *,
+    player_id: int | str,
+    obs_spec: ObsSpec,
+    step_mul: int = 1,
+    screen_size: int = 64,
+    minimap_size: int = 64,
+    multi_action_strategy: str = "first_non_noop",
+) -> Iterator[tuple[np.ndarray, np.ndarray]]:
+    """Open a single replay and yield ``(obs_vec, action_vec)`` pairs.
+
+    Parameters
+    ----------
+    path:
+        Path to a ``.SC2Replay`` file.
+    player_id:
+        Which player to observe: ``"winner"`` (resolved from ``replay_info``)
+        or an explicit integer ``1`` / ``2``.
+    obs_spec:
+        Active observation spec — passed to :func:`extract_flat_obs`.
+    step_mul:
+        Game ticks advanced per loop step (coarsens replay playback).
+    screen_size, minimap_size:
+        Feature-layer resolutions; must match the experiment's config.
+    multi_action_strategy:
+        ``"first_non_noop"`` (default) keeps the first non-``no_op`` action
+        when a step has multiple actions, falling back to the first action
+        when all are ``no_op``.  ``"first"`` always returns the first action.
+
+    Yields
+    ------
+    (obs_vec, action_vec):
+        ``obs_vec`` is float32 of shape ``(obs_spec.n_dims,)``;
+        ``action_vec`` is float32 of shape ``(4,)`` = ``[fn_idx, x, y, queue]``.
+        Steps with no actions or only unknown fn_idx values are skipped.
+
+    Notes
+    -----
+    PySC2 imports are lazy — callers without PySC2 installed can still import
+    this module.  Raises ``ImportError`` at call-time if PySC2 is absent.
+    """
+    from pysc2 import run_configs
+    from pysc2.lib import features as sc2_features
+    from s2clientprotocol import sc2api_pb2 as sc2_api
+
+    from games.sc2.actions import function_call_to_action
+    from games.sc2.client import _ObsExtractState, extract_flat_obs
+
+    path = pathlib.Path(path)
+    run_config = run_configs.get()
+
+    with run_config.start(want_rgb=False) as controller:
+        replay_data = run_config.replay_data(str(path))
+        info = controller.replay_info(replay_data)
+        winner_id, _player_races = _parse_replay_info(info)
+        resolved_pid = _resolve_player_id(player_id, winner_id)
+
+        iface_options = sc2_api.InterfaceOptions(
+            feature_layer=sc2_api.SpatialCameraSetup(
+                width=24,
+                resolution=sc2_api.Size2DI(x=screen_size, y=screen_size),
+                minimap_resolution=sc2_api.Size2DI(x=minimap_size, y=minimap_size),
+            ),
+        )
+        controller.start_replay(
+            sc2_api.RequestStartReplay(
+                replay_data=replay_data,
+                options=iface_options,
+                observed_player_id=resolved_pid,
+                disable_fog=True,
+            )
+        )
+
+        game_info = controller.game_info()
+        feat = sc2_features.features_from_game_info(
+            game_info=game_info,
+            feature_dimensions=sc2_features.Dimensions(
+                screen=screen_size, minimap=minimap_size
+            ),
+            use_feature_units=True,
+        )
+
+        state = _ObsExtractState()
+        skipped_unknown = 0
+
+        while True:
+            obs_proto = controller.observe()
+
+            # player_result is a repeated field — truthy when the game is over.
+            if obs_proto.player_result:
+                break
+
+            # Build flat obs vector via the shared extractor (issue #350).
+            obs_dict = feat.transform_obs(obs_proto.observation)
+            timestep = _TimestepAdapter(obs_dict)
+            obs_vec, _feats = extract_flat_obs(timestep, obs_spec.names, state=state)
+
+            # Extract actions issued during this step.
+            raw_actions = list(obs_proto.actions)
+            if not raw_actions:
+                controller.step(step_mul)
+                continue
+
+            function_calls = [feat.reverse_action(a) for a in raw_actions]
+            chosen_fc = _pick_best_action(function_calls, multi_action_strategy)
+            if chosen_fc is None:
+                controller.step(step_mul)
+                continue
+
+            action_vec = function_call_to_action(
+                chosen_fc, screen_size=screen_size, minimap_size=minimap_size
+            )
+            if action_vec is None:
+                skipped_unknown += 1
+                logger.debug(
+                    "Skipping step in %s: unknown PySC2 fn_id %d",
+                    path.name,
+                    int(chosen_fc.function),
+                )
+                controller.step(step_mul)
+                continue
+
+            # Update last-action state for next step's obs extraction.
+            state.last_fn_idx = int(action_vec[0])
+            yield obs_vec, action_vec
+            controller.step(step_mul)
+
+        if skipped_unknown:
+            logger.info(
+                "%s: skipped %d step(s) with unknown fn_idx",
+                path.name,
+                skipped_unknown,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Dataset builder
+# ---------------------------------------------------------------------------
+
+
+def _read_one_replay(
+    path: pathlib.Path,
+    *,
+    player_id: int | str,
+    race_filter: str | None,
+    obs_spec: ObsSpec,
+    step_mul: int,
+    screen_size: int,
+    minimap_size: int,
+    multi_action_strategy: str,
+) -> tuple[bool, str, list[tuple[np.ndarray, np.ndarray]]]:
+    """Open ONE SC2 process per replay: race-check first, then collect pairs.
+
+    Returns
+    -------
+    (race_matched, player_race, pairs)
+        *race_matched* is ``False`` (and *pairs* is empty) when the replay was
+        dropped by the race filter.  *player_race* is the race string of the
+        observed player regardless of filtering.
+    """
+    from pysc2 import run_configs
+    from pysc2.lib import features as sc2_features
+    from s2clientprotocol import sc2api_pb2 as sc2_api
+
+    from games.sc2.actions import function_call_to_action
+    from games.sc2.client import _ObsExtractState, extract_flat_obs
+
+    run_config = run_configs.get()
+
+    with run_config.start(want_rgb=False) as controller:
+        replay_data = run_config.replay_data(str(path))
+        info = controller.replay_info(replay_data)
+        winner_id, player_races = _parse_replay_info(info)
+        resolved_pid = _resolve_player_id(player_id, winner_id)
+        player_race = player_races.get(resolved_pid, "random")
+
+        # Apply race filter before starting the replay.
+        if race_filter is not None and player_race != race_filter:
+            return False, player_race, []
+
+        iface_options = sc2_api.InterfaceOptions(
+            feature_layer=sc2_api.SpatialCameraSetup(
+                width=24,
+                resolution=sc2_api.Size2DI(x=screen_size, y=screen_size),
+                minimap_resolution=sc2_api.Size2DI(x=minimap_size, y=minimap_size),
+            ),
+        )
+        controller.start_replay(
+            sc2_api.RequestStartReplay(
+                replay_data=replay_data,
+                options=iface_options,
+                observed_player_id=resolved_pid,
+                disable_fog=True,
+            )
+        )
+
+        game_info = controller.game_info()
+        feat = sc2_features.features_from_game_info(
+            game_info=game_info,
+            feature_dimensions=sc2_features.Dimensions(
+                screen=screen_size, minimap=minimap_size
+            ),
+            use_feature_units=True,
+        )
+
+        state = _ObsExtractState()
+        skipped_unknown = 0
+        pairs: list[tuple[np.ndarray, np.ndarray]] = []
+
+        while True:
+            obs_proto = controller.observe()
+            if obs_proto.player_result:
+                break
+
+            obs_dict = feat.transform_obs(obs_proto.observation)
+            timestep = _TimestepAdapter(obs_dict)
+            obs_vec, _feats = extract_flat_obs(timestep, obs_spec.names, state=state)
+
+            raw_actions = list(obs_proto.actions)
+            if not raw_actions:
+                controller.step(step_mul)
+                continue
+
+            function_calls = [feat.reverse_action(a) for a in raw_actions]
+            chosen_fc = _pick_best_action(function_calls, multi_action_strategy)
+            if chosen_fc is None:
+                controller.step(step_mul)
+                continue
+
+            action_vec = function_call_to_action(
+                chosen_fc, screen_size=screen_size, minimap_size=minimap_size
+            )
+            if action_vec is None:
+                skipped_unknown += 1
+                logger.debug(
+                    "Skipping step in %s: unknown PySC2 fn_id %d",
+                    path.name,
+                    int(chosen_fc.function),
+                )
+                controller.step(step_mul)
+                continue
+
+            state.last_fn_idx = int(action_vec[0])
+            pairs.append((obs_vec, action_vec))
+            controller.step(step_mul)
+
+        if skipped_unknown:
+            logger.info(
+                "%s: skipped %d step(s) with unknown fn_idx",
+                path.name,
+                skipped_unknown,
+            )
+
+    return True, player_race, pairs
+
+
+def build_dataset(
+    folder: str | pathlib.Path,
+    save_path: str | pathlib.Path,
+    *,
+    obs_spec: ObsSpec,
+    player_id: int | str = _WINNER_SENTINEL,
+    race: str | None = None,
+    step_mul: int = 1,
+    screen_size: int = 64,
+    minimap_size: int = 64,
+    multi_action_strategy: str = "first_non_noop",
+) -> dict:
+    """Read replays in *folder*, optionally filter by race, and write ``demos.npz``.
+
+    Parameters
+    ----------
+    folder:
+        Directory containing ``.SC2Replay`` files.
+    save_path:
+        Output path for the compressed dataset (``demos.npz``).
+    obs_spec:
+        Active observation spec.  Determines the obs vector dimension.
+    player_id:
+        ``"winner"`` (default) or an explicit integer ``1`` / ``2``.
+    race:
+        When given (e.g. ``"terran"``), whole replays whose observed player
+        is not that race are dropped.  ``None`` / ``"any"`` keeps all replays.
+    step_mul, screen_size, minimap_size, multi_action_strategy:
+        Forwarded to the per-replay collector.
+
+    Returns
+    -------
+    dict
+        Metadata dict; the same dict is embedded in the ``.npz`` as a JSON
+        string under the ``meta`` key.
+
+    Raises
+    ------
+    ValueError
+        If no ``.SC2Replay`` files are found, or if the race filter removes
+        every replay.
+    """
+    replay_paths = iter_replays(folder)
+    if not replay_paths:
+        raise ValueError(f"No .SC2Replay files found in {folder!r}")
+
+    race_filter: str | None = None
+    if race and race.lower() not in ("", "any"):
+        race_filter = race.lower()
+
+    all_obs: list[np.ndarray] = []
+    all_actions: list[np.ndarray] = []
+    episode_starts: list[int] = []
+    episode_lengths: list[int] = []
+    episode_id_chunks: list[np.ndarray] = []
+    source_names: list[str] = []
+    kept = 0
+    skipped_race = 0
+
+    for replay_path in replay_paths:
+        try:
+            race_ok, player_race, pairs = _read_one_replay(
+                replay_path,
+                player_id=player_id,
+                race_filter=race_filter,
+                obs_spec=obs_spec,
+                step_mul=step_mul,
+                screen_size=screen_size,
+                minimap_size=minimap_size,
+                multi_action_strategy=multi_action_strategy,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Failed to process %s: %s", replay_path.name, exc)
+            continue
+
+        if not race_ok:
+            skipped_race += 1
+            logger.debug(
+                "Race filter '%s' dropped %s (player race: %s)",
+                race_filter,
+                replay_path.name,
+                player_race,
+            )
+            continue
+
+        if not pairs:
+            logger.debug("Replay %s yielded no steps; skipping.", replay_path.name)
+            continue
+
+        start_idx = len(all_obs)
+        ep_len = len(pairs)
+        episode_starts.append(start_idx)
+        episode_lengths.append(ep_len)
+        all_obs.extend(obs for obs, _ in pairs)
+        all_actions.extend(act for _, act in pairs)
+        episode_id_chunks.append(np.full(ep_len, kept, dtype=np.int64))
+        source_names.append(replay_path.name)
+        kept += 1
+        logger.info("Loaded %s (%d steps)", replay_path.name, ep_len)
+
+    if kept == 0:
+        if skipped_race > 0:
+            raise ValueError(
+                f"Race filter '{race}' removed all {skipped_race} replay(s) in {folder!r}."
+            )
+        raise ValueError(f"No usable replays found in {folder!r}.")
+
+    obs_arr = np.stack(all_obs, axis=0).astype(np.float32)
+    act_arr = np.stack(all_actions, axis=0).astype(np.float32)
+    ep_starts_arr = np.array(episode_starts, dtype=np.int64)
+    ep_lengths_arr = np.array(episode_lengths, dtype=np.int64)
+    ep_id_arr = np.concatenate(episode_id_chunks).astype(np.int64)
+
+    meta: dict = {
+        "player_id": str(player_id),
+        "race_filter": race_filter,
+        "step_mul": step_mul,
+        "screen_size": screen_size,
+        "minimap_size": minimap_size,
+        "source_filenames": source_names,
+        "n_episodes": kept,
+        "n_steps": int(obs_arr.shape[0]),
+        "obs_dim": int(obs_arr.shape[1]),
+    }
+
+    logger.info(
+        "Kept %d replay(s) (%d steps total; %d skipped by race filter).",
+        kept,
+        int(obs_arr.shape[0]),
+        skipped_race,
+    )
+
+    save_path = pathlib.Path(save_path)
+    save_path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        str(save_path),
+        obs=obs_arr,
+        actions=act_arr,
+        episode_starts=ep_starts_arr,
+        episode_lengths=ep_lengths_arr,
+        episode_id=ep_id_arr,
+        meta=np.array(json.dumps(meta)),
+    )
+    logger.info("Saved dataset to %s", save_path)
+    return meta
+
+
+# ---------------------------------------------------------------------------
+# Dataset loader
+# ---------------------------------------------------------------------------
+
+
+def load_dataset(
+    path: str | pathlib.Path,
+    *,
+    as_episodes: bool = False,
+) -> dict | list[tuple[np.ndarray, np.ndarray]]:
+    """Load a ``demos.npz`` dataset saved by :func:`build_dataset`.
+
+    Parameters
+    ----------
+    path:
+        Path to the ``.npz`` file.
+    as_episodes:
+        ``False`` (default) — return a dict with keys ``obs``, ``actions``,
+        ``episode_starts``, ``episode_lengths``, ``episode_id``, and ``meta``
+        (parsed JSON).  Suitable for memoryless policies that sample
+        individual (obs, action) pairs.
+
+        ``True`` — return a list of ``(obs_seq, act_seq)`` tuples, one per
+        episode, preserving temporal order within each episode.  Suitable for
+        recurrent policies that consume whole ordered sequences with
+        hidden-state carry-over.
+
+    Returns
+    -------
+    dict or list of (obs_seq, act_seq)
+    """
+    data = np.load(str(path), allow_pickle=False)
+    obs = data["obs"]
+    actions = data["actions"]
+    episode_starts = data["episode_starts"]
+    episode_lengths = data["episode_lengths"]
+    episode_id = data["episode_id"]
+    meta = json.loads(str(data["meta"]))
+
+    if not as_episodes:
+        return {
+            "obs": obs,
+            "actions": actions,
+            "episode_starts": episode_starts,
+            "episode_lengths": episode_lengths,
+            "episode_id": episode_id,
+            "meta": meta,
+        }
+
+    episodes: list[tuple[np.ndarray, np.ndarray]] = []
+    for start, length in zip(episode_starts.tolist(), episode_lengths.tolist()):
+        ep_obs = obs[start : start + length]
+        ep_act = actions[start : start + length]
+        episodes.append((ep_obs, ep_act))
+    return episodes

--- a/games/sc2/replay_bc.py
+++ b/games/sc2/replay_bc.py
@@ -99,10 +99,13 @@ def _parse_replay_info(info: Any) -> tuple[int, dict[int, str]]:
 
 
 def _resolve_player_id(player_id: int | str, winner_id: int) -> int:
-    """Convert *player_id* (``"winner"`` or 1/2) to a concrete integer."""
+    """Convert *player_id* (``"winner"`` or a positive integer) to a concrete integer."""
     if player_id == _WINNER_SENTINEL:
         return winner_id if winner_id != 0 else 1
-    return int(player_id)
+    pid = int(player_id)
+    if pid < 1:
+        raise ValueError(f"player_id must be a positive integer, got {player_id!r}")
+    return pid
 
 
 def _pick_best_action(function_calls: list[Any], strategy: str) -> Any | None:
@@ -236,12 +239,14 @@ def replay_observations(
             # Extract actions issued during this step.
             raw_actions = list(obs_proto.actions)
             if not raw_actions:
+                state.last_fn_idx = 0  # idle frame → no_op for next obs
                 controller.step(step_mul)
                 continue
 
             function_calls = [feat.reverse_action(a) for a in raw_actions]
             chosen_fc = _pick_best_action(function_calls, multi_action_strategy)
             if chosen_fc is None:
+                state.last_fn_idx = 0
                 controller.step(step_mul)
                 continue
 
@@ -250,6 +255,7 @@ def replay_observations(
             )
             if action_vec is None:
                 skipped_unknown += 1
+                state.last_fn_idx = 0
                 logger.debug(
                     "Skipping step in %s: unknown PySC2 fn_id %d",
                     path.name,
@@ -356,12 +362,14 @@ def _read_one_replay(
 
             raw_actions = list(obs_proto.actions)
             if not raw_actions:
+                state.last_fn_idx = 0  # idle frame → no_op for next obs
                 controller.step(step_mul)
                 continue
 
             function_calls = [feat.reverse_action(a) for a in raw_actions]
             chosen_fc = _pick_best_action(function_calls, multi_action_strategy)
             if chosen_fc is None:
+                state.last_fn_idx = 0
                 controller.step(step_mul)
                 continue
 
@@ -370,6 +378,7 @@ def _read_one_replay(
             )
             if action_vec is None:
                 skipped_unknown += 1
+                state.last_fn_idx = 0
                 logger.debug(
                     "Skipping step in %s: unknown PySC2 fn_id %d",
                     path.name,

--- a/tests/README.md
+++ b/tests/README.md
@@ -71,6 +71,7 @@
   - [test\_sc2\_play.py — `play_sc2.py` script](#test_sc2_playpy--play_sc2py-script)
   - [test\_sc2\_simple64\_training.py — Simple64 ladder integration](#test_sc2_simple64_trainingpy--simple64-ladder-integration)
   - [test\_sc2\_analytics.py — SC2-specific analytics plots and flags](#test_sc2_analyticspy--sc2-specific-analytics-plots-and-flags)
+  - [test\_sc2\_replay\_bc.py — SC2 replay reader → BC demonstration dataset (issue #351)](#test_sc2_replay_bcpy--sc2-replay-reader--bc-demonstration-dataset-issue-351)
 - [Rocket League](#rocket-league)
   - [test\_rocket\_league\_obs\_spec.py — Rocket League observation spec (142-dim)](#test_rocket_league_obs_specpy--rocket-league-observation-spec-142-dim)
   - [test\_rocket\_league\_reward.py — Rocket League reward calc](#test_rocket_league_rewardpy--rocket-league-reward-calc)
@@ -584,11 +585,17 @@ round-trips for cmaes and neural_dqn; and the SC2-specific analytics module
 feature averages, spatial heatmap, outcome breakdown, and the full
 `save_experiment_results` integration including that no racing plots appear).
 
+The offline replay-reader module (`games/sc2/replay_bc.py`, issue #351) is covered
+in `test_sc2_replay_bc.py`: the full PySC2 replay API (run_config, controller,
+features) is replaced by lightweight fakes injected into `sys.modules` before
+import, so the suite runs with no SC2 binary or PySC2 package installed.
+
 **Not tested.** PySC2 against the actual Blizzard SC2 binary; real
 1v1 games against the built-in bot; minimap rendering; the deferred
 fog-of-war belief machinery beyond the standalone `test_belief.py`
 encoder; long-horizon RL convergence on Simple64 (loops are run for a
-handful of iterations only).
+handful of iterations only); reading real `.SC2Replay` files end-to-end
+(covered by integration tests in `tests/integration/test_sc2.py`).
 
 ### test_sc2_obs_spec.py — SC2 obs spec
 - minigame dim (15); ladder dim (46); rich dim (103 = exact breakdown); ladder extends minigame; default = minigame; get_spec for minigame / ladder; minigame count; obs_names match dims
@@ -781,6 +788,32 @@ handful of iterations only).
 - `save_experiment_results` now also writes `reward_component_breakdown.png` (regression-guarded in `test_writes_sc2_plots`)
 - `save_grid_summary`: forwards config-normalized rewards **and per-component contributions** using `v / max(abs(weight), 1.0)` — weights ≥ 1.0 are divided (making large-weight components comparable across grid-search runs), weights < 1.0 use the raw value (which already encodes the weight, so dividing would amplify by ×1000); wires SC2 extra-plot hook into framework summary generation; covers no-components fallback, multi-sim normalization, malformed YAML fallback, non-mapping YAML fallback, non-numeric weight fallback, allow-listed `scout` component (no unmapped-key warning), step_penalty with sub-1.0 weight passes through raw (-0.5 not -500), idle_penalty with sub-1.0 weight passes through raw, any sub-1.0 weight (0.0001 or 0.001) both use scale=1.0, the new `unit_loss` / `damage_taken` / `passive_under_fire` components normalize through their config weights without unmapped-key warnings, realistic positive reward stays positive after normalization (313.5 ✓), and emits SC2 cross-run charts + summary links; passes `task_metric_fn`, `task_metric_fmt` (percentage formatter) to framework; `attack_bonus` mapped to `attack_bonus` config key in normalisation
 - `_sc2_task_metric`: empty sims → 0.0; win+finish counted as success; loss/timeout/None/other not counted; all-wins → 1.0; `_GS_SUCCESS_REASONS` constant contains win+finish, excludes loss+timeout
+
+### test_sc2_replay_bc.py — SC2 replay reader → BC demonstration dataset (issue #351)
+- `TestIterReplays`: finds only `.SC2Replay` files; sorted order; empty folder returns `[]`
+- `TestParseReplayInfo`: winner + races parsed correctly; winner is player 2; undecided returns `(0, {})`;
+  race integer mapping (1=terran, 2=zerg, 3=protoss, 4=random); unknown race falls back to `"random"`
+- `TestResolvePlayerId`: `"winner"` resolves to winner pid; fallback to 1 when winner=0; explicit int id;
+  explicit int id with zero winner
+- `TestPickBestAction`: empty returns None; `"first"` returns first even if no_op; `"first_non_noop"` skips
+  no_op; fallback to first when all no_op; single action returned regardless of strategy
+- `TestReplayObservations`: obs shape matches spec (float32, `[D]`); action shape+dtype `([4], float32)`;
+  fn_idx preserved in action vector; temporal order preserved via monotonically increasing x-coord;
+  steps with no actions skipped; `[no_op, Move_screen]` → `Move_screen` selected; unknown PySC2 fn_id
+  skipped; `winner_id=0` falls back to player 1; explicit `player_id=2` overrides winner; `controller.step()`
+  called once per step including no-action steps; unknown fn_id still calls `step()`
+- `TestReadOneReplay`: race match returns `(True, player_race, pairs)`; race mismatch returns `(False, ..., [])`;
+  no race filter processes all; race filter drops replay → `start_replay` not called; `player_race` always
+  returned even when filter drops replay
+- `TestBuildDataset` (mocks `_read_one_replay`): single replay writes correct NPZ with `n_episodes=1`;
+  `obs`/`actions` shapes correct; episode boundaries for two replays (`episode_starts`, `episode_lengths`,
+  `episode_id`); temporal order preserved within episode; meta JSON round-trip (`player_id`, `step_mul`,
+  `screen_size`, `source_filenames`); all replays dropped by race filter raises `ValueError` with race name
+  in message; no replay files raises `ValueError`; `race="any"` keeps all; `source_filenames` recorded
+  in meta; `episode_id` covers all rows
+- `TestLoadDataset`: flat load returns all expected keys; correct shapes; `as_episodes=True` yields correct
+  per-episode shapes; episode `episode_starts` partitions correctly; temporal order preserved per episode;
+  `meta` parsed as dict in `as_episodes` mode; round-trip save+load preserves obs+action values
 
 ## Rocket League
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -595,7 +595,7 @@ import, so the suite runs with no SC2 binary or PySC2 package installed.
 fog-of-war belief machinery beyond the standalone `test_belief.py`
 encoder; long-horizon RL convergence on Simple64 (loops are run for a
 handful of iterations only); reading real `.SC2Replay` files end-to-end
-(covered by integration tests in `tests/integration/test_sc2.py`).
+(no integration test exists yet for `replay_bc`).
 
 ### test_sc2_obs_spec.py — SC2 obs spec
 - minigame dim (15); ladder dim (46); rich dim (103 = exact breakdown); ladder extends minigame; default = minigame; get_spec for minigame / ladder; minigame count; obs_names match dims

--- a/tests/test_sc2_replay_bc.py
+++ b/tests/test_sc2_replay_bc.py
@@ -1,0 +1,931 @@
+"""Tests for games.sc2.replay_bc — replay BC dataset builder (issue #351).
+
+The SC2 binary and PySC2 are never imported; all controller / features
+interactions are replaced by lightweight fakes injected into sys.modules
+before the module under test is imported, so lazy imports inside
+replay_bc.py see the fakes.  The suite runs in milliseconds with no
+external dependencies.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import numpy as np
+
+# ---------------------------------------------------------------------------
+# Fake PySC2 + s2clientprotocol modules — injected before any import of
+# games.sc2.replay_bc so lazy imports inside that module see the fakes.
+#
+# The module-level run_configs_mod and features_mod references let tests
+# configure return values without needing patch() on module attributes.
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_pysc2():
+    """Build a minimal fake pysc2 hierarchy and inject it into sys.modules.
+
+    Also injects ``pysc2.lib.actions`` with an identity PySC2-id mapping
+    (PySC2 id == internal fn_idx) so ``function_call_to_action`` can resolve
+    ``_FakeFunctionCall(fn_id=N)`` → internal fn_idx N.  This lets test
+    helpers use internal fn_idx values directly as the function call id.
+    """
+    pysc2 = types.ModuleType("pysc2")
+    run_configs_mod = types.ModuleType("pysc2.run_configs")
+    lib_mod = types.ModuleType("pysc2.lib")
+    features_mod = types.ModuleType("pysc2.lib.features")
+    actions_mod = types.ModuleType("pysc2.lib.actions")
+
+    class _Dimensions:
+        def __init__(self, *, screen, minimap):
+            self.screen = screen
+            self.minimap = minimap
+
+    features_mod.Dimensions = _Dimensions
+    features_mod.features_from_game_info = MagicMock(return_value=MagicMock())
+
+    # Build FUNCTIONS with identity mapping so PySC2 id == internal fn_idx.
+    # function_call_to_action does getattr(FUNCTIONS, name) → .id to get the
+    # PySC2 id for the call, and _get_pysc2_id_to_fn_idx builds the reverse
+    # mapping.  Identity keeps both consistent without needing real PySC2.
+    from games.sc2.actions import FUNCTION_IDS
+
+    _functions_ns = types.SimpleNamespace()
+    for fn_idx, fn_name in FUNCTION_IDS.items():
+        setattr(_functions_ns, fn_name, types.SimpleNamespace(id=fn_idx))
+
+    class _FunctionCall:
+        def __init__(self, function, arguments):
+            self.function = function
+            self.arguments = arguments
+
+    actions_mod.FUNCTIONS = _functions_ns
+    actions_mod.FunctionCall = _FunctionCall
+
+    lib_mod.features = features_mod
+    lib_mod.actions = actions_mod
+
+    run_configs_mod.get = MagicMock(return_value=MagicMock())
+
+    pysc2.run_configs = run_configs_mod
+    pysc2.lib = lib_mod
+
+    sys.modules.setdefault("pysc2", pysc2)
+    sys.modules.setdefault("pysc2.run_configs", run_configs_mod)
+    sys.modules.setdefault("pysc2.lib", lib_mod)
+    sys.modules.setdefault("pysc2.lib.features", features_mod)
+    sys.modules.setdefault("pysc2.lib.actions", actions_mod)
+    return pysc2, run_configs_mod, features_mod
+
+
+def _make_fake_s2api():
+    """Build minimal s2clientprotocol proto stubs."""
+    s2_mod = types.ModuleType("s2clientprotocol")
+    api_mod = types.ModuleType("s2clientprotocol.sc2api_pb2")
+
+    class _ProtoStub:
+        """Accept any kwargs and store them as attrs."""
+
+        def __init__(self, **kwargs):
+            for k, v in kwargs.items():
+                setattr(self, k, v)
+
+    api_mod.InterfaceOptions = _ProtoStub
+    api_mod.SpatialCameraSetup = _ProtoStub
+    api_mod.Size2DI = _ProtoStub
+    api_mod.RequestStartReplay = _ProtoStub
+
+    s2_mod.sc2api_pb2 = api_mod
+    sys.modules.setdefault("s2clientprotocol", s2_mod)
+    sys.modules.setdefault("s2clientprotocol.sc2api_pb2", api_mod)
+    return s2_mod, api_mod
+
+
+# Inject fakes before importing the module under test.
+_pysc2_pkg, _run_configs_mod, _features_mod = _make_fake_pysc2()
+_s2_pkg, _sc2_api_mod = _make_fake_s2api()
+
+from games.sc2.replay_bc import (  # noqa: E402
+    _parse_replay_info,
+    _pick_best_action,
+    _read_one_replay,
+    _resolve_player_id,
+    build_dataset,
+    iter_replays,
+    load_dataset,
+    replay_observations,
+)
+from games.sc2.obs_spec import SC2_MINIGAME_OBS_SPEC
+
+_OBS_DIM = len(SC2_MINIGAME_OBS_SPEC.names)
+_OBS_NAMES = SC2_MINIGAME_OBS_SPEC.names
+
+
+# ---------------------------------------------------------------------------
+# Helpers — mock replay infrastructure
+# ---------------------------------------------------------------------------
+
+
+class _FakePlayerInfo:
+    """Simulates a single entry in info.player_info."""
+
+    def __init__(self, player_id: int, race_int: int, result: int):
+        class _PI:
+            pass
+
+        pi = _PI()
+        pi.player_id = player_id
+        pi.race_actual = race_int
+        self.player_info = pi
+
+        class _PR:
+            pass
+
+        pr = _PR()
+        pr.result = result
+        self.player_result = pr
+
+
+def _fake_replay_info(*, winner_pid: int, races: dict[int, int]):
+    """Return a fake replay_info proto with given winner + race map.
+
+    *races* maps player_id → race_int (1=terran, 2=zerg, 3=protoss, 4=random).
+    """
+    info = MagicMock()
+    info.player_info = [
+        _FakePlayerInfo(pid, race_int, 1 if pid == winner_pid else 2)
+        for pid, race_int in races.items()
+    ]
+    return info
+
+
+class _FakeFunctionCall:
+    """Minimal FunctionCall stub: .function (int, the PySC2 fn_id) and .arguments."""
+
+    def __init__(self, fn_id: int, arguments: list | None = None):
+        self.function = fn_id
+        self.arguments = arguments or []
+
+
+def _build_mock_controller(
+    replay_info: object,
+    observe_sequence: list[dict],
+    actions_per_step: list[list[_FakeFunctionCall]],
+) -> MagicMock:
+    """Build a mock controller for a single replay.
+
+    *observe_sequence* is a list of obs dicts (one per step).  After all
+    steps a terminal ``player_result`` response is appended automatically.
+    *actions_per_step* is a parallel list of per-step action lists.
+    """
+    assert len(observe_sequence) == len(actions_per_step)
+
+    class _FakeObsProto:
+        def __init__(self, obs_dict, raw_actions, done=False):
+            self.observation = obs_dict
+            self.actions = raw_actions
+            self.player_result = [object()] if done else []
+
+    responses = [
+        _FakeObsProto(obs, acts)
+        for obs, acts in zip(observe_sequence, actions_per_step)
+    ]
+    responses.append(_FakeObsProto({}, [], done=True))
+    observe_iter = iter(responses)
+
+    ctrl = MagicMock()
+    ctrl.replay_info.return_value = replay_info
+    ctrl.observe.side_effect = lambda: next(observe_iter)
+    ctrl.step.return_value = None
+    ctrl.start_replay.return_value = None
+    ctrl.game_info.return_value = MagicMock()
+    return ctrl
+
+
+def _build_mock_features() -> MagicMock:
+    """Build a mock Features object.
+
+    ``transform_obs`` returns its argument unchanged (the obs dict is already
+    in the right format for ``extract_flat_obs``).
+    ``reverse_action`` returns its argument unchanged (FakeFunctionCall
+    already has the right interface).
+    """
+    feat = MagicMock()
+    feat.transform_obs.side_effect = lambda obs_dict: obs_dict
+    feat.reverse_action.side_effect = lambda a: a
+    return feat
+
+
+def _patch_run_config(controller: MagicMock) -> MagicMock:
+    """Return a mock run_config whose ``start()`` yields *controller*."""
+
+    @contextmanager
+    def _start(**_kwargs):
+        yield controller
+
+    rc = MagicMock()
+    rc.start.side_effect = _start
+    rc.replay_data.return_value = b"fake_replay_bytes"
+    return rc
+
+
+def _configure_fakes(rc: MagicMock, feat: MagicMock) -> None:
+    """Point the globally-injected pysc2 fakes at *rc* and *feat*.
+
+    Since replay_bc.py uses lazy imports (``from pysc2 import run_configs``
+    inside functions), patching module-level attributes is not possible.
+    Instead we configure the already-injected fakes in sys.modules directly.
+    """
+    _run_configs_mod.get.return_value = rc
+    _features_mod.features_from_game_info.return_value = feat
+
+
+def _reset_fakes() -> None:
+    """Reset the injected fakes to avoid test cross-contamination."""
+    _run_configs_mod.get.reset_mock(return_value=True, side_effect=True)
+    _features_mod.features_from_game_info.reset_mock(return_value=True, side_effect=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests: iter_replays
+# ---------------------------------------------------------------------------
+
+
+class TestIterReplays(unittest.TestCase):
+    def test_finds_sc2replay_files(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "game1.SC2Replay").touch()
+            (d / "game2.SC2Replay").touch()
+            (d / "not_a_replay.txt").touch()
+            result = iter_replays(d)
+            self.assertEqual([p.name for p in result], ["game1.SC2Replay", "game2.SC2Replay"])
+
+    def test_sorted_order(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "b.SC2Replay").touch()
+            (d / "a.SC2Replay").touch()
+            result = iter_replays(d)
+            self.assertEqual(result[0].name, "a.SC2Replay")
+
+    def test_empty_folder(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            self.assertEqual(iter_replays(d), [])
+
+
+# ---------------------------------------------------------------------------
+# Tests: _parse_replay_info
+# ---------------------------------------------------------------------------
+
+
+class TestParseReplayInfo(unittest.TestCase):
+    def test_winner_and_races(self):
+        info = _fake_replay_info(winner_pid=1, races={1: 1, 2: 3})
+        winner_id, player_races = _parse_replay_info(info)
+        self.assertEqual(winner_id, 1)
+        self.assertEqual(player_races, {1: "terran", 2: "protoss"})
+
+    def test_winner_is_player2(self):
+        info = _fake_replay_info(winner_pid=2, races={1: 2, 2: 1})
+        winner_id, _ = _parse_replay_info(info)
+        self.assertEqual(winner_id, 2)
+
+    def test_undecided_game(self):
+        info = MagicMock()
+        info.player_info = []
+        winner_id, player_races = _parse_replay_info(info)
+        self.assertEqual(winner_id, 0)
+        self.assertEqual(player_races, {})
+
+    def test_race_int_mapping(self):
+        info = _fake_replay_info(winner_pid=1, races={1: 2, 2: 4})
+        _, player_races = _parse_replay_info(info)
+        self.assertEqual(player_races[1], "zerg")
+        self.assertEqual(player_races[2], "random")
+
+    def test_unknown_race_falls_back_to_random(self):
+        info = _fake_replay_info(winner_pid=1, races={1: 99})
+        _, player_races = _parse_replay_info(info)
+        self.assertEqual(player_races[1], "random")
+
+
+# ---------------------------------------------------------------------------
+# Tests: _resolve_player_id
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePlayerId(unittest.TestCase):
+    def test_winner_with_known_winner(self):
+        self.assertEqual(_resolve_player_id("winner", winner_id=2), 2)
+
+    def test_winner_falls_back_to_1_when_no_winner(self):
+        self.assertEqual(_resolve_player_id("winner", winner_id=0), 1)
+
+    def test_explicit_player_id(self):
+        self.assertEqual(_resolve_player_id(2, winner_id=1), 2)
+
+    def test_explicit_player_id_string_cast(self):
+        self.assertEqual(_resolve_player_id(1, winner_id=0), 1)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _pick_best_action
+# ---------------------------------------------------------------------------
+
+
+class TestPickBestAction(unittest.TestCase):
+    def test_empty_returns_none(self):
+        self.assertIsNone(_pick_best_action([], "first_non_noop"))
+
+    def test_first_strategy_returns_first_even_if_noop(self):
+        calls = [_FakeFunctionCall(0), _FakeFunctionCall(2)]
+        result = _pick_best_action(calls, "first")
+        self.assertEqual(result.function, 0)
+
+    def test_first_non_noop_skips_noop(self):
+        calls = [_FakeFunctionCall(0), _FakeFunctionCall(2), _FakeFunctionCall(3)]
+        result = _pick_best_action(calls, "first_non_noop")
+        self.assertEqual(result.function, 2)
+
+    def test_first_non_noop_falls_back_to_first_when_all_noop(self):
+        calls = [_FakeFunctionCall(0), _FakeFunctionCall(0)]
+        result = _pick_best_action(calls, "first_non_noop")
+        self.assertEqual(result.function, 0)
+
+    def test_single_action_returned_regardless_of_strategy(self):
+        calls = [_FakeFunctionCall(5)]
+        self.assertEqual(_pick_best_action(calls, "first_non_noop").function, 5)
+        self.assertEqual(_pick_best_action(calls, "first").function, 5)
+
+
+# ---------------------------------------------------------------------------
+# Tests: replay_observations
+# ---------------------------------------------------------------------------
+
+
+class TestReplayObservations(unittest.TestCase):
+    """Public generator — controller fully mocked via sys.modules fakes."""
+
+    def setUp(self):
+        _reset_fakes()
+
+    def tearDown(self):
+        _reset_fakes()
+
+    def _run(self, obs_dicts, actions_per_step, *, winner_pid=1, races=None, player_id="winner", screen_size=64):
+        if races is None:
+            races = {1: 1, 2: 3}
+        spec = SC2_MINIGAME_OBS_SPEC
+        info = _fake_replay_info(winner_pid=winner_pid, races=races)
+        ctrl = _build_mock_controller(info, obs_dicts, actions_per_step)
+        rc = _patch_run_config(ctrl)
+        feat = _build_mock_features()
+        _configure_fakes(rc, feat)
+        pairs = list(
+            replay_observations(
+                "fake.SC2Replay",
+                player_id=player_id,
+                obs_spec=spec,
+                screen_size=screen_size,
+            )
+        )
+        return pairs, ctrl
+
+    def test_obs_shape_matches_spec(self):
+        obs_dicts = [{} for _ in range(3)]
+        actions = [[_FakeFunctionCall(2, [[0], [10, 10]])] for _ in range(3)]
+        pairs, _ = self._run(obs_dicts, actions)
+        self.assertEqual(len(pairs), 3)
+        for obs_vec, act_vec in pairs:
+            self.assertEqual(obs_vec.shape, (_OBS_DIM,))
+            self.assertEqual(obs_vec.dtype, np.float32)
+
+    def test_action_shape_and_dtype(self):
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(2, [[0], [32, 32]])]]
+        pairs, _ = self._run(obs_dicts, actions)
+        self.assertEqual(len(pairs), 1)
+        _, act_vec = pairs[0]
+        self.assertEqual(act_vec.shape, (4,))
+        self.assertEqual(act_vec.dtype, np.float32)
+
+    def test_action_fn_idx_preserved(self):
+        """The fn_idx in the action vector must match the issued action."""
+        # select_army (internal fn_idx=1) → PySC2 id for select_army
+        from games.sc2.actions import FUNCTION_IDS
+        pysc2_id_for_select_army = next(
+            i for i, name in FUNCTION_IDS.items() if name == "select_army"
+        )
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(pysc2_id_for_select_army)]]
+        pairs, _ = self._run(obs_dicts, actions)
+        self.assertEqual(len(pairs), 1)
+        _, act_vec = pairs[0]
+        self.assertEqual(int(act_vec[0]), 1)  # internal fn_idx for select_army
+
+    def test_temporal_order_preserved_via_action_x_coords(self):
+        """Action vectors must appear in the same order as steps (checked via x-coord)."""
+        screen_size = 64
+        obs_dicts = [{} for _ in range(5)]
+        # Each step issues Move_screen with a strictly increasing x pixel coordinate.
+        # PySC2 fn_id for Move_screen is 2 in FUNCTION_IDS (internal fn_idx 2).
+        actions = [
+            [_FakeFunctionCall(2, [[0], [i * 10, 5]])]
+            for i in range(5)
+        ]
+        pairs, _ = self._run(obs_dicts, actions, screen_size=screen_size)
+        self.assertEqual(len(pairs), 5)
+        # x_norm = pixel_x / (screen_size - 1); must be monotonically increasing.
+        x_coords = [float(act_vec[1]) for _, act_vec in pairs]
+        for a, b in zip(x_coords, x_coords[1:]):
+            self.assertLess(a, b)
+
+    def test_step_with_no_actions_skipped(self):
+        obs_dicts = [{}, {}]
+        actions = [[], [_FakeFunctionCall(2, [[0], [32, 32]])]]
+        pairs, _ = self._run(obs_dicts, actions)
+        self.assertEqual(len(pairs), 1)
+
+    def test_multiple_actions_first_non_noop_selected(self):
+        """[no_op, Move_screen] → Move_screen (fn_idx 2) selected."""
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(0), _FakeFunctionCall(2, [[0], [10, 10]])]]
+        pairs, _ = self._run(obs_dicts, actions)
+        self.assertEqual(len(pairs), 1)
+        _, act_vec = pairs[0]
+        self.assertEqual(int(act_vec[0]), 2)
+
+    def test_unknown_fn_id_step_skipped(self):
+        """Unknown PySC2 fn_id (not in FUNCTION_IDS) must be skipped."""
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(9999)]]
+        pairs, _ = self._run(obs_dicts, actions)
+        self.assertEqual(len(pairs), 0)
+
+    def test_winner_resolution_fallback_to_player1(self):
+        """winner_id=0 (undecided) must fall back to player 1."""
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(1)]]
+        pairs, _ = self._run(obs_dicts, actions, winner_pid=0)
+        self.assertEqual(len(pairs), 1)
+
+    def test_explicit_player_id_overrides_winner(self):
+        """player_id=2 uses player 2 regardless of who won."""
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(1)]]
+        pairs, _ = self._run(obs_dicts, actions, winner_pid=1, player_id=2)
+        self.assertEqual(len(pairs), 1)
+
+    def test_controller_step_called_for_each_step(self):
+        """controller.step() must be called once per step (including no-action steps)."""
+        obs_dicts = [{} for _ in range(4)]
+        actions = [
+            [],
+            [_FakeFunctionCall(2, [[0], [10, 10]])],
+            [],
+            [_FakeFunctionCall(2, [[0], [20, 20]])],
+        ]
+        _, ctrl = self._run(obs_dicts, actions)
+        self.assertEqual(ctrl.step.call_count, 4)
+
+    def test_unknown_fn_id_still_calls_step(self):
+        """Unknown fn_id steps are skipped but controller.step() is still called."""
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(9999)]]
+        _, ctrl = self._run(obs_dicts, actions)
+        self.assertEqual(ctrl.step.call_count, 1)
+
+
+# ---------------------------------------------------------------------------
+# Tests: _read_one_replay — single-launch race filtering
+# ---------------------------------------------------------------------------
+
+
+class TestReadOneReplay(unittest.TestCase):
+    """Single-launch helper: race check + playback in one SC2 process."""
+
+    def setUp(self):
+        _reset_fakes()
+
+    def tearDown(self):
+        _reset_fakes()
+
+    def _run(self, obs_dicts, actions_per_step, *, race_filter, winner_pid=1, races=None):
+        if races is None:
+            races = {1: 1, 2: 3}  # player1=terran, player2=protoss
+        spec = SC2_MINIGAME_OBS_SPEC
+        info = _fake_replay_info(winner_pid=winner_pid, races=races)
+        ctrl = _build_mock_controller(info, obs_dicts, actions_per_step)
+        rc = _patch_run_config(ctrl)
+        feat = _build_mock_features()
+        _configure_fakes(rc, feat)
+        return (
+            _read_one_replay(
+                Path("fake.SC2Replay"),
+                player_id="winner",
+                race_filter=race_filter,
+                obs_spec=spec,
+                step_mul=1,
+                screen_size=64,
+                minimap_size=64,
+                multi_action_strategy="first_non_noop",
+            ),
+            ctrl,
+        )
+
+    def test_race_match_returns_true_and_pairs(self):
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(2, [[0], [10, 10]])]]
+        (race_ok, player_race, pairs), _ = self._run(obs_dicts, actions, race_filter="terran")
+        self.assertTrue(race_ok)
+        self.assertEqual(player_race, "terran")
+        self.assertEqual(len(pairs), 1)
+
+    def test_race_mismatch_returns_false_no_pairs(self):
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(2, [[0], [10, 10]])]]
+        (race_ok, player_race, pairs), _ = self._run(obs_dicts, actions, race_filter="zerg")
+        self.assertFalse(race_ok)
+        self.assertEqual(player_race, "terran")
+        self.assertEqual(pairs, [])
+
+    def test_no_race_filter_processes_all(self):
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(2, [[0], [10, 10]])]]
+        (race_ok, _, pairs), _ = self._run(obs_dicts, actions, race_filter=None)
+        self.assertTrue(race_ok)
+        self.assertEqual(len(pairs), 1)
+
+    def test_race_filter_skips_start_replay(self):
+        """start_replay must NOT be called when the race filter drops the replay."""
+        spec = SC2_MINIGAME_OBS_SPEC
+        # player1=protoss, race_filter="terran" → should skip
+        info = _fake_replay_info(winner_pid=1, races={1: 3, 2: 1})
+        ctrl = _build_mock_controller(info, [], [])
+        rc = _patch_run_config(ctrl)
+        feat = _build_mock_features()
+        _configure_fakes(rc, feat)
+        _read_one_replay(
+            Path("fake.SC2Replay"),
+            player_id="winner",
+            race_filter="terran",
+            obs_spec=spec,
+            step_mul=1,
+            screen_size=64,
+            minimap_size=64,
+            multi_action_strategy="first_non_noop",
+        )
+        ctrl.start_replay.assert_not_called()
+
+    def test_player_race_always_returned(self):
+        """player_race is populated even when the race filter drops the replay."""
+        obs_dicts = [{}]
+        actions = [[_FakeFunctionCall(2, [[0], [10, 10]])]]
+        (race_ok, player_race, _), _ = self._run(
+            obs_dicts, actions, race_filter="zerg", races={1: 1, 2: 3}
+        )
+        self.assertFalse(race_ok)
+        self.assertEqual(player_race, "terran")
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_dataset
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDataset(unittest.TestCase):
+    """Full dataset builder — filesystem + _read_one_replay mocked."""
+
+    def _setup_folder(self, tmp_path: Path, names: list[str]) -> Path:
+        folder = tmp_path / "replays"
+        folder.mkdir(parents=True, exist_ok=True)
+        for name in names:
+            (folder / name).touch()
+        return folder
+
+    def _mock_read_one(self, return_values: list):
+        """Patch _read_one_replay at module level to return successive values."""
+        from unittest.mock import patch
+
+        side_effects = iter(return_values)
+        return patch(
+            "games.sc2.replay_bc._read_one_replay",
+            side_effect=lambda *a, **kw: next(side_effects),
+        )
+
+    def test_single_replay_correct_npz(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            folder = self._setup_folder(tmp, ["g.SC2Replay"])
+            save_path = tmp / "demos.npz"
+            spec = SC2_MINIGAME_OBS_SPEC
+            obs0 = np.zeros(_OBS_DIM, dtype=np.float32)
+            act0 = np.array([2.0, 0.5, 0.5, 0.0], dtype=np.float32)
+            pairs = [(obs0, act0), (obs0, act0)]
+            with self._mock_read_one([(True, "terran", pairs)]):
+                meta = build_dataset(folder, save_path, obs_spec=spec)
+            self.assertTrue(save_path.exists())
+            self.assertEqual(meta["n_episodes"], 1)
+            self.assertEqual(meta["n_steps"], 2)
+            self.assertEqual(meta["obs_dim"], _OBS_DIM)
+
+    def test_obs_actions_shape(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            folder = self._setup_folder(tmp, ["g.SC2Replay"])
+            save_path = tmp / "demos.npz"
+            spec = SC2_MINIGAME_OBS_SPEC
+            pairs = [
+                (np.zeros(_OBS_DIM, dtype=np.float32), np.zeros(4, dtype=np.float32))
+                for _ in range(5)
+            ]
+            with self._mock_read_one([(True, "terran", pairs)]):
+                build_dataset(folder, save_path, obs_spec=spec)
+            data = np.load(str(save_path), allow_pickle=False)
+            self.assertEqual(data["obs"].shape, (5, _OBS_DIM))
+            self.assertEqual(data["actions"].shape, (5, 4))
+
+    def test_episode_boundaries_two_replays(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            folder = self._setup_folder(tmp, ["a.SC2Replay", "b.SC2Replay"])
+            save_path = tmp / "demos.npz"
+            spec = SC2_MINIGAME_OBS_SPEC
+            pairs_a = [(np.zeros(_OBS_DIM, dtype=np.float32), np.zeros(4, dtype=np.float32))] * 3
+            pairs_b = [(np.zeros(_OBS_DIM, dtype=np.float32), np.zeros(4, dtype=np.float32))] * 2
+            with self._mock_read_one([(True, "terran", pairs_a), (True, "terran", pairs_b)]):
+                build_dataset(folder, save_path, obs_spec=spec)
+            data = np.load(str(save_path), allow_pickle=False)
+            np.testing.assert_array_equal(data["episode_starts"], [0, 3])
+            np.testing.assert_array_equal(data["episode_lengths"], [3, 2])
+            np.testing.assert_array_equal(data["episode_id"], [0, 0, 0, 1, 1])
+
+    def test_rows_stored_in_temporal_order(self):
+        """obs values within an episode must preserve temporal order."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            folder = self._setup_folder(tmp, ["g.SC2Replay"])
+            save_path = tmp / "demos.npz"
+            spec = SC2_MINIGAME_OBS_SPEC
+            pairs = [
+                (np.full(_OBS_DIM, float(i), dtype=np.float32), np.zeros(4, dtype=np.float32))
+                for i in range(4)
+            ]
+            with self._mock_read_one([(True, "terran", pairs)]):
+                build_dataset(folder, save_path, obs_spec=spec)
+            data = np.load(str(save_path), allow_pickle=False)
+            for i in range(4):
+                self.assertAlmostEqual(data["obs"][i, 0], float(i), places=5)
+
+    def test_meta_json_round_trip(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            folder = self._setup_folder(tmp, ["x.SC2Replay"])
+            save_path = tmp / "demos.npz"
+            spec = SC2_MINIGAME_OBS_SPEC
+            pairs = [(np.zeros(_OBS_DIM, dtype=np.float32), np.zeros(4, dtype=np.float32))]
+            with self._mock_read_one([(True, "terran", pairs)]):
+                build_dataset(
+                    folder, save_path, obs_spec=spec, player_id="winner", step_mul=2, screen_size=32
+                )
+            data = np.load(str(save_path), allow_pickle=False)
+            meta = json.loads(str(data["meta"]))
+            self.assertEqual(meta["player_id"], "winner")
+            self.assertEqual(meta["step_mul"], 2)
+            self.assertEqual(meta["screen_size"], 32)
+            self.assertIn("source_filenames", meta)
+
+    def test_race_filter_drops_all_raises(self):
+        """All replays dropped by race filter → ValueError with race in message."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            folder = self._setup_folder(tmp, ["a.SC2Replay", "b.SC2Replay"])
+            save_path = tmp / "demos.npz"
+            spec = SC2_MINIGAME_OBS_SPEC
+            with self._mock_read_one([(False, "protoss", []), (False, "zerg", [])]):
+                with self.assertRaises(ValueError) as ctx:
+                    build_dataset(folder, save_path, obs_spec=spec, race="terran")
+            self.assertIn("terran", str(ctx.exception))
+
+    def test_no_replay_files_raises(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            empty = tmp / "empty"
+            empty.mkdir()
+            with self.assertRaises(ValueError):
+                build_dataset(empty, tmp / "demos.npz", obs_spec=SC2_MINIGAME_OBS_SPEC)
+
+    def test_race_any_keeps_all(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            folder = self._setup_folder(tmp, ["a.SC2Replay"])
+            save_path = tmp / "demos.npz"
+            spec = SC2_MINIGAME_OBS_SPEC
+            pairs = [(np.zeros(_OBS_DIM, dtype=np.float32), np.zeros(4, dtype=np.float32))]
+            with self._mock_read_one([(True, "zerg", pairs)]):
+                meta = build_dataset(folder, save_path, obs_spec=spec, race="any")
+            self.assertEqual(meta["n_episodes"], 1)
+
+    def test_source_filenames_recorded(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            folder = self._setup_folder(tmp, ["replay1.SC2Replay"])
+            save_path = tmp / "demos.npz"
+            spec = SC2_MINIGAME_OBS_SPEC
+            pairs = [(np.zeros(_OBS_DIM, dtype=np.float32), np.zeros(4, dtype=np.float32))]
+            with self._mock_read_one([(True, "terran", pairs)]):
+                meta = build_dataset(folder, save_path, obs_spec=spec)
+            self.assertIn("replay1.SC2Replay", meta["source_filenames"])
+
+    def test_episode_id_partitions_all_rows(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            folder = self._setup_folder(tmp, ["a.SC2Replay", "b.SC2Replay"])
+            save_path = tmp / "demos.npz"
+            spec = SC2_MINIGAME_OBS_SPEC
+            pairs2 = [(np.zeros(_OBS_DIM, dtype=np.float32), np.zeros(4, dtype=np.float32))] * 2
+            with self._mock_read_one([(True, "t", pairs2), (True, "t", pairs2)]):
+                build_dataset(folder, save_path, obs_spec=spec)
+            data = np.load(str(save_path), allow_pickle=False)
+            self.assertEqual(len(data["episode_id"]), 4)
+
+
+# ---------------------------------------------------------------------------
+# Tests: load_dataset
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDataset(unittest.TestCase):
+    """Loader helper — pure NumPy + JSON, no SC2 involved."""
+
+    def _write(
+        self,
+        path: Path,
+        obs: np.ndarray,
+        actions: np.ndarray,
+        episode_starts: list[int],
+        episode_lengths: list[int],
+        meta: dict,
+    ) -> None:
+        ep_starts = np.array(episode_starts, dtype=np.int64)
+        ep_lengths = np.array(episode_lengths, dtype=np.int64)
+        ep_id = np.concatenate(
+            [np.full(l, i, dtype=np.int64) for i, l in enumerate(episode_lengths)]
+        )
+        np.savez_compressed(
+            str(path),
+            obs=obs,
+            actions=actions,
+            episode_starts=ep_starts,
+            episode_lengths=ep_lengths,
+            episode_id=ep_id,
+            meta=np.array(json.dumps(meta)),
+        )
+
+    def test_flat_load_returns_correct_keys(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "d.npz"
+            obs = np.zeros((5, _OBS_DIM), dtype=np.float32)
+            actions = np.zeros((5, 4), dtype=np.float32)
+            self._write(p, obs, actions, [0, 3], [3, 2], {"n_episodes": 2})
+            data = load_dataset(p)
+            for key in ("obs", "actions", "episode_starts", "episode_lengths", "episode_id", "meta"):
+                self.assertIn(key, data)
+
+    def test_flat_load_shapes(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "d.npz"
+            obs = np.random.rand(7, _OBS_DIM).astype(np.float32)
+            actions = np.random.rand(7, 4).astype(np.float32)
+            self._write(p, obs, actions, [0, 4], [4, 3], {})
+            data = load_dataset(p)
+            self.assertEqual(data["obs"].shape, (7, _OBS_DIM))
+            self.assertEqual(data["actions"].shape, (7, 4))
+
+    def test_as_episodes_shapes(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "d.npz"
+            obs = np.zeros((10, _OBS_DIM), dtype=np.float32)
+            actions = np.zeros((10, 4), dtype=np.float32)
+            self._write(p, obs, actions, [0, 6], [6, 4], {"n_episodes": 2})
+            episodes = load_dataset(p, as_episodes=True)
+            self.assertEqual(len(episodes), 2)
+            obs_seq0, act_seq0 = episodes[0]
+            obs_seq1, act_seq1 = episodes[1]
+            self.assertEqual(obs_seq0.shape, (6, _OBS_DIM))
+            self.assertEqual(obs_seq1.shape, (4, _OBS_DIM))
+            self.assertEqual(act_seq0.shape, (6, 4))
+            self.assertEqual(act_seq1.shape, (4, 4))
+
+    def test_episode_temporal_order_preserved(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "d.npz"
+            obs = np.tile(np.arange(8, dtype=np.float32).reshape(8, 1), _OBS_DIM)[:, :_OBS_DIM]
+            actions = np.zeros((8, 4), dtype=np.float32)
+            self._write(p, obs, actions, [0, 5], [5, 3], {})
+            episodes = load_dataset(p, as_episodes=True)
+            obs_seq0, _ = episodes[0]
+            for i in range(5):
+                self.assertAlmostEqual(float(obs_seq0[i, 0]), float(i), places=5)
+
+    def test_meta_parsed_as_dict(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "d.npz"
+            obs = np.zeros((2, _OBS_DIM), dtype=np.float32)
+            actions = np.zeros((2, 4), dtype=np.float32)
+            meta_in = {"n_episodes": 1, "step_mul": 4, "race_filter": "terran"}
+            self._write(p, obs, actions, [0], [2], meta_in)
+            data = load_dataset(p)
+            self.assertIsInstance(data["meta"], dict)
+            self.assertEqual(data["meta"]["step_mul"], 4)
+            self.assertEqual(data["meta"]["race_filter"], "terran")
+
+    def test_episode_starts_partitions_correctly(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            p = Path(tmp) / "d.npz"
+            obs = np.arange(_OBS_DIM * 9, dtype=np.float32).reshape(9, _OBS_DIM)
+            actions = np.zeros((9, 4), dtype=np.float32)
+            self._write(p, obs, actions, [0, 4, 7], [4, 3, 2], {})
+            data = load_dataset(p)
+            np.testing.assert_array_equal(data["episode_starts"], [0, 4, 7])
+            np.testing.assert_array_equal(data["episode_lengths"], [4, 3, 2])
+
+    def test_round_trip_save_load(self):
+        """build_dataset output is readable by load_dataset without data loss."""
+        import tempfile
+        from unittest.mock import patch
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            folder = tmp / "replays"
+            folder.mkdir()
+            (folder / "g.SC2Replay").touch()
+            save_path = tmp / "demos.npz"
+            spec = SC2_MINIGAME_OBS_SPEC
+
+            obs_expected = np.arange(_OBS_DIM, dtype=np.float32)
+            act_expected = np.array([2.0, 0.3, 0.7, 0.0], dtype=np.float32)
+            pairs = [(obs_expected, act_expected)]
+
+            with patch(
+                "games.sc2.replay_bc._read_one_replay",
+                return_value=(True, "terran", pairs),
+            ):
+                build_dataset(folder, save_path, obs_spec=spec)
+
+            data = load_dataset(save_path)
+            np.testing.assert_array_almost_equal(data["obs"][0], obs_expected)
+            np.testing.assert_array_almost_equal(data["actions"][0], act_expected)
+
+            episodes = load_dataset(save_path, as_episodes=True)
+            self.assertEqual(len(episodes), 1)
+            np.testing.assert_array_almost_equal(episodes[0][0][0], obs_expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sc2_replay_bc.py
+++ b/tests/test_sc2_replay_bc.py
@@ -111,6 +111,7 @@ def _make_fake_s2api():
 _pysc2_pkg, _run_configs_mod, _features_mod = _make_fake_pysc2()
 _s2_pkg, _sc2_api_mod = _make_fake_s2api()
 
+from games.sc2.obs_spec import SC2_MINIGAME_OBS_SPEC  # noqa: E402
 from games.sc2.replay_bc import (  # noqa: E402
     _parse_replay_info,
     _pick_best_action,
@@ -121,7 +122,6 @@ from games.sc2.replay_bc import (  # noqa: E402
     load_dataset,
     replay_observations,
 )
-from games.sc2.obs_spec import SC2_MINIGAME_OBS_SPEC
 
 _OBS_DIM = len(SC2_MINIGAME_OBS_SPEC.names)
 _OBS_NAMES = SC2_MINIGAME_OBS_SPEC.names
@@ -803,7 +803,7 @@ class TestLoadDataset(unittest.TestCase):
         ep_starts = np.array(episode_starts, dtype=np.int64)
         ep_lengths = np.array(episode_lengths, dtype=np.int64)
         ep_id = np.concatenate(
-            [np.full(l, i, dtype=np.int64) for i, l in enumerate(episode_lengths)]
+            [np.full(n, i, dtype=np.int64) for i, n in enumerate(episode_lengths)]
         )
         np.savez_compressed(
             str(path),

--- a/tests/test_sc2_replay_bc.py
+++ b/tests/test_sc2_replay_bc.py
@@ -76,11 +76,11 @@ def _make_fake_pysc2():
     pysc2.run_configs = run_configs_mod
     pysc2.lib = lib_mod
 
-    sys.modules.setdefault("pysc2", pysc2)
-    sys.modules.setdefault("pysc2.run_configs", run_configs_mod)
-    sys.modules.setdefault("pysc2.lib", lib_mod)
-    sys.modules.setdefault("pysc2.lib.features", features_mod)
-    sys.modules.setdefault("pysc2.lib.actions", actions_mod)
+    sys.modules["pysc2"] = pysc2
+    sys.modules["pysc2.run_configs"] = run_configs_mod
+    sys.modules["pysc2.lib"] = lib_mod
+    sys.modules["pysc2.lib.features"] = features_mod
+    sys.modules["pysc2.lib.actions"] = actions_mod
     return pysc2, run_configs_mod, features_mod
 
 
@@ -102,8 +102,8 @@ def _make_fake_s2api():
     api_mod.RequestStartReplay = _ProtoStub
 
     s2_mod.sc2api_pb2 = api_mod
-    sys.modules.setdefault("s2clientprotocol", s2_mod)
-    sys.modules.setdefault("s2clientprotocol.sc2api_pb2", api_mod)
+    sys.modules["s2clientprotocol"] = s2_mod
+    sys.modules["s2clientprotocol.sc2api_pb2"] = api_mod
     return s2_mod, api_mod
 
 


### PR DESCRIPTION
$(cat <<'EOF'
Closes #351

## Summary

- Adds `games/sc2/replay_bc.py`: a PySC2-backed replay reader that produces sequence-aware NPZ demonstration datasets for behaviour cloning.
- Public API: `iter_replays`, `replay_observations` (generator), `build_dataset`, `load_dataset`.
- 50 fully-mocked unit tests in `tests/test_sc2_replay_bc.py` — no SC2 binary or PySC2 package required.

## New feature

**`games/sc2/replay_bc.py`**

| Function | Description |
|---|---|
| `iter_replays(folder)` | Glob all `.SC2Replay` files under `folder`, sorted |
| `replay_observations(path, ...)` | Generator: open one replay, yield `(obs_vec, action_vec)` pairs |
| `build_dataset(folder, save_path, ...)` | Read all replays, filter by race, write `demos.npz` |
| `load_dataset(path, ...)` | Load `demos.npz`; `as_episodes=True` returns per-episode lists |

NPZ format: `obs [N, D]`, `actions [N, 4]`, `episode_starts [E]`, `episode_lengths [E]`, `episode_id [N]`, `meta` (JSON string).

Key design choices:
- Uses shared `extract_flat_obs` / `function_call_to_action` from issue #349 — single code path for live client and offline reader.
- All PySC2 imports are lazy (inside function bodies), matching the existing `games/sc2` convention so the module is importable without PySC2 installed.
- `multi_action_strategy` (`"first"` / `"first_non_noop"`) handles steps with multiple simultaneous actions.
- Race filtering and winner/explicit player selection are resolved before `start_replay()` via `controller.replay_info()`.

## Validation

```bash
python -m pytest tests/test_sc2_actions.py tests/test_sc2_replay_bc.py -v
# 92 passed
```

## Checklist

- [x] `CHANGELOG.md` entry added under `## [Unreleased]`
- [x] `tests/README.md` updated with new section for `test_sc2_replay_bc.py`
- [x] All PySC2 imports lazy — module importable without `pysc2` installed
- [x] 50 unit tests, zero external dependencies

https://claude.ai/code/session_01SvVcddsdbP1Sd7GhyhFJSc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvVcddsdbP1Sd7GhyhFJSc)_