### PR TITLE
Fix SC2 agent freezing due to deferred-action oscillation and tech-tree regressions (#356)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+### Fixed
+- SC2 agent no longer freezes on ladder maps (issue #356).  Three bugs
+  introduced by PR #348 (tech-tree preconditions + deferred-action queue)
+  are fixed:
+  - **H1 — infinite select_army oscillation**: `step()` now bypasses
+    `_resolve_action()` when consuming a deferred action.  Previously,
+    re-running the resolver on the replayed action would emit another
+    `select_army` (always "available" in PySC2 even with an empty army)
+    and re-defer indefinitely, stalling the agent for the entire episode.
+  - **H2 — buildings disappear on camera move**: `_owned_buildings` is now
+    accumulated across steps via `_owned_buildings_seen` so structures that
+    scroll off-screen no longer vanish from the tech-tree mask and block
+    build/train actions mid-episode.
+  - **H3 — per-step tech-tree CPU overhead**: `_compute_available_fn_ids()`
+    caches its result and skips the 118-call `fn_idx_satisfied()` loop when
+    `owned_buildings`, `completed_upgrades`, `selected_unit_types`, and the
+    PySC2 candidate set are all unchanged since the previous step.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,28 @@ unit-tested logic and mocked integration shifts.
 
 ---
 
+## Pre-commit checks
+
+The repository uses [pre-commit](https://pre-commit.com/) to enforce YAML
+validity, merge-conflict markers, end-of-file newlines, trailing whitespace,
+and Ruff lint + format. **All pre-commit checks must pass before committing.**
+
+```bash
+# Install once
+pip install pre-commit
+pre-commit install   # installs the git hook so it runs automatically
+
+# Run manually on all files
+pre-commit run --all-files
+```
+
+Ruff's `--fix` flag auto-corrects most lint issues in-place; run
+`pre-commit run --all-files` a second time after it modifies files to confirm
+everything is clean before staging. **Never use `--no-verify` to skip the
+hook.** Fix the underlying issue instead.
+
+---
+
 ## Changelog
 
 `CHANGELOG.md` is the project's running log of user- and

--- a/games/sc2/client.py
+++ b/games/sc2/client.py
@@ -345,10 +345,18 @@ class SC2Client:
         self._unit_type_id_to_attack_range_gu: dict[int, float] | None = None
         # Tech-tree state cached from the latest timestep.
         self._owned_buildings: frozenset[str] = frozenset()
+        # Accumulates every building seen this episode so that buildings that
+        # scroll off-screen don't vanish from the tech-tree mask (issue #356 H2).
+        self._owned_buildings_seen: frozenset[str] = frozenset()
         self._completed_upgrades: frozenset[str] = frozenset()
         # Current resource counts cached from the latest timestep (issue #357).
         self._minerals: float = 0.0
         self._vespene: float = 0.0
+        # Cache for _compute_available_fn_ids() — skip the 118-call tech-tree
+        # loop when owned_buildings / completed_upgrades / selected_unit_types
+        # and the candidate set are all unchanged since last step (issue #356 H3).
+        self._fn_ids_cache_keys: tuple | None = None
+        self._fn_ids_cache_result: set[int] = set()
         # Currently-selected unit-type name (None when nothing selected or
         # the selection is mixed across types).
         # Set of currently-selected unit-type names.  Multi-type
@@ -396,10 +404,13 @@ class SC2Client:
         self._selected_count = 0.0
         self._last_fn_idx = 0
         self._owned_buildings = frozenset()
+        self._owned_buildings_seen = frozenset()
         self._completed_upgrades = frozenset()
         self._selected_unit_types = frozenset()
         self._minerals = 0.0
         self._vespene = 0.0
+        self._fn_ids_cache_keys = None
+        self._fn_ids_cache_result = set()
         self._screen_xy_by_unit_type = {}
         self._deferred_action = None
         self._last_state_log_wall_s = None
@@ -430,13 +441,20 @@ class SC2Client:
            slot for the next step.
         """
         if self._deferred_action is not None:
+            # The selector was already emitted last step; send the original
+            # action directly without re-resolving.  If the selection still
+            # doesn't match, PySC2 will no-op it — but we must not re-defer,
+            # or we get an infinite select_army oscillation (issue #356: H1).
+            # select_army is always "available" in PySC2 even with zero army
+            # units, so without this guard the deferred action would never
+            # actually execute.
             action = self._deferred_action
             self._deferred_action = None
-        elif self._is_extreme_random_phase():
-            action = self._sample_extreme_random_action()
-
-        action, deferred = self._resolve_action(action)
-        self._deferred_action = deferred
+        else:
+            if self._is_extreme_random_phase():
+                action = self._sample_extreme_random_action()
+            action, deferred = self._resolve_action(action)
+            self._deferred_action = deferred
 
         fn_call = self._action_to_call(action)
         if self._self_play and self._opponent_policy is not None:
@@ -881,7 +899,8 @@ class SC2Client:
         # Compute the full internal mask: race ∩ PySC2 ∩ tech-tree ∩ selection ∩ resources.
         # Single source of truth — read by extreme-random sampler, policies
         # (via info["available_fn_ids"]), and the deferred-action resolver.
-        self._owned_buildings = self._compute_owned_buildings(ob)
+        self._owned_buildings_seen = self._owned_buildings_seen | self._compute_owned_buildings(ob)
+        self._owned_buildings = self._owned_buildings_seen
         self._completed_upgrades = self._compute_completed_upgrades(ob)
         self._selected_unit_types = self._compute_selected_unit_types(ob)
         self._minerals = feats.get("minerals", 0.0)
@@ -1601,7 +1620,21 @@ class SC2Client:
         if not self._unit_type_id_to_name:
             return set(candidate)
 
-        return {
+        # Cache: skip the full fn_idx_satisfied loop when the game-state inputs
+        # are unchanged (issue #356 H3).  Minerals and vespene are included
+        # because PR #357 gates build/train actions on affordability.
+        cache_keys = (
+            frozenset(candidate),
+            self._owned_buildings,
+            self._completed_upgrades,
+            self._selected_unit_types,
+            self._minerals,
+            self._vespene,
+        )
+        if cache_keys == self._fn_ids_cache_keys:
+            return set(self._fn_ids_cache_result)
+
+        result = {
             fn_idx
             for fn_idx in candidate
             if fn_idx_satisfied(
@@ -1613,6 +1646,9 @@ class SC2Client:
                 self._vespene,
             )
         }
+        self._fn_ids_cache_keys = cache_keys
+        self._fn_ids_cache_result = result
+        return set(result)
 
     _upgrade_id_to_name_cache: dict[int, str] | None = None
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -655,6 +655,8 @@ handful of iterations only).
 - score_features field-name access: named NamedNumpyArray access takes priority over positional; score→score_total rename applied; missing score array → all zeros
 - last_fn_idx property: `_resolve_action` routing → idx=1 when select_army resolved; no_op fallback on blocked PySC2 mask → idx=0; passthrough → requested idx
 - realtime param: default False stored; True stored; forwarded as kwarg to SC2Env constructor
+- deferred-action oscillation fix (#356 H1): deferred `Move_screen` replays directly on step 2 even when army is still empty; `select_army` appears exactly once across both steps (not re-emitted, not re-deferred)
+- owned-buildings accumulation fix (#356 H2): buildings seen in prior steps remain in `_owned_buildings` after the camera pans away; new buildings are unioned in each step; episode `reset()` clears the accumulator
 
 ### test_sc2_env.py — SC2 env wrapper
 - minigame obs space; action space shape+bounds; ladder obs space; episode time-limit get/set

--- a/tests/README.md
+++ b/tests/README.md
@@ -656,7 +656,8 @@ handful of iterations only).
 - last_fn_idx property: `_resolve_action` routing → idx=1 when select_army resolved; no_op fallback on blocked PySC2 mask → idx=0; passthrough → requested idx
 - realtime param: default False stored; True stored; forwarded as kwarg to SC2Env constructor
 - deferred-action oscillation fix (#356 H1): deferred `Move_screen` replays directly on step 2 even when army is still empty; `select_army` appears exactly once across both steps (not re-emitted, not re-deferred)
-- owned-buildings accumulation fix (#356 H2): buildings seen in prior steps remain in `_owned_buildings` after the camera pans away; new buildings are unioned in each step; episode `reset()` clears the accumulator
+- owned-buildings accumulation fix (#356 H2): drives real `_timestep_to_obs_info()` with patched `_compute_owned_buildings()` — buildings seen in prior steps remain in `_owned_buildings` after the camera pans away; new buildings are unioned in each step; episode `reset()` clears both `_owned_buildings` and `_owned_buildings_seen`
+- fn_idx_satisfied cache fix (#356 H3): patches `games.sc2.client.fn_idx_satisfied` to count calls — zero new calls on cache hit (identical state); fresh pass triggered when `owned_buildings`, `selected_unit_types`, or the PySC2 candidate set changes
 
 ### test_sc2_env.py — SC2 env wrapper
 - minigame obs space; action space shape+bounds; ladder obs space; episode time-limit get/set

--- a/tests/test_sc2_client.py
+++ b/tests/test_sc2_client.py
@@ -2301,7 +2301,6 @@ class TestIssue356FnIdxCache(unittest.TestCase):
             after_first = mock_sat.call_count
 
             # Shrink the candidate set → cache miss.
-            from games.sc2.actions import fn_ids_for_race
 
             id_map = __import__("games.sc2.client", fromlist=["_get_pysc2_id_to_fn_idx"])._get_pysc2_id_to_fn_idx()
             if id_map:
@@ -2309,7 +2308,6 @@ class TestIssue356FnIdxCache(unittest.TestCase):
                 self.client._available_actions = {min(id_map.keys())}
                 self.client._compute_available_fn_ids(None)
                 self.assertGreater(mock_sat.call_count, after_first)
-
 
 
 if __name__ == "__main__":

--- a/tests/test_sc2_client.py
+++ b/tests/test_sc2_client.py
@@ -2005,5 +2005,156 @@ class TestSC2ClientLadderRestart(unittest.TestCase):
         fake_env_new.reset.assert_called_once()
 
 
+class TestIssue356DeferredActionOscillation(unittest.TestCase):
+    """Regression tests for issue #356 H1: deferred-action infinite loop.
+
+    Before the fix, _resolve_action() was called again when consuming a
+    deferred action.  With an empty army, select_army is always "available"
+    in PySC2 but never populates a selection, so the agent would emit
+    select_army every step forever.  After the fix, the deferred action is
+    sent directly on step 2 regardless of the current selection state.
+    """
+
+    def setUp(self):
+        from unittest.mock import MagicMock, patch
+
+        patcher_pysc2 = patch.dict(
+            "sys.modules",
+            {
+                "pysc2": _FakePySc2,
+                "pysc2.lib": _FakePySc2.lib,
+                "pysc2.lib.actions": _FakeActionsModule,
+            },
+        )
+        patcher_pysc2.start()
+        self.addCleanup(patcher_pysc2.stop)
+
+        from games.sc2 import client as client_mod
+
+        def _fake_action_to_call(action, screen_size, minimap_size=None):
+            fn_idx = int(action[0])
+            fn_id = {
+                0: _FakeFunctions.no_op.id,
+                1: _FakeFunctions.select_army.id,
+                2: _FakeFunctions.Move_screen.id,
+            }.get(fn_idx, _FakeFunctions.no_op.id)
+            return _FakeFunctionCall(fn_id, [])
+
+        patcher_helper = patch.object(client_mod, "action_to_function_call", _fake_action_to_call)
+        patcher_helper.start()
+        self.addCleanup(patcher_helper.stop)
+
+        from games.sc2.client import SC2Client
+
+        self.client = SC2Client(map_name="MoveToBeacon")
+        fake_ts = MagicMock()
+        fake_ts.last.return_value = False
+        fake_ts.reward = 0.0
+        self.client._sc2_env = MagicMock()
+        self.client._sc2_env.step.return_value = [fake_ts]
+        self.client._timestep_to_obs_info = MagicMock(return_value=(np.zeros(10), {}))
+        self.client._available_actions = None
+        self._calls = []
+        original_atc = self.client._action_to_call
+
+        def _spy(action):
+            self._calls.append(int(action[0]))
+            return original_atc(action)
+
+        self.client._action_to_call = _spy
+
+    def test_deferred_action_replayed_directly_when_army_still_empty(self):
+        """H1 fix: step 2 sends Move_screen directly even if army is still 0."""
+        # Step 1: empty selection → select_army emitted, Move_screen deferred.
+        self.client._selected_count = 0.0
+        self.client._selected_unit_types = frozenset()
+        self.client.step(np.array([2, 0.4, 0.6, 0], dtype=np.float32))
+        self.assertEqual(self._calls[-1], 1)  # select_army
+        self.assertIsNotNone(self.client._deferred_action)
+        self.assertEqual(int(self.client._deferred_action[0]), 2)
+
+        # Step 2: army STILL empty (select_army found nothing on a ladder map
+        # at game start).  Before the fix this would emit another select_army
+        # and re-defer, looping forever.  After the fix, Move_screen goes out.
+        self.client._selected_count = 0.0
+        self.client._selected_unit_types = frozenset()
+        self.client.step(np.array([0, 0.0, 0.0, 0], dtype=np.float32))
+        self.assertEqual(self._calls[-1], 2)  # Move_screen — NOT another select_army
+        self.assertIsNone(self.client._deferred_action)  # no re-deferral
+
+    def test_no_third_select_army_emitted(self):
+        """Across both steps, select_army appears exactly once (not twice)."""
+        self.client._selected_count = 0.0
+        self.client._selected_unit_types = frozenset()
+        self.client.step(np.array([2, 0.4, 0.6, 0], dtype=np.float32))
+
+        self.client._selected_count = 0.0
+        self.client._selected_unit_types = frozenset()
+        self.client.step(np.array([0, 0.0, 0.0, 0], dtype=np.float32))
+
+        select_army_count = self._calls.count(1)
+        self.assertEqual(select_army_count, 1, f"select_army should appear once; got {self._calls}")
+
+
+class TestIssue356OwnedBuildingsAccumulation(unittest.TestCase):
+    """Regression tests for issue #356 H2: buildings vanish when camera moves.
+
+    _compute_owned_buildings() only scans feature_units (the current camera
+    view).  Before the fix, panning away from the base would empty
+    _owned_buildings and block every build/train action whose tech-tree prereq
+    required a structure.  After the fix, _owned_buildings_seen accumulates
+    the union across steps for the entire episode.
+    """
+
+    def _make_client(self):
+        from games.sc2.client import SC2Client
+
+        return SC2Client(map_name="Simple64")
+
+    def test_buildings_persist_after_camera_moves_away(self):
+        """Buildings seen on step 1 remain in _owned_buildings on step 2
+        even when _compute_owned_buildings returns empty (camera moved)."""
+        client = self._make_client()
+
+        # Simulate step 1: CommandCenter visible.
+        client._owned_buildings_seen = client._owned_buildings_seen | frozenset({"CommandCenter"})
+        client._owned_buildings = client._owned_buildings_seen
+
+        # Simulate step 2: camera has panned to a different area; no buildings
+        # are visible so _compute_owned_buildings returns empty.
+        new_step_buildings = frozenset()
+        client._owned_buildings_seen = client._owned_buildings_seen | new_step_buildings
+        client._owned_buildings = client._owned_buildings_seen
+
+        self.assertIn("CommandCenter", client._owned_buildings)
+
+    def test_reset_clears_accumulated_buildings(self):
+        """Episode boundary clears _owned_buildings_seen so old-game buildings
+        don't leak into the next episode."""
+        client = self._make_client()
+        client._owned_buildings_seen = frozenset({"CommandCenter", "Barracks"})
+        client._owned_buildings = client._owned_buildings_seen
+
+        # reset() should clear both accumulators.
+        client._owned_buildings_seen = frozenset()
+        client._owned_buildings = frozenset()
+
+        self.assertEqual(client._owned_buildings, frozenset())
+        self.assertEqual(client._owned_buildings_seen, frozenset())
+
+    def test_new_buildings_added_each_step(self):
+        """Each step's visible buildings are unioned into the accumulator."""
+        client = self._make_client()
+
+        client._owned_buildings_seen = client._owned_buildings_seen | frozenset({"CommandCenter"})
+        client._owned_buildings = client._owned_buildings_seen
+
+        client._owned_buildings_seen = client._owned_buildings_seen | frozenset({"Barracks"})
+        client._owned_buildings = client._owned_buildings_seen
+
+        self.assertIn("CommandCenter", client._owned_buildings)
+        self.assertIn("Barracks", client._owned_buildings)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sc2_client.py
+++ b/tests/test_sc2_client.py
@@ -2104,7 +2104,32 @@ class TestIssue356OwnedBuildingsAccumulation(unittest.TestCase):
     _owned_buildings and block every build/train action whose tech-tree prereq
     required a structure.  After the fix, _owned_buildings_seen accumulates
     the union across steps for the entire episode.
+
+    All tests drive the real _timestep_to_obs_info() code path (with
+    _compute_owned_buildings patched to control visibility) rather than
+    directly manipulating the accumulator, so they would catch a regression
+    where the accumulation assignment is removed from _timestep_to_obs_info.
     """
+
+    def _make_fake_obs(self):
+        return {
+            "player": _NamedArr(
+                {
+                    "minerals": 50,
+                    "vespene": 0,
+                    "food_used": 1,
+                    "food_cap": 15,
+                    "army_count": 0,
+                    "idle_worker_count": 0,
+                    "warp_gate_count": 0,
+                    "larva_count": 0,
+                }
+            ),
+            "single_select": np.zeros((0, 7), dtype=np.int32),
+            "multi_select": np.zeros((0, 7), dtype=np.int32),
+            "feature_screen": np.zeros((17, 64, 64), dtype=np.int32),
+            "score_cumulative": np.array([0]),
+        }
 
     def _make_client(self):
         from games.sc2.client import SC2Client
@@ -2114,46 +2139,177 @@ class TestIssue356OwnedBuildingsAccumulation(unittest.TestCase):
     def test_buildings_persist_after_camera_moves_away(self):
         """Buildings seen on step 1 remain in _owned_buildings on step 2
         even when _compute_owned_buildings returns empty (camera moved)."""
+        from unittest.mock import MagicMock
+
         client = self._make_client()
+        ts = _FakeTimeStep(self._make_fake_obs())
 
-        # Simulate step 1: CommandCenter visible.
-        client._owned_buildings_seen = client._owned_buildings_seen | frozenset({"CommandCenter"})
-        client._owned_buildings = client._owned_buildings_seen
+        # Step 1: CommandCenter visible this tick.
+        client._compute_owned_buildings = MagicMock(return_value=frozenset({"CommandCenter"}))
+        client._timestep_to_obs_info(ts)
+        self.assertIn("CommandCenter", client._owned_buildings)
 
-        # Simulate step 2: camera has panned to a different area; no buildings
-        # are visible so _compute_owned_buildings returns empty.
-        new_step_buildings = frozenset()
-        client._owned_buildings_seen = client._owned_buildings_seen | new_step_buildings
-        client._owned_buildings = client._owned_buildings_seen
+        # Step 2: camera panned away; _compute_owned_buildings returns empty.
+        client._compute_owned_buildings = MagicMock(return_value=frozenset())
+        client._timestep_to_obs_info(ts)
 
+        # The accumulator must keep the CommandCenter seen in step 1.
         self.assertIn("CommandCenter", client._owned_buildings)
 
     def test_reset_clears_accumulated_buildings(self):
         """Episode boundary clears _owned_buildings_seen so old-game buildings
         don't leak into the next episode."""
-        client = self._make_client()
-        client._owned_buildings_seen = frozenset({"CommandCenter", "Barracks"})
-        client._owned_buildings = client._owned_buildings_seen
+        from unittest.mock import MagicMock
 
-        # reset() should clear both accumulators.
-        client._owned_buildings_seen = frozenset()
-        client._owned_buildings = frozenset()
+        client = self._make_client()
+        ts = _FakeTimeStep(self._make_fake_obs())
+
+        # Accumulate a building via the real code path.
+        client._compute_owned_buildings = MagicMock(return_value=frozenset({"CommandCenter"}))
+        client._timestep_to_obs_info(ts)
+        self.assertIn("CommandCenter", client._owned_buildings)
+
+        # Now call reset() itself (not manual field assignment) to verify it
+        # clears both _owned_buildings and _owned_buildings_seen.
+        fake_env = MagicMock()
+        fake_ts = MagicMock()
+        fake_ts.last.return_value = False
+        fake_env.reset.return_value = [fake_ts]
+        client._make_sc2_env = MagicMock(return_value=fake_env)
+        # Stub _timestep_to_obs_info for the reset() call so we only test the
+        # field-clearing side of reset(), not obs flattening.
+        client._timestep_to_obs_info = MagicMock(return_value=(np.zeros(10, dtype=np.float32), {}))
+
+        client.reset()
 
         self.assertEqual(client._owned_buildings, frozenset())
         self.assertEqual(client._owned_buildings_seen, frozenset())
 
     def test_new_buildings_added_each_step(self):
         """Each step's visible buildings are unioned into the accumulator."""
+        from unittest.mock import MagicMock
+
         client = self._make_client()
+        ts = _FakeTimeStep(self._make_fake_obs())
 
-        client._owned_buildings_seen = client._owned_buildings_seen | frozenset({"CommandCenter"})
-        client._owned_buildings = client._owned_buildings_seen
+        # Step 1: CommandCenter visible.
+        client._compute_owned_buildings = MagicMock(return_value=frozenset({"CommandCenter"}))
+        client._timestep_to_obs_info(ts)
 
-        client._owned_buildings_seen = client._owned_buildings_seen | frozenset({"Barracks"})
-        client._owned_buildings = client._owned_buildings_seen
+        # Step 2: Barracks now visible (camera panned to construction site).
+        client._compute_owned_buildings = MagicMock(return_value=frozenset({"Barracks"}))
+        client._timestep_to_obs_info(ts)
 
+        # Both buildings must be in the accumulator.
         self.assertIn("CommandCenter", client._owned_buildings)
         self.assertIn("Barracks", client._owned_buildings)
+
+
+class TestIssue356FnIdxCache(unittest.TestCase):
+    """Regression tests for issue #356 H3: per-step fn_idx_satisfied overhead.
+
+    _compute_available_fn_ids() must skip the fn_idx_satisfied loop when
+    owned_buildings, completed_upgrades, selected_unit_types, and the PySC2
+    candidate set are all unchanged from the previous call.  When any of
+    the four keys changes, the loop must run again.
+    """
+
+    def setUp(self):
+        from games.sc2.client import SC2Client
+
+        self.client = SC2Client(map_name="MoveToBeacon")
+        # Use a fixed race so the candidate set is deterministic (avoids the
+        # _infer_fn_ids_from_units(ob) path which needs a real observation).
+        self.client._agent_race = "terran"
+        # Non-empty lookup enables the tech-tree branch; contents don't matter
+        # because fn_idx_satisfied is patched below.
+        self.client._unit_type_id_to_name = {"1": "SCV"}
+        self.client._available_actions = None  # use the full race candidate set
+
+    def _call(self, patcher):
+        """Call _compute_available_fn_ids with a dummy observation."""
+        return self.client._compute_available_fn_ids(None)
+
+    def test_cache_hit_skips_fn_idx_satisfied(self):
+        """Calling with unchanged state a second time must not invoke
+        fn_idx_satisfied again."""
+        from unittest.mock import patch
+
+        with patch("games.sc2.client.fn_idx_satisfied", return_value=True) as mock_sat:
+            self.client._owned_buildings = frozenset()
+            self.client._completed_upgrades = frozenset()
+            self.client._selected_unit_types = frozenset()
+
+            self.client._compute_available_fn_ids(None)
+            first_call_count = mock_sat.call_count
+            self.assertGreater(first_call_count, 0, "fn_idx_satisfied must be called on first run")
+
+            # Second call with identical state → cache hit → zero new calls.
+            self.client._compute_available_fn_ids(None)
+            self.assertEqual(
+                mock_sat.call_count,
+                first_call_count,
+                "fn_idx_satisfied should not be called on a cache hit",
+            )
+
+    def test_cache_invalidated_when_owned_buildings_changes(self):
+        """Changing owned_buildings must trigger a fresh tech-tree pass."""
+        from unittest.mock import patch
+
+        with patch("games.sc2.client.fn_idx_satisfied", return_value=True) as mock_sat:
+            self.client._owned_buildings = frozenset()
+            self.client._completed_upgrades = frozenset()
+            self.client._selected_unit_types = frozenset()
+
+            self.client._compute_available_fn_ids(None)
+            after_first = mock_sat.call_count
+
+            # Change owned_buildings → cache miss.
+            self.client._owned_buildings = frozenset({"Barracks"})
+            self.client._compute_available_fn_ids(None)
+            self.assertGreater(mock_sat.call_count, after_first)
+
+    def test_cache_invalidated_when_selected_unit_types_changes(self):
+        """Changing selected_unit_types must trigger a fresh tech-tree pass."""
+        from unittest.mock import patch
+
+        with patch("games.sc2.client.fn_idx_satisfied", return_value=True) as mock_sat:
+            self.client._owned_buildings = frozenset()
+            self.client._completed_upgrades = frozenset()
+            self.client._selected_unit_types = frozenset()
+
+            self.client._compute_available_fn_ids(None)
+            after_first = mock_sat.call_count
+
+            self.client._selected_unit_types = frozenset({"Marine"})
+            self.client._compute_available_fn_ids(None)
+            self.assertGreater(mock_sat.call_count, after_first)
+
+    def test_cache_invalidated_when_available_actions_changes(self):
+        """Changing the PySC2 available-actions set (candidate) must trigger a
+        fresh pass even when buildings/upgrades/selection are unchanged."""
+        from unittest.mock import patch
+
+        with patch("games.sc2.client.fn_idx_satisfied", return_value=True) as mock_sat:
+            self.client._owned_buildings = frozenset()
+            self.client._completed_upgrades = frozenset()
+            self.client._selected_unit_types = frozenset()
+
+            # First pass: no PySC2 filter → candidate = full race set.
+            self.client._available_actions = None
+            self.client._compute_available_fn_ids(None)
+            after_first = mock_sat.call_count
+
+            # Shrink the candidate set → cache miss.
+            from games.sc2.actions import fn_ids_for_race
+
+            id_map = __import__("games.sc2.client", fromlist=["_get_pysc2_id_to_fn_idx"])._get_pysc2_id_to_fn_idx()
+            if id_map:
+                # Keep only no_op in the PySC2 available set → tiny candidate.
+                self.client._available_actions = {min(id_map.keys())}
+                self.client._compute_available_fn_ids(None)
+                self.assertGreater(mock_sat.call_count, after_first)
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Three bugs introduced by PR #348 (tech-tree preconditions + deferred-action
queue) caused the SC2 agent to stall indefinitely on ladder maps:

H1 — Infinite select_army oscillation: step() now bypasses _resolve_action()
when consuming a deferred action.  Previously, re-running the resolver on the
replayed action would emit another select_army (always "available" in PySC2
even with an empty army) and re-defer indefinitely, stalling the agent for the
entire episode.

H2 — Buildings vanish on camera move: _owned_buildings is now accumulated via
_owned_buildings_seen so structures that scroll off-screen no longer vanish from
the tech-tree mask and block build/train actions mid-episode.

H3 — Per-step tech-tree CPU overhead: _compute_available_fn_ids() caches its
result and skips the 118-call fn_idx_satisfied() loop when owned_buildings,
completed_upgrades, selected_unit_types, and the PySC2 candidate set are all
unchanged since the previous step.

Adds regression tests for H1 and H2 in test_sc2_client.py.

https://claude.ai/code/session_01XdEKyChHbzjz7hq8BP867J