### PR TITLE
SC2 replay BC [3/6]: validate_replay_dir + dataset sourcing docs (issue #352)

### DIFF
--- a/games/sc2/README.md
+++ b/games/sc2/README.md
@@ -26,6 +26,11 @@ StarCraft II (PySC2) integration for the tmnf-ai reinforcement learning framewor
 - [Supported policies](#supported-policies)
   - [`sc2_genetic` — SC2GeneticPolicy](#sc2_genetic--sc2geneticpolicy)
   - [`sc2_cnn` — SC2CNNEvolutionPolicy](#sc2_cnn--sc2cnnevolutionpolicy)
+- [Behaviour cloning from replays](#behaviour-cloning-from-replays)
+  - [Getting replay data](#getting-replay-data)
+  - [Validating a replay directory](#validating-a-replay-directory)
+  - [Running behaviour cloning](#running-behaviour-cloning)
+  - [Version-matching guidance](#version-matching-guidance)
 - [Analytics output](#analytics-output)
   - [Files written per experiment](#files-written-per-experiment)
   - [Plot reference](#plot-reference)
@@ -647,6 +652,117 @@ python grid_search.py games/sc2/config/gs_sc2_cnn_template.yaml --game sc2
 The provided template sweeps `population_size ∈ {10, 20}`, `initial_sigma ∈ {0.005, 0.01}`, and `idle_bonus ∈ {0.0, 0.5}` on DefeatRoaches with the minigame flat-obs preset and two screen channels (`player_relative` + `unit_hit_points`). That is 2 × 2 × 2 = 8 combinations, each running 40 generations.
 
 Champion weights are saved as `<experiment_dir>/weights.npz`. Trainer state (ES mean vector and current σ) is saved as `<experiment_dir>/trainer_state.npz` and is reloaded automatically on restart.
+
+---
+
+## Behaviour cloning from replays
+
+Offline behaviour cloning (BC) lets you base-train a policy from human (or
+high-level AI) SC2 gameplay before any RL fine-tuning. The workflow:
+
+```bash
+# 1. Behaviour-clone from a folder of replays (winner of each game, Terran-only)
+python main.py myrun --game sc2 --bc --replay-dir /path/to/replays --bc-race terran
+
+# 2. Fine-tune from the BC weights with whatever policy_type is configured
+python main.py myrun --game sc2
+```
+
+`--bc` is SC2-only (rejected with an error for other games). The resulting
+`policy_weights.yaml` (and optional `trainer_state.npz`) are written to the
+standard experiment directory; the normal SC2 training loop auto-loads them on
+the next run, so step 2 is just a regular training run.
+
+### Getting replay data
+
+**Blizzard official replay packs** are the recommended source. They are the
+same packs DeepMind's AlphaStar was trained on (via
+[`google-deepmind/alphastar`](https://github.com/google-deepmind/alphastar)).
+
+1. Clone the Blizzard [`s2client-proto`](https://github.com/Blizzard/s2client-proto) repo.
+2. Accept the **Blizzard AI & ML License** (found in the repo root). The
+   replay files are password-protected behind this license; you must agree to
+   it before downloading.
+3. Run the provided download helper to fetch `.SC2Replay` files grouped by
+   game version:
+
+   ```bash
+   python samples/replay-api/download_replays.py \
+       --key <your-api-key> \
+       --version 4.9.3 \
+       --save-dir /data/sc2_replays
+   ```
+
+4. Unzip the downloaded archives; the resulting `*.SC2Replay` files are what
+   `--replay-dir` / `bc_replay_dir` expects.
+
+> **License note.** The replay packs may **not** be redistributed or bundled
+> with this project. Always fetch them directly from Blizzard under the terms
+> of the AI & ML License. Tests in this repository use only synthetic mocked
+> replays — no real `.SC2Replay` files are included.
+
+### Validating a replay directory
+
+Use `validate_replay_dir()` in `games/sc2/replay_bc` to check a folder before
+kicking off a potentially slow `build_dataset` run:
+
+```python
+from games.sc2.replay_bc import validate_replay_dir
+
+replays = validate_replay_dir(
+    "/data/sc2_replays",
+    race="terran",      # warn if cross-race replays will be dropped
+    version="4.9.3",    # warn if filenames suggest a different SC2 build
+)
+print(f"Found {len(replays)} replay(s)")
+```
+
+`validate_replay_dir` raises `ValueError` if the directory is missing or empty,
+and emits `WARNING` log messages when:
+
+- `race` is non-null and non-`"any"` (cross-race replays will be silently
+  skipped by `build_dataset`).
+- `version` is provided but one or more filenames do not contain the version
+  string (Blizzard packs encode the SC2 build in filenames, e.g.
+  `4.9.3.77379`; a mismatch means replays may fail to load against your binary).
+
+### Running behaviour cloning
+
+| CLI flag | Config key | Default | Description |
+|---|---|---|---|
+| `--bc` | *(mode flag)* | — | Enable BC mode (SC2 only) |
+| `--replay-dir DIR` | `bc_replay_dir` | — | Folder of `*.SC2Replay` files |
+| `--bc-player winner\|1\|2` | `bc_player_id` | `winner` | Which player to clone |
+| `--bc-race RACE` | `bc_race` | `any` | Race filter (`terran`, `zerg`, `protoss`, or `any`) |
+| `--bc-target POLICY` | `bc_target` | `sc2_reinforce` | Target policy family for BC fit |
+
+CLI flags override the corresponding `bc_*` keys in `training_params.yaml`.
+
+**Default target** is `sc2_reinforce` (MLP with cross-entropy fn-head + MSE
+spatial head). Pass `--bc-target sc2_genetic` for a closed-form linear fit into
+`SC2MultiHeadLinearPolicy`.
+
+### Version-matching guidance
+
+Replays are tied to the SC2 build they were recorded on. If you replay a
+`4.9.3` replay against a `5.0.x` binary, PySC2 may fail to start the replay
+or produce garbled observations.
+
+Practical steps to ensure alignment:
+
+1. Check the version string encoded in the replay filename (e.g.
+   `4.9.3.77379` → build `4.9.3`).
+2. Confirm your SC2 binary is on the same version. On Linux:
+   ```bash
+   SC2PATH/Versions/BaseXXXXX/SC2_x64 --version
+   ```
+3. Alternatively, download the pack version that matches your binary.
+4. Use `validate_replay_dir(..., version="4.9.3")` to get a warning for any
+   replays whose filename does not contain that string.
+
+Mixed-version folders are not rejected outright — PySC2 will attempt to load
+each replay and log a warning if it fails; `build_dataset` skips failed
+replays and continues.
 
 ---
 

--- a/games/sc2/README.md
+++ b/games/sc2/README.md
@@ -658,20 +658,23 @@ Champion weights are saved as `<experiment_dir>/weights.npz`. Trainer state (ES 
 ## Behaviour cloning from replays
 
 Offline behaviour cloning (BC) lets you base-train a policy from human (or
-high-level AI) SC2 gameplay before any RL fine-tuning. The workflow:
+high-level AI) SC2 gameplay before any RL fine-tuning. The planned workflow
+(CLI wired up in issue #353 [4/6]):
 
 ```bash
 # 1. Behaviour-clone from a folder of replays (winner of each game, Terran-only)
+#    NOTE: --bc / --replay-dir / --bc-race are added in issue #353 [4/6].
+#    The commands below will not work until that PR is merged.
 python main.py myrun --game sc2 --bc --replay-dir /path/to/replays --bc-race terran
 
 # 2. Fine-tune from the BC weights with whatever policy_type is configured
 python main.py myrun --game sc2
 ```
 
-`--bc` is SC2-only (rejected with an error for other games). The resulting
-`policy_weights.yaml` (and optional `trainer_state.npz`) are written to the
-standard experiment directory; the normal SC2 training loop auto-loads them on
-the next run, so step 2 is just a regular training run.
+Once wired up, `--bc` will be SC2-only (rejected with an error for other games).
+The resulting `policy_weights.yaml` (and optional `trainer_state.npz`) are
+written to the standard experiment directory; the normal SC2 training loop
+auto-loads them on the next run, so step 2 is just a regular training run.
 
 ### Getting replay data
 

--- a/games/sc2/replay_bc.py
+++ b/games/sc2/replay_bc.py
@@ -296,9 +296,7 @@ def replay_observations(
         game_info = controller.game_info()
         feat = sc2_features.features_from_game_info(
             game_info=game_info,
-            feature_dimensions=sc2_features.Dimensions(
-                screen=screen_size, minimap=minimap_size
-            ),
+            feature_dimensions=sc2_features.Dimensions(screen=screen_size, minimap=minimap_size),
             use_feature_units=True,
         )
 
@@ -331,9 +329,7 @@ def replay_observations(
                 controller.step(step_mul)
                 continue
 
-            action_vec = function_call_to_action(
-                chosen_fc, screen_size=screen_size, minimap_size=minimap_size
-            )
+            action_vec = function_call_to_action(chosen_fc, screen_size=screen_size, minimap_size=minimap_size)
             if action_vec is None:
                 skipped_unknown += 1
                 state.last_fn_idx = 0
@@ -422,9 +418,7 @@ def _read_one_replay(
         game_info = controller.game_info()
         feat = sc2_features.features_from_game_info(
             game_info=game_info,
-            feature_dimensions=sc2_features.Dimensions(
-                screen=screen_size, minimap=minimap_size
-            ),
+            feature_dimensions=sc2_features.Dimensions(screen=screen_size, minimap=minimap_size),
             use_feature_units=True,
         )
 
@@ -454,9 +448,7 @@ def _read_one_replay(
                 controller.step(step_mul)
                 continue
 
-            action_vec = function_call_to_action(
-                chosen_fc, screen_size=screen_size, minimap_size=minimap_size
-            )
+            action_vec = function_call_to_action(chosen_fc, screen_size=screen_size, minimap_size=minimap_size)
             if action_vec is None:
                 skipped_unknown += 1
                 state.last_fn_idx = 0
@@ -584,9 +576,7 @@ def build_dataset(
 
     if kept == 0:
         if skipped_race > 0:
-            raise ValueError(
-                f"Race filter '{race}' removed all {skipped_race} replay(s) in {folder!r}."
-            )
+            raise ValueError(f"Race filter '{race}' removed all {skipped_race} replay(s) in {folder!r}.")
         raise ValueError(f"No usable replays found in {folder!r}.")
 
     obs_arr = np.stack(all_obs, axis=0).astype(np.float32)

--- a/games/sc2/replay_bc.py
+++ b/games/sc2/replay_bc.py
@@ -74,6 +74,87 @@ def iter_replays(folder: str | pathlib.Path) -> list[pathlib.Path]:
     return sorted(pathlib.Path(folder).glob("*.SC2Replay"))
 
 
+def validate_replay_dir(
+    folder: str | pathlib.Path,
+    *,
+    race: str | None = None,
+    version: str | None = None,
+) -> list[pathlib.Path]:
+    """Validate *folder* for use as a behaviour-cloning replay source.
+
+    Checks that the directory exists, is non-empty, and contains at least one
+    ``.SC2Replay`` file.  Emits :mod:`logging` warnings when *race* or
+    *version* hints suggest the replay set may not match the experiment config.
+
+    Parameters
+    ----------
+    folder:
+        Directory to validate.
+    race:
+        Race filter the caller intends to apply (e.g. ``"terran"``).  When
+        set to a non-empty, non-``"any"`` value, a ``WARNING`` is emitted
+        reminding the user that cross-race replays will be silently skipped
+        by :func:`build_dataset`.
+    version:
+        SC2 build version string to cross-check against replay filenames
+        (e.g. ``"4.9.3"``).  Blizzard packs encode the build in the filename
+        (e.g. ``"4.9.3.77379"``); a ``WARNING`` is emitted when one or more
+        filenames do not contain the supplied string.  Does **not** reject
+        any files.
+
+    Returns
+    -------
+    list[Path]
+        Sorted list of ``.SC2Replay`` paths found in *folder*.
+
+    Raises
+    ------
+    ValueError
+        If *folder* does not exist, is not a directory, or contains no
+        ``.SC2Replay`` files.
+    """
+    folder = pathlib.Path(folder)
+    if not folder.exists():
+        raise ValueError(f"Replay directory does not exist: {folder}")
+    if not folder.is_dir():
+        raise ValueError(f"Replay path is not a directory: {folder}")
+
+    replays = sorted(folder.glob("*.SC2Replay"))
+    if not replays:
+        raise ValueError(
+            f"No .SC2Replay files found in {folder!r}. "
+            "Download Blizzard replay packs via the replay-api samples at "
+            "https://github.com/Blizzard/s2client-proto and unzip them here."
+        )
+
+    logger.info("Found %d .SC2Replay file(s) in %s.", len(replays), folder)
+
+    if race and race.lower() not in ("", "any"):
+        logger.warning(
+            "Race filter '%s' is active: replays whose cloned player is not "
+            "%s will be silently skipped. Use race=None or race='any' to keep "
+            "all races.",
+            race,
+            race,
+        )
+
+    if version:
+        unmatched = [r for r in replays if version not in r.name]
+        if unmatched:
+            logger.warning(
+                "%d/%d replay file(s) do not contain version string %r in "
+                "their filename. Blizzard packs encode the SC2 build in the "
+                "filename (e.g. '4.9.3.77379'). Replays from a different "
+                "build may fail to load — ensure your SC2 binary version "
+                "matches the replay pack.",
+                len(unmatched),
+                len(replays),
+                version,
+            )
+
+    return replays
+
+
 def _parse_replay_info(info: Any) -> tuple[int, dict[int, str]]:
     """Return ``(winner_player_id, {player_id: race_name})`` from a replay_info proto.
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -585,10 +585,12 @@ round-trips for cmaes and neural_dqn; and the SC2-specific analytics module
 feature averages, spatial heatmap, outcome breakdown, and the full
 `save_experiment_results` integration including that no racing plots appear).
 
-The offline replay-reader module (`games/sc2/replay_bc.py`, issue #351) is covered
-in `test_sc2_replay_bc.py`: the full PySC2 replay API (run_config, controller,
-features) is replaced by lightweight fakes injected into `sys.modules` before
-import, so the suite runs with no SC2 binary or PySC2 package installed.
+The offline replay-reader module (`games/sc2/replay_bc.py`, issues #351 and #352)
+is covered in `test_sc2_replay_bc.py`: the full PySC2 replay API (run_config,
+controller, features) is replaced by lightweight fakes injected into
+`sys.modules` before import, so the suite runs with no SC2 binary or PySC2
+package installed. `validate_replay_dir` (issue #352) is tested against real
+temp-dir fixtures — no fakes needed since it only touches the filesystem.
 
 **Not tested.** PySC2 against the actual Blizzard SC2 binary; real
 1v1 games against the built-in bot; minimap rendering; the deferred
@@ -789,7 +791,12 @@ handful of iterations only); reading real `.SC2Replay` files end-to-end
 - `save_grid_summary`: forwards config-normalized rewards **and per-component contributions** using `v / max(abs(weight), 1.0)` — weights ≥ 1.0 are divided (making large-weight components comparable across grid-search runs), weights < 1.0 use the raw value (which already encodes the weight, so dividing would amplify by ×1000); wires SC2 extra-plot hook into framework summary generation; covers no-components fallback, multi-sim normalization, malformed YAML fallback, non-mapping YAML fallback, non-numeric weight fallback, allow-listed `scout` component (no unmapped-key warning), step_penalty with sub-1.0 weight passes through raw (-0.5 not -500), idle_penalty with sub-1.0 weight passes through raw, any sub-1.0 weight (0.0001 or 0.001) both use scale=1.0, the new `unit_loss` / `damage_taken` / `passive_under_fire` components normalize through their config weights without unmapped-key warnings, realistic positive reward stays positive after normalization (313.5 ✓), and emits SC2 cross-run charts + summary links; passes `task_metric_fn`, `task_metric_fmt` (percentage formatter) to framework; `attack_bonus` mapped to `attack_bonus` config key in normalisation
 - `_sc2_task_metric`: empty sims → 0.0; win+finish counted as success; loss/timeout/None/other not counted; all-wins → 1.0; `_GS_SUCCESS_REASONS` constant contains win+finish, excludes loss+timeout
 
-### test_sc2_replay_bc.py — SC2 replay reader → BC demonstration dataset (issue #351)
+### test_sc2_replay_bc.py — SC2 replay reader → BC demonstration dataset (issues #351, #352)
+- `TestValidateReplayDir`: nonexistent folder raises `ValueError`; file path raises `ValueError`; empty
+  folder raises with "No .SC2Replay files found"; returns only `.SC2Replay` files sorted; race filter warning
+  emitted when race is non-null/non-"any"; no warning for `race="any"` or `race=None`; version mismatch
+  warning emitted when filenames don't contain the version string; no warning when all filenames match;
+  partial mismatch warning includes count ratio (e.g. "1/2")
 - `TestIterReplays`: finds only `.SC2Replay` files; sorted order; empty folder returns `[]`
 - `TestParseReplayInfo`: winner + races parsed correctly; winner is player 2; undecided returns `(0, {})`;
   race integer mapping (1=terran, 2=zerg, 3=protoss, 4=random); unknown race falls back to `"random"`

--- a/tests/README.md
+++ b/tests/README.md
@@ -71,7 +71,7 @@
   - [test\_sc2\_play.py — `play_sc2.py` script](#test_sc2_playpy--play_sc2py-script)
   - [test\_sc2\_simple64\_training.py — Simple64 ladder integration](#test_sc2_simple64_trainingpy--simple64-ladder-integration)
   - [test\_sc2\_analytics.py — SC2-specific analytics plots and flags](#test_sc2_analyticspy--sc2-specific-analytics-plots-and-flags)
-  - [test\_sc2\_replay\_bc.py — SC2 replay reader → BC demonstration dataset (issue #351)](#test_sc2_replay_bcpy--sc2-replay-reader--bc-demonstration-dataset-issue-351)
+  - [test\_sc2\_replay\_bc.py — SC2 replay reader → BC demonstration dataset (issues #351, #352)](#test_sc2_replay_bcpy--sc2-replay-reader--bc-demonstration-dataset-issues-351-352)
 - [Rocket League](#rocket-league)
   - [test\_rocket\_league\_obs\_spec.py — Rocket League observation spec (142-dim)](#test_rocket_league_obs_specpy--rocket-league-observation-spec-142-dim)
   - [test\_rocket\_league\_reward.py — Rocket League reward calc](#test_rocket_league_rewardpy--rocket-league-reward-calc)

--- a/tests/test_sc2_replay_bc.py
+++ b/tests/test_sc2_replay_bc.py
@@ -160,8 +160,7 @@ def _fake_replay_info(*, winner_pid: int, races: dict[int, int]):
     """
     info = MagicMock()
     info.player_info = [
-        _FakePlayerInfo(pid, race_int, 1 if pid == winner_pid else 2)
-        for pid, race_int in races.items()
+        _FakePlayerInfo(pid, race_int, 1 if pid == winner_pid else 2) for pid, race_int in races.items()
     ]
     return info
 
@@ -193,10 +192,7 @@ def _build_mock_controller(
             self.actions = raw_actions
             self.player_result = [object()] if done else []
 
-    responses = [
-        _FakeObsProto(obs, acts)
-        for obs, acts in zip(observe_sequence, actions_per_step)
-    ]
+    responses = [_FakeObsProto(obs, acts) for obs, acts in zip(observe_sequence, actions_per_step)]
     responses.append(_FakeObsProto({}, [], done=True))
     observe_iter = iter(responses)
 
@@ -313,7 +309,6 @@ class TestValidateReplayDir(unittest.TestCase):
             self.assertTrue(any("terran" in msg for msg in cm.output))
 
     def test_race_any_no_warning(self):
-        import logging
         import tempfile
 
         with tempfile.TemporaryDirectory() as d:
@@ -352,9 +347,7 @@ class TestValidateReplayDir(unittest.TestCase):
             (d / "replay_4.9.3.77379.SC2Replay").touch()
             with self.assertLogs("games.sc2.replay_bc", level="INFO") as cm:
                 validate_replay_dir(d, version="4.9.3")
-            self.assertFalse(
-                any("WARNING" in msg and "version" in msg.lower() for msg in cm.output)
-            )
+            self.assertFalse(any("WARNING" in msg and "version" in msg.lower() for msg in cm.output))
 
     def test_version_partial_mismatch_warns(self):
         """Warns when SOME but not all replays match the version string."""
@@ -545,9 +538,8 @@ class TestReplayObservations(unittest.TestCase):
         """The fn_idx in the action vector must match the issued action."""
         # select_army (internal fn_idx=1) → PySC2 id for select_army
         from games.sc2.actions import FUNCTION_IDS
-        pysc2_id_for_select_army = next(
-            i for i, name in FUNCTION_IDS.items() if name == "select_army"
-        )
+
+        pysc2_id_for_select_army = next(i for i, name in FUNCTION_IDS.items() if name == "select_army")
         obs_dicts = [{}]
         actions = [[_FakeFunctionCall(pysc2_id_for_select_army)]]
         pairs, _ = self._run(obs_dicts, actions)
@@ -561,10 +553,7 @@ class TestReplayObservations(unittest.TestCase):
         obs_dicts = [{} for _ in range(5)]
         # Each step issues Move_screen with a strictly increasing x pixel coordinate.
         # PySC2 fn_id for Move_screen is 2 in FUNCTION_IDS (internal fn_idx 2).
-        actions = [
-            [_FakeFunctionCall(2, [[0], [i * 10, 5]])]
-            for i in range(5)
-        ]
+        actions = [[_FakeFunctionCall(2, [[0], [i * 10, 5]])] for i in range(5)]
         pairs, _ = self._run(obs_dicts, actions, screen_size=screen_size)
         self.assertEqual(len(pairs), 5)
         # x_norm = pixel_x / (screen_size - 1); must be monotonically increasing.
@@ -713,9 +702,7 @@ class TestReadOneReplay(unittest.TestCase):
         """player_race is populated even when the race filter drops the replay."""
         obs_dicts = [{}]
         actions = [[_FakeFunctionCall(2, [[0], [10, 10]])]]
-        (race_ok, player_race, _), _ = self._run(
-            obs_dicts, actions, race_filter="zerg", races={1: 1, 2: 3}
-        )
+        (race_ok, player_race, _), _ = self._run(obs_dicts, actions, race_filter="zerg", races={1: 1, 2: 3})
         self.assertFalse(race_ok)
         self.assertEqual(player_race, "terran")
 
@@ -771,10 +758,7 @@ class TestBuildDataset(unittest.TestCase):
             folder = self._setup_folder(tmp, ["g.SC2Replay"])
             save_path = tmp / "demos.npz"
             spec = SC2_MINIGAME_OBS_SPEC
-            pairs = [
-                (np.zeros(_OBS_DIM, dtype=np.float32), np.zeros(4, dtype=np.float32))
-                for _ in range(5)
-            ]
+            pairs = [(np.zeros(_OBS_DIM, dtype=np.float32), np.zeros(4, dtype=np.float32)) for _ in range(5)]
             with self._mock_read_one([(True, "terran", pairs)]):
                 build_dataset(folder, save_path, obs_spec=spec)
             data = np.load(str(save_path), allow_pickle=False)
@@ -807,10 +791,7 @@ class TestBuildDataset(unittest.TestCase):
             folder = self._setup_folder(tmp, ["g.SC2Replay"])
             save_path = tmp / "demos.npz"
             spec = SC2_MINIGAME_OBS_SPEC
-            pairs = [
-                (np.full(_OBS_DIM, float(i), dtype=np.float32), np.zeros(4, dtype=np.float32))
-                for i in range(4)
-            ]
+            pairs = [(np.full(_OBS_DIM, float(i), dtype=np.float32), np.zeros(4, dtype=np.float32)) for i in range(4)]
             with self._mock_read_one([(True, "terran", pairs)]):
                 build_dataset(folder, save_path, obs_spec=spec)
             data = np.load(str(save_path), allow_pickle=False)
@@ -827,9 +808,7 @@ class TestBuildDataset(unittest.TestCase):
             spec = SC2_MINIGAME_OBS_SPEC
             pairs = [(np.zeros(_OBS_DIM, dtype=np.float32), np.zeros(4, dtype=np.float32))]
             with self._mock_read_one([(True, "terran", pairs)]):
-                build_dataset(
-                    folder, save_path, obs_spec=spec, player_id="winner", step_mul=2, screen_size=32
-                )
+                build_dataset(folder, save_path, obs_spec=spec, player_id="winner", step_mul=2, screen_size=32)
             data = np.load(str(save_path), allow_pickle=False)
             meta = json.loads(str(data["meta"]))
             self.assertEqual(meta["player_id"], "winner")
@@ -921,9 +900,7 @@ class TestLoadDataset(unittest.TestCase):
     ) -> None:
         ep_starts = np.array(episode_starts, dtype=np.int64)
         ep_lengths = np.array(episode_lengths, dtype=np.int64)
-        ep_id = np.concatenate(
-            [np.full(n, i, dtype=np.int64) for i, n in enumerate(episode_lengths)]
-        )
+        ep_id = np.concatenate([np.full(n, i, dtype=np.int64) for i, n in enumerate(episode_lengths)])
         np.savez_compressed(
             str(path),
             obs=obs,

--- a/tests/test_sc2_replay_bc.py
+++ b/tests/test_sc2_replay_bc.py
@@ -121,6 +121,7 @@ from games.sc2.replay_bc import (  # noqa: E402
     iter_replays,
     load_dataset,
     replay_observations,
+    validate_replay_dir,
 )
 
 _OBS_DIM = len(SC2_MINIGAME_OBS_SPEC.names)
@@ -250,6 +251,124 @@ def _reset_fakes() -> None:
     """Reset the injected fakes to avoid test cross-contamination."""
     _run_configs_mod.get.reset_mock(return_value=True, side_effect=True)
     _features_mod.features_from_game_info.reset_mock(return_value=True, side_effect=True)
+
+
+# ---------------------------------------------------------------------------
+# Tests: validate_replay_dir (issue #352)
+# ---------------------------------------------------------------------------
+
+
+class TestValidateReplayDir(unittest.TestCase):
+    def test_nonexistent_folder_raises(self):
+        with self.assertRaises(ValueError) as ctx:
+            validate_replay_dir("/nonexistent/path/that/does/not/exist")
+        self.assertIn("does not exist", str(ctx.exception))
+
+    def test_file_path_raises(self):
+        import tempfile
+
+        with tempfile.NamedTemporaryFile(suffix=".SC2Replay") as f:
+            with self.assertRaises(ValueError) as ctx:
+                validate_replay_dir(f.name)
+        self.assertIn("not a directory", str(ctx.exception))
+
+    def test_empty_folder_raises(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            with self.assertRaises(ValueError) as ctx:
+                validate_replay_dir(d)
+        self.assertIn("No .SC2Replay files found", str(ctx.exception))
+
+    def test_returns_sc2replay_files_only(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "game1.SC2Replay").touch()
+            (d / "game2.SC2Replay").touch()
+            (d / "notes.txt").touch()
+            result = validate_replay_dir(d)
+            self.assertEqual([p.name for p in result], ["game1.SC2Replay", "game2.SC2Replay"])
+
+    def test_returns_sorted_paths(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "b.SC2Replay").touch()
+            (d / "a.SC2Replay").touch()
+            result = validate_replay_dir(d)
+            self.assertEqual(result[0].name, "a.SC2Replay")
+            self.assertEqual(result[1].name, "b.SC2Replay")
+
+    def test_race_filter_warning_emitted(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "game.SC2Replay").touch()
+            with self.assertLogs("games.sc2.replay_bc", level="WARNING") as cm:
+                validate_replay_dir(d, race="terran")
+            self.assertTrue(any("terran" in msg for msg in cm.output))
+
+    def test_race_any_no_warning(self):
+        import logging
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "game.SC2Replay").touch()
+            with self.assertLogs("games.sc2.replay_bc", level="INFO") as cm:
+                validate_replay_dir(d, race="any")
+            # No WARNING lines about race should appear
+            self.assertFalse(any("WARNING" in msg and "Race filter" in msg for msg in cm.output))
+
+    def test_race_none_no_warning(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "game.SC2Replay").touch()
+            with self.assertLogs("games.sc2.replay_bc", level="INFO") as cm:
+                validate_replay_dir(d, race=None)
+            self.assertFalse(any("Race filter" in msg for msg in cm.output))
+
+    def test_version_mismatch_warning_emitted(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "replay_3.0.0.12345.SC2Replay").touch()
+            with self.assertLogs("games.sc2.replay_bc", level="WARNING") as cm:
+                validate_replay_dir(d, version="4.9.3")
+            self.assertTrue(any("4.9.3" in msg for msg in cm.output))
+
+    def test_version_match_no_warning(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "replay_4.9.3.77379.SC2Replay").touch()
+            with self.assertLogs("games.sc2.replay_bc", level="INFO") as cm:
+                validate_replay_dir(d, version="4.9.3")
+            self.assertFalse(
+                any("WARNING" in msg and "version" in msg.lower() for msg in cm.output)
+            )
+
+    def test_version_partial_mismatch_warns(self):
+        """Warns when SOME but not all replays match the version string."""
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as d:
+            d = Path(d)
+            (d / "replay_4.9.3.77379.SC2Replay").touch()
+            (d / "replay_4.8.2.70000.SC2Replay").touch()
+            with self.assertLogs("games.sc2.replay_bc", level="WARNING") as cm:
+                validate_replay_dir(d, version="4.9.3")
+            warning_msgs = [m for m in cm.output if "WARNING" in m and "version" in m.lower()]
+            self.assertEqual(len(warning_msgs), 1)
+            self.assertIn("1/2", warning_msgs[0])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
$(cat <<'EOF'
Refs #352
Part of #349.

## Summary

- Adds `validate_replay_dir()` to `games/sc2/replay_bc` — raises `ValueError` when the folder is missing or empty; emits `WARNING` log messages when a race filter will silently drop cross-race replays or when replay filenames don't match an expected SC2 version string (Blizzard packs encode the build in the filename).
- Adds a **"Behaviour cloning from replays"** section to `games/sc2/README.md` documenting: where to get Blizzard replay packs (`s2client-proto` / `download_replays.py`), the Blizzard AI & ML License constraint, the `--bc` CLI flags and `bc_*` config key table, and version-matching guidance.
- 11 new `TestValidateReplayDir` tests in `tests/test_sc2_replay_bc.py` (all passing; no SC2 binary required). `tests/README.md` updated.

## Validation

```
python -m pytest tests/test_sc2_replay_bc.py -v
# 61 passed in 0.35s
```

## Checklist

- [x] Tests added (`TestValidateReplayDir`, 11 cases)
- [x] `tests/README.md` updated
- [x] `games/sc2/README.md` updated with dataset sourcing section
- [ ] `CHANGELOG.md` — deferred to [6/6] (#355)
- [ ] `CLAUDE.md` — deferred to [6/6] (#355)

https://claude.ai/code/session_015VVowkMaa7ndtfbHYpXbfe
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_015VVowkMaa7ndtfbHYpXbfe)_