### PR TITLE
SC2: remove Patrol commands from the action space (issue #359)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+### Changed
+- **SC2: removed the Patrol commands from the action space (issue #359).**
+  `Patrol_screen` and `Patrol_minimap` (the rarely-useful follow/patrol-unit
+  orders) are dropped from `FUNCTION_IDS`, the race fn-id sets, and the
+  tech-tree `PRECONDITIONS` / `RESOURCE_COSTS` tables.  All following fn_ids
+  shift down by 2 to keep the table contiguous (`FUNCTION_IDS` now has 116
+  entries, `0–115`).  Existing SC2 champion weight files migrate via the
+  standard "missing key → 0.0" path; the fn_idx head is now 2 rows smaller.
 
 ---
 

--- a/games/sc2/actions.py
+++ b/games/sc2/actions.py
@@ -86,121 +86,121 @@ FUNCTION_IDS = {
     10: "Train_SCV_quick",
     # --- issue #276 (expanded): full cross-race action coverage ---
     # movement / combat
+    # Patrol_screen / Patrol_minimap were removed in issue #359 (rarely useful);
+    # all following fn_ids shifted down by 2 to keep the table contiguous.
     11: "Move_minimap",
-    12: "Patrol_screen",
-    13: "Patrol_minimap",
-    14: "HoldPosition_quick",
-    15: "Stop_quick",
-    16: "Attack_minimap",
+    12: "HoldPosition_quick",
+    13: "Stop_quick",
+    14: "Attack_minimap",
     # selection / logistics
-    17: "select_rect",
-    18: "Harvest_Return_quick",
-    19: "Rally_Units_screen",
-    20: "Rally_Workers_screen",
-    21: "Rally_Units_minimap",
-    22: "Rally_Workers_minimap",
+    15: "select_rect",
+    16: "Harvest_Return_quick",
+    17: "Rally_Units_screen",
+    18: "Rally_Workers_screen",
+    19: "Rally_Units_minimap",
+    20: "Rally_Workers_minimap",
     # === Terran buildings ===
-    23: "Build_CommandCenter_screen",
-    24: "Build_Refinery_screen",
-    25: "Build_EngineeringBay_screen",
-    26: "Build_Factory_screen",
-    27: "Build_Armory_screen",
-    28: "Build_Bunker_screen",
-    29: "Build_MissileTurret_screen",
-    30: "Build_Starport_screen",
-    31: "Build_GhostAcademy_screen",
-    32: "Build_FusionCore_screen",
-    33: "Build_TechLab_quick",
-    34: "Build_Reactor_quick",
+    21: "Build_CommandCenter_screen",
+    22: "Build_Refinery_screen",
+    23: "Build_EngineeringBay_screen",
+    24: "Build_Factory_screen",
+    25: "Build_Armory_screen",
+    26: "Build_Bunker_screen",
+    27: "Build_MissileTurret_screen",
+    28: "Build_Starport_screen",
+    29: "Build_GhostAcademy_screen",
+    30: "Build_FusionCore_screen",
+    31: "Build_TechLab_quick",
+    32: "Build_Reactor_quick",
     # === Terran training ===
-    35: "Train_Marauder_quick",
-    36: "Train_Ghost_quick",
-    37: "Train_Hellion_quick",
-    38: "Train_SiegeTank_quick",
-    39: "Train_Medivac_quick",
-    40: "Train_Viking_quick",
-    41: "Train_Raven_quick",
-    42: "Train_Banshee_quick",
-    43: "Train_Battlecruiser_quick",
-    44: "Train_Cyclone_quick",
-    45: "Train_Thor_quick",
-    46: "Train_Liberator_quick",
+    33: "Train_Marauder_quick",
+    34: "Train_Ghost_quick",
+    35: "Train_Hellion_quick",
+    36: "Train_SiegeTank_quick",
+    37: "Train_Medivac_quick",
+    38: "Train_Viking_quick",
+    39: "Train_Raven_quick",
+    40: "Train_Banshee_quick",
+    41: "Train_Battlecruiser_quick",
+    42: "Train_Cyclone_quick",
+    43: "Train_Thor_quick",
+    44: "Train_Liberator_quick",
     # === Terran unit abilities ===
-    47: "Effect_Stim_quick",
-    48: "Morph_SiegeMode_quick",
-    49: "Morph_Unsiege_quick",
+    45: "Effect_Stim_quick",
+    46: "Morph_SiegeMode_quick",
+    47: "Morph_Unsiege_quick",
     # === Protoss buildings ===
-    50: "Build_Nexus_screen",
-    51: "Build_Pylon_screen",
-    52: "Build_Gateway_screen",
-    53: "Build_Assimilator_screen",
-    54: "Build_CyberneticsCore_screen",
-    55: "Build_Forge_screen",
-    56: "Build_PhotonCannon_screen",
-    57: "Build_RoboticsFacility_screen",
-    58: "Build_Stargate_screen",
-    59: "Build_TwilightCouncil_screen",
-    60: "Build_TemplarArchive_screen",
-    61: "Build_DarkShrine_screen",
-    62: "Build_RoboticsBay_screen",
-    63: "Build_FleetBeacon_screen",
-    64: "Build_ShieldBattery_screen",
+    48: "Build_Nexus_screen",
+    49: "Build_Pylon_screen",
+    50: "Build_Gateway_screen",
+    51: "Build_Assimilator_screen",
+    52: "Build_CyberneticsCore_screen",
+    53: "Build_Forge_screen",
+    54: "Build_PhotonCannon_screen",
+    55: "Build_RoboticsFacility_screen",
+    56: "Build_Stargate_screen",
+    57: "Build_TwilightCouncil_screen",
+    58: "Build_TemplarArchive_screen",
+    59: "Build_DarkShrine_screen",
+    60: "Build_RoboticsBay_screen",
+    61: "Build_FleetBeacon_screen",
+    62: "Build_ShieldBattery_screen",
     # === Protoss training / morphs ===
-    65: "Train_Probe_quick",
-    66: "Train_Zealot_quick",
-    67: "Train_Stalker_quick",
-    68: "Train_Adept_quick",
-    69: "Train_HighTemplar_quick",
-    70: "Train_DarkTemplar_quick",
-    71: "Train_Sentry_quick",
-    72: "Train_Phoenix_quick",
-    73: "Train_Carrier_quick",
-    74: "Train_VoidRay_quick",
-    75: "Train_Oracle_quick",
-    76: "Train_Colossus_quick",
-    77: "Train_Immortal_quick",
-    78: "Train_Tempest_quick",
-    79: "Train_Disruptor_quick",
-    80: "Morph_Archon_quick",
-    81: "Train_Mothership_quick",
+    63: "Train_Probe_quick",
+    64: "Train_Zealot_quick",
+    65: "Train_Stalker_quick",
+    66: "Train_Adept_quick",
+    67: "Train_HighTemplar_quick",
+    68: "Train_DarkTemplar_quick",
+    69: "Train_Sentry_quick",
+    70: "Train_Phoenix_quick",
+    71: "Train_Carrier_quick",
+    72: "Train_VoidRay_quick",
+    73: "Train_Oracle_quick",
+    74: "Train_Colossus_quick",
+    75: "Train_Immortal_quick",
+    76: "Train_Tempest_quick",
+    77: "Train_Disruptor_quick",
+    78: "Morph_Archon_quick",
+    79: "Train_Mothership_quick",
     # === Zerg buildings ===
-    82: "Build_Hatchery_screen",
-    83: "Build_SpawningPool_screen",
-    84: "Build_Extractor_screen",
-    85: "Build_EvolutionChamber_screen",
-    86: "Build_HydraliskDen_screen",
-    87: "Build_BanelingNest_screen",
-    88: "Build_RoachWarren_screen",
-    89: "Build_Spire_screen",
-    90: "Build_InfestationPit_screen",
-    91: "Build_UltraliskCavern_screen",
-    92: "Build_CreepTumor_screen",
-    93: "Build_SpineCrawler_screen",
-    94: "Build_SporeCrawler_screen",
-    95: "Build_NydusNetwork_screen",
-    96: "Build_LurkerDen_screen",
+    80: "Build_Hatchery_screen",
+    81: "Build_SpawningPool_screen",
+    82: "Build_Extractor_screen",
+    83: "Build_EvolutionChamber_screen",
+    84: "Build_HydraliskDen_screen",
+    85: "Build_BanelingNest_screen",
+    86: "Build_RoachWarren_screen",
+    87: "Build_Spire_screen",
+    88: "Build_InfestationPit_screen",
+    89: "Build_UltraliskCavern_screen",
+    90: "Build_CreepTumor_screen",
+    91: "Build_SpineCrawler_screen",
+    92: "Build_SporeCrawler_screen",
+    93: "Build_NydusNetwork_screen",
+    94: "Build_LurkerDen_screen",
     # === Zerg training / morphs ===
-    97: "Train_Drone_quick",
-    98: "Train_Overlord_quick",
-    99: "Train_Zergling_quick",
-    100: "Train_Baneling_quick",
-    101: "Train_Roach_quick",
-    102: "Train_Ravager_quick",
-    103: "Train_Hydralisk_quick",
-    104: "Train_Infestor_quick",
-    105: "Train_SwarmHost_quick",
-    106: "Train_Mutalisk_quick",
-    107: "Train_Corruptor_quick",
-    108: "Train_BroodLord_quick",
-    109: "Train_Viper_quick",
-    110: "Train_Ultralisk_quick",
-    111: "Train_Lurker_quick",
-    112: "Train_Queen_quick",
-    113: "Morph_Lair_quick",
-    114: "Morph_Hive_quick",
-    115: "Morph_Overseer_quick",
-    116: "Morph_GreaterSpire_quick",
-    117: "Morph_BroodLord_quick",
+    95: "Train_Drone_quick",
+    96: "Train_Overlord_quick",
+    97: "Train_Zergling_quick",
+    98: "Train_Baneling_quick",
+    99: "Train_Roach_quick",
+    100: "Train_Ravager_quick",
+    101: "Train_Hydralisk_quick",
+    102: "Train_Infestor_quick",
+    103: "Train_SwarmHost_quick",
+    104: "Train_Mutalisk_quick",
+    105: "Train_Corruptor_quick",
+    106: "Train_BroodLord_quick",
+    107: "Train_Viper_quick",
+    108: "Train_Ultralisk_quick",
+    109: "Train_Lurker_quick",
+    110: "Train_Queen_quick",
+    111: "Morph_Lair_quick",
+    112: "Morph_Hive_quick",
+    113: "Morph_Overseer_quick",
+    114: "Morph_GreaterSpire_quick",
+    115: "Morph_BroodLord_quick",
 }
 
 # ---------------------------------------------------------------------------
@@ -231,17 +231,15 @@ _UNIVERSAL_FN_IDS: frozenset[int] = frozenset(
         5,  # Harvest_Gather_screen
         6,  # select_point
         11,  # Move_minimap
-        12,  # Patrol_screen
-        13,  # Patrol_minimap
-        14,  # HoldPosition_quick
-        15,  # Stop_quick
-        16,  # Attack_minimap
-        17,  # select_rect
-        18,  # Harvest_Return_quick
-        19,  # Rally_Units_screen
-        20,  # Rally_Workers_screen
-        21,  # Rally_Units_minimap
-        22,  # Rally_Workers_minimap
+        12,  # HoldPosition_quick
+        13,  # Stop_quick
+        14,  # Attack_minimap
+        15,  # select_rect
+        16,  # Harvest_Return_quick
+        17,  # Rally_Units_screen
+        18,  # Rally_Workers_screen
+        19,  # Rally_Units_minimap
+        20,  # Rally_Workers_minimap
     }
 )
 
@@ -251,111 +249,111 @@ _TERRAN_FN_IDS: frozenset[int] = frozenset(
         8,
         9,
         10,  # Train_Marine, Build_Barracks, Build_SupplyDepot, Train_SCV
+        21,
+        22,
         23,
         24,
-        25,
+        25,  # CommandCenter, Refinery, EngineeringBay, Factory, Armory
         26,
-        27,  # CommandCenter, Refinery, EngineeringBay, Factory, Armory
+        27,
         28,
         29,
-        30,
+        30,  # Bunker, MissileTurret, Starport, GhostAcademy, FusionCore
         31,
-        32,  # Bunker, MissileTurret, Starport, GhostAcademy, FusionCore
+        32,  # TechLab_quick, Reactor_quick
         33,
-        34,  # TechLab_quick, Reactor_quick
+        34,
         35,
         36,
-        37,
+        37,  # Marauder, Ghost, Hellion, SiegeTank, Medivac
         38,
-        39,  # Marauder, Ghost, Hellion, SiegeTank, Medivac
+        39,
         40,
         41,
-        42,
+        42,  # Viking, Raven, Banshee, Battlecruiser, Cyclone
         43,
-        44,  # Viking, Raven, Banshee, Battlecruiser, Cyclone
+        44,  # Thor, Liberator
         45,
-        46,  # Thor, Liberator
-        47,
-        48,
-        49,  # Stim, SiegeMode, Unsiege
+        46,
+        47,  # Stim, SiegeMode, Unsiege
     }
 )
 
 _PROTOSS_FN_IDS: frozenset[int] = frozenset(
     {
+        48,
+        49,
         50,
         51,
-        52,
+        52,  # Nexus, Pylon, Gateway, Assimilator, CyberneticsCore
         53,
-        54,  # Nexus, Pylon, Gateway, Assimilator, CyberneticsCore
+        54,
         55,
         56,
-        57,
+        57,  # Forge, PhotonCannon, RoboticsFacility, Stargate, TwilightCouncil
         58,
-        59,  # Forge, PhotonCannon, RoboticsFacility, Stargate, TwilightCouncil
+        59,
         60,
         61,
-        62,
+        62,  # TemplarArchive, DarkShrine, RoboticsBay, FleetBeacon, ShieldBattery
         63,
-        64,  # TemplarArchive, DarkShrine, RoboticsBay, FleetBeacon, ShieldBattery
+        64,
         65,
         66,
-        67,
+        67,  # Probe, Zealot, Stalker, Adept, HighTemplar
         68,
-        69,  # Probe, Zealot, Stalker, Adept, HighTemplar
+        69,
         70,
         71,
-        72,
+        72,  # DarkTemplar, Sentry, Phoenix, Carrier, VoidRay
         73,
-        74,  # DarkTemplar, Sentry, Phoenix, Carrier, VoidRay
+        74,
         75,
         76,
-        77,
+        77,  # Oracle, Colossus, Immortal, Tempest, Disruptor
         78,
-        79,  # Oracle, Colossus, Immortal, Tempest, Disruptor
-        80,
-        81,  # Morph_Archon, Mothership
+        79,  # Morph_Archon, Mothership
     }
 )
 
 _ZERG_FN_IDS: frozenset[int] = frozenset(
     {
+        80,
+        81,
         82,
         83,
-        84,
+        84,  # Hatchery, SpawningPool, Extractor, EvolutionChamber, HydraliskDen
         85,
-        86,  # Hatchery, SpawningPool, Extractor, EvolutionChamber, HydraliskDen
+        86,
         87,
         88,
-        89,
+        89,  # BanelingNest, RoachWarren, Spire, InfestationPit, UltraliskCavern
         90,
-        91,  # BanelingNest, RoachWarren, Spire, InfestationPit, UltraliskCavern
+        91,
         92,
         93,
-        94,
+        94,  # CreepTumor, SpineCrawler, SporeCrawler, NydusNetwork, LurkerDen
         95,
-        96,  # CreepTumor, SpineCrawler, SporeCrawler, NydusNetwork, LurkerDen
+        96,
         97,
         98,
-        99,
+        99,  # Drone, Overlord, Zergling, Baneling, Roach
         100,
-        101,  # Drone, Overlord, Zergling, Baneling, Roach
+        101,
         102,
-        103,
+        103,  # Ravager, Hydralisk, Infestor, SwarmHost
         104,
-        105,  # Ravager, Hydralisk, Infestor, SwarmHost
+        105,
         106,
-        107,
+        107,  # Mutalisk, Corruptor, BroodLord, Viper
         108,
-        109,  # Mutalisk, Corruptor, BroodLord, Viper
-        110,
+        109,
+        110,  # Ultralisk, Lurker, Queen
         111,
-        112,  # Ultralisk, Lurker, Queen
+        112,
         113,
         114,
-        115,
-        116,
-        117,  # Morph_Lair, Hive, Overseer, GreaterSpire, BroodLord
+        115,  # Morph_Lair, Hive, Overseer, GreaterSpire, BroodLord
     }
 )
 
@@ -550,6 +548,6 @@ def action_to_function_call(action: np.ndarray, screen_size: int, minimap_size: 
         # queued flag — no spatial target.
         return actions.FunctionCall(fn_id, [[queue]])
     # Default: spatial actions with [queued, target_screen/minimap].
-    # Covers Move_screen/minimap, Attack_screen/minimap, Patrol_screen/minimap,
+    # Covers Move_screen/minimap, Attack_screen/minimap,
     # Harvest_Gather_screen, all Build_*_screen, Rally_*_screen/minimap, etc.
     return actions.FunctionCall(fn_id, [[queue], [sx, sy]])

--- a/games/sc2/client.py
+++ b/games/sc2/client.py
@@ -352,7 +352,7 @@ class SC2Client:
         # Current resource counts cached from the latest timestep (issue #357).
         self._minerals: float = 0.0
         self._vespene: float = 0.0
-        # Cache for _compute_available_fn_ids() — skip the 118-call tech-tree
+        # Cache for _compute_available_fn_ids() — skip the per-fn_idx tech-tree
         # loop when owned_buildings / completed_upgrades / selected_unit_types
         # and the candidate set are all unchanged since last step (issue #356 H3).
         self._fn_ids_cache_keys: tuple | None = None

--- a/games/sc2/tech_tree.py
+++ b/games/sc2/tech_tree.py
@@ -332,7 +332,7 @@ STRUCTURE_NAMES: frozenset[str] = frozenset(
 # Per-fn_idx Preconditions table.
 # ---------------------------------------------------------------------------
 # One Preconditions record per fn_idx in games.sc2.actions.FUNCTION_IDS.
-# Universal actions (no_op, select_*, Move/Attack, Stop, Patrol,
+# Universal actions (no_op, select_*, Move/Attack, Stop,
 # HoldPosition, Rally_*_minimap, ...) have empty preconditions and
 # require no specific selection — they're handled by the surrounding
 # logic in SC2Client (warmup, selection presence, ...).
@@ -411,7 +411,7 @@ def _effect_on(units: frozenset[str], upgrades: frozenset[str] = frozenset()) ->
 
 
 def _any() -> Preconditions:
-    """Move/Attack/Stop/Patrol/Hold helper: any unit selected."""
+    """Move/Attack/Stop/Hold helper: any unit selected."""
     return Preconditions(required_selection=SelectionReq.ANY_UNIT)
 
 
@@ -436,132 +436,130 @@ PRECONDITIONS: dict[int, Preconditions] = {
     10: _train("SCV"),  # Train_SCV_quick
     # movement / combat
     11: _any(),  # Move_minimap
-    12: _any(),  # Patrol_screen
-    13: _any(),  # Patrol_minimap
-    14: _any(),  # HoldPosition_quick
-    15: _any(),  # Stop_quick
-    16: _any(),  # Attack_minimap
+    12: _any(),  # HoldPosition_quick
+    13: _any(),  # Stop_quick
+    14: _any(),  # Attack_minimap
     # selection / logistics
-    17: _none(),  # select_rect
-    18: _effect_on(_BUILDER_PROBES),  # Harvest_Return_quick
-    19: _any(),  # Rally_Units_screen
-    20: _any(),  # Rally_Workers_screen
-    21: _any(),  # Rally_Units_minimap
-    22: _any(),  # Rally_Workers_minimap
+    15: _none(),  # select_rect
+    16: _effect_on(_BUILDER_PROBES),  # Harvest_Return_quick
+    17: _any(),  # Rally_Units_screen
+    18: _any(),  # Rally_Workers_screen
+    19: _any(),  # Rally_Units_minimap
+    20: _any(),  # Rally_Workers_minimap
     # Terran buildings
-    23: _build("CommandCenter"),
-    24: _build("Refinery"),
-    25: _build("EngineeringBay"),
-    26: _build("Factory"),
-    27: _build("Armory"),
-    28: _build("Bunker"),
-    29: _build("MissileTurret"),
-    30: _build("Starport"),
-    31: _build("GhostAcademy"),
-    32: _build("FusionCore"),
-    33: _addon(frozenset({"Barracks", "Factory", "Starport"})),  # Build_TechLab_quick
-    34: _addon(frozenset({"Barracks", "Factory", "Starport"})),  # Build_Reactor_quick
+    21: _build("CommandCenter"),
+    22: _build("Refinery"),
+    23: _build("EngineeringBay"),
+    24: _build("Factory"),
+    25: _build("Armory"),
+    26: _build("Bunker"),
+    27: _build("MissileTurret"),
+    28: _build("Starport"),
+    29: _build("GhostAcademy"),
+    30: _build("FusionCore"),
+    31: _addon(frozenset({"Barracks", "Factory", "Starport"})),  # Build_TechLab_quick
+    32: _addon(frozenset({"Barracks", "Factory", "Starport"})),  # Build_Reactor_quick
     # Terran training
-    35: _train("Marauder", extra_buildings=_and("BarracksTechLab")),
-    36: _train("Ghost", extra_buildings=_and("BarracksTechLab", "GhostAcademy")),
-    37: _train("Hellion"),
-    38: _train("SiegeTank", extra_buildings=_and("FactoryTechLab")),
-    39: _train("Medivac"),
-    40: _train("Viking"),
-    41: _train("Raven", extra_buildings=_and("StarportTechLab")),
-    42: _train("Banshee", extra_buildings=_and("StarportTechLab")),
-    43: _train("Battlecruiser", extra_buildings=_and("StarportTechLab", "FusionCore")),
-    44: _train("Cyclone", extra_buildings=_and("FactoryTechLab")),
-    45: _train("Thor", extra_buildings=_and("FactoryTechLab", "Armory")),
-    46: _train("Liberator"),
+    33: _train("Marauder", extra_buildings=_and("BarracksTechLab")),
+    34: _train("Ghost", extra_buildings=_and("BarracksTechLab", "GhostAcademy")),
+    35: _train("Hellion"),
+    36: _train("SiegeTank", extra_buildings=_and("FactoryTechLab")),
+    37: _train("Medivac"),
+    38: _train("Viking"),
+    39: _train("Raven", extra_buildings=_and("StarportTechLab")),
+    40: _train("Banshee", extra_buildings=_and("StarportTechLab")),
+    41: _train("Battlecruiser", extra_buildings=_and("StarportTechLab", "FusionCore")),
+    42: _train("Cyclone", extra_buildings=_and("FactoryTechLab")),
+    43: _train("Thor", extra_buildings=_and("FactoryTechLab", "Armory")),
+    44: _train("Liberator"),
     # Terran unit abilities
-    47: _effect_on(_ATTACK_INFANTRY, upgrades=frozenset({"Stimpack"})),  # Effect_Stim_quick
+    45: _effect_on(_ATTACK_INFANTRY, upgrades=frozenset({"Stimpack"})),  # Effect_Stim_quick
     # Morph_SiegeMode_quick — SiegeTank → SiegeTankSieged (FactoryTechLab gates it).
-    48: _train("SiegeTankSieged", extra_buildings=_and("FactoryTechLab")),
+    46: _train("SiegeTankSieged", extra_buildings=_and("FactoryTechLab")),
     # Morph_Unsiege_quick — in-place morph of an already-sieged tank.  Kept on
     # _morph_inplace because the "produced" SiegeTank entry in UNIT_PRODUCERS
     # is the Factory-built one, and we want the selection target to be
     # SiegeTankSieged here.
-    49: _morph_inplace("SiegeTankSieged"),
+    47: _morph_inplace("SiegeTankSieged"),
     # Protoss buildings
-    50: _build("Nexus"),
-    51: _build("Pylon"),
-    52: _build("Gateway"),
-    53: _build("Assimilator"),
-    54: _build("CyberneticsCore"),
-    55: _build("Forge"),
-    56: _build("PhotonCannon"),
-    57: _build("RoboticsFacility"),
-    58: _build("Stargate"),
-    59: _build("TwilightCouncil"),
-    60: _build("TemplarArchive"),
-    61: _build("DarkShrine"),
-    62: _build("RoboticsBay"),
-    63: _build("FleetBeacon"),
-    64: _build("ShieldBattery"),
+    48: _build("Nexus"),
+    49: _build("Pylon"),
+    50: _build("Gateway"),
+    51: _build("Assimilator"),
+    52: _build("CyberneticsCore"),
+    53: _build("Forge"),
+    54: _build("PhotonCannon"),
+    55: _build("RoboticsFacility"),
+    56: _build("Stargate"),
+    57: _build("TwilightCouncil"),
+    58: _build("TemplarArchive"),
+    59: _build("DarkShrine"),
+    60: _build("RoboticsBay"),
+    61: _build("FleetBeacon"),
+    62: _build("ShieldBattery"),
     # Protoss training / morphs
-    65: _train("Probe"),
-    66: _train("Zealot"),
-    67: _train("Stalker", extra_buildings=_and("CyberneticsCore")),
-    68: _train("Adept", extra_buildings=_and("CyberneticsCore")),
-    69: _train("HighTemplar", extra_buildings=_and("TemplarArchive")),
-    70: _train("DarkTemplar", extra_buildings=_and("DarkShrine")),
-    71: _train("Sentry", extra_buildings=_and("CyberneticsCore")),
-    72: _train("Phoenix"),
-    73: _train("Carrier", extra_buildings=_and("FleetBeacon")),
-    74: _train("VoidRay"),
-    75: _train("Oracle"),
-    76: _train("Colossus", extra_buildings=_and("RoboticsBay")),
-    77: _train("Immortal"),
-    78: _train("Tempest", extra_buildings=_and("FleetBeacon")),
-    79: _train("Disruptor", extra_buildings=_and("RoboticsBay")),
+    63: _train("Probe"),
+    64: _train("Zealot"),
+    65: _train("Stalker", extra_buildings=_and("CyberneticsCore")),
+    66: _train("Adept", extra_buildings=_and("CyberneticsCore")),
+    67: _train("HighTemplar", extra_buildings=_and("TemplarArchive")),
+    68: _train("DarkTemplar", extra_buildings=_and("DarkShrine")),
+    69: _train("Sentry", extra_buildings=_and("CyberneticsCore")),
+    70: _train("Phoenix"),
+    71: _train("Carrier", extra_buildings=_and("FleetBeacon")),
+    72: _train("VoidRay"),
+    73: _train("Oracle"),
+    74: _train("Colossus", extra_buildings=_and("RoboticsBay")),
+    75: _train("Immortal"),
+    76: _train("Tempest", extra_buildings=_and("FleetBeacon")),
+    77: _train("Disruptor", extra_buildings=_and("RoboticsBay")),
     # Morph_Archon_quick — needs two HighTemplars OR two DarkTemplars.  The
     # selection-type filter only checks the right *type* is selected; the
     # quantity check (≥ 2 templars) is enforced by PySC2 at execution time.
-    80: _train("Archon", extra_buildings=_and("TemplarArchive")),
-    81: _train("Mothership", extra_buildings=_and("FleetBeacon")),
+    78: _train("Archon", extra_buildings=_and("TemplarArchive")),
+    79: _train("Mothership", extra_buildings=_and("FleetBeacon")),
     # Zerg buildings
-    82: _build("Hatchery"),
-    83: _build("SpawningPool"),
-    84: _build("Extractor"),
-    85: _build("EvolutionChamber"),
-    86: _build("HydraliskDen"),
-    87: _build("BanelingNest"),
-    88: _build("RoachWarren"),
-    89: _build("Spire"),
-    90: _build("InfestationPit"),
-    91: _build("UltraliskCavern"),
-    92: Preconditions(  # Build_CreepTumor_screen — Queen ability, not Drone build.
+    80: _build("Hatchery"),
+    81: _build("SpawningPool"),
+    82: _build("Extractor"),
+    83: _build("EvolutionChamber"),
+    84: _build("HydraliskDen"),
+    85: _build("BanelingNest"),
+    86: _build("RoachWarren"),
+    87: _build("Spire"),
+    88: _build("InfestationPit"),
+    89: _build("UltraliskCavern"),
+    90: Preconditions(  # Build_CreepTumor_screen — Queen ability, not Drone build.
         required_selection=SelectionReq.OF_TYPE,
         selection_target=frozenset({"Queen", "CreepTumorBurrowed"}),
     ),
-    93: _build("SpineCrawler"),
-    94: _build("SporeCrawler"),
-    95: _build("NydusNetwork"),
-    96: _build("LurkerDenMP"),
+    91: _build("SpineCrawler"),
+    92: _build("SporeCrawler"),
+    93: _build("NydusNetwork"),
+    94: _build("LurkerDenMP"),
     # Zerg training / morphs
-    97: _train("Drone"),
-    98: _train("Overlord"),
-    99: _train("Zergling", extra_buildings=_and("SpawningPool")),
-    100: _train("Baneling", extra_buildings=_and("BanelingNest")),  # Train_Baneling_quick
-    101: _train("Roach", extra_buildings=_and("RoachWarren")),
-    102: _train("Ravager", extra_buildings=_and("RoachWarren")),  # Train_Ravager_quick
-    103: _train("Hydralisk", extra_buildings=_and("HydraliskDen")),
-    104: _train("Infestor", extra_buildings=_and("InfestationPit")),
-    105: _train("SwarmHost", extra_buildings=_and("InfestationPit")),
-    106: _train("Mutalisk", extra_buildings=_and("Spire")),
-    107: _train("Corruptor", extra_buildings=_and("Spire")),
-    108: _train("BroodLord", extra_buildings=_and("GreaterSpire")),  # Train_BroodLord_quick
-    109: _train("Viper", extra_buildings=_and("Hive")),
-    110: _train("Ultralisk", extra_buildings=_and("UltraliskCavern")),
-    111: _train("Lurker", extra_buildings=_and("LurkerDenMP")),  # Train_Lurker_quick
-    112: _train("Queen", extra_buildings=_and("SpawningPool")),
-    113: _train("Lair", extra_buildings=_and("SpawningPool")),  # Morph_Lair
-    114: _train("Hive", extra_buildings=_and("InfestationPit")),  # Morph_Hive
+    95: _train("Drone"),
+    96: _train("Overlord"),
+    97: _train("Zergling", extra_buildings=_and("SpawningPool")),
+    98: _train("Baneling", extra_buildings=_and("BanelingNest")),  # Train_Baneling_quick
+    99: _train("Roach", extra_buildings=_and("RoachWarren")),
+    100: _train("Ravager", extra_buildings=_and("RoachWarren")),  # Train_Ravager_quick
+    101: _train("Hydralisk", extra_buildings=_and("HydraliskDen")),
+    102: _train("Infestor", extra_buildings=_and("InfestationPit")),
+    103: _train("SwarmHost", extra_buildings=_and("InfestationPit")),
+    104: _train("Mutalisk", extra_buildings=_and("Spire")),
+    105: _train("Corruptor", extra_buildings=_and("Spire")),
+    106: _train("BroodLord", extra_buildings=_and("GreaterSpire")),  # Train_BroodLord_quick
+    107: _train("Viper", extra_buildings=_and("Hive")),
+    108: _train("Ultralisk", extra_buildings=_and("UltraliskCavern")),
+    109: _train("Lurker", extra_buildings=_and("LurkerDenMP")),  # Train_Lurker_quick
+    110: _train("Queen", extra_buildings=_and("SpawningPool")),
+    111: _train("Lair", extra_buildings=_and("SpawningPool")),  # Morph_Lair
+    112: _train("Hive", extra_buildings=_and("InfestationPit")),  # Morph_Hive
     # Morph_Overseer — Overlord → Overseer; requires Lair (or Hive).
-    115: _train("Overseer", extra_buildings=(frozenset({"Lair", "Hive"}),)),
-    116: _train("GreaterSpire", extra_buildings=_and("Hive")),  # Morph_GreaterSpire
-    117: _train("BroodLord", extra_buildings=_and("GreaterSpire")),  # Morph_BroodLord
+    113: _train("Overseer", extra_buildings=(frozenset({"Lair", "Hive"}),)),
+    114: _train("GreaterSpire", extra_buildings=_and("Hive")),  # Morph_GreaterSpire
+    115: _train("BroodLord", extra_buildings=_and("GreaterSpire")),  # Morph_BroodLord
 }
 
 
@@ -580,103 +578,103 @@ RESOURCE_COSTS: dict[int, tuple[int, int]] = {
     # --- Terran buildings ---
     8: (150, 0),  # Build_Barracks_screen
     9: (100, 0),  # Build_SupplyDepot_screen
-    23: (400, 0),  # Build_CommandCenter_screen
-    24: (75, 0),  # Build_Refinery_screen
-    25: (125, 0),  # Build_EngineeringBay_screen
-    26: (150, 100),  # Build_Factory_screen
-    27: (150, 100),  # Build_Armory_screen
-    28: (100, 0),  # Build_Bunker_screen
-    29: (100, 0),  # Build_MissileTurret_screen
-    30: (150, 100),  # Build_Starport_screen
-    31: (150, 50),  # Build_GhostAcademy_screen
-    32: (150, 150),  # Build_FusionCore_screen
-    33: (50, 25),  # Build_TechLab_quick
-    34: (50, 50),  # Build_Reactor_quick
+    21: (400, 0),  # Build_CommandCenter_screen
+    22: (75, 0),  # Build_Refinery_screen
+    23: (125, 0),  # Build_EngineeringBay_screen
+    24: (150, 100),  # Build_Factory_screen
+    25: (150, 100),  # Build_Armory_screen
+    26: (100, 0),  # Build_Bunker_screen
+    27: (100, 0),  # Build_MissileTurret_screen
+    28: (150, 100),  # Build_Starport_screen
+    29: (150, 50),  # Build_GhostAcademy_screen
+    30: (150, 150),  # Build_FusionCore_screen
+    31: (50, 25),  # Build_TechLab_quick
+    32: (50, 50),  # Build_Reactor_quick
     # --- Terran units ---
     7: (50, 0),  # Train_Marine_quick
     10: (50, 0),  # Train_SCV_quick
-    35: (100, 25),  # Train_Marauder_quick
-    36: (150, 125),  # Train_Ghost_quick
-    37: (100, 0),  # Train_Hellion_quick
-    38: (150, 125),  # Train_SiegeTank_quick
-    39: (100, 100),  # Train_Medivac_quick
-    40: (150, 75),  # Train_Viking_quick
-    41: (100, 200),  # Train_Raven_quick
-    42: (150, 100),  # Train_Banshee_quick
-    43: (400, 300),  # Train_Battlecruiser_quick
-    44: (150, 100),  # Train_Cyclone_quick
-    45: (300, 200),  # Train_Thor_quick
-    46: (150, 150),  # Train_Liberator_quick
+    33: (100, 25),  # Train_Marauder_quick
+    34: (150, 125),  # Train_Ghost_quick
+    35: (100, 0),  # Train_Hellion_quick
+    36: (150, 125),  # Train_SiegeTank_quick
+    37: (100, 100),  # Train_Medivac_quick
+    38: (150, 75),  # Train_Viking_quick
+    39: (100, 200),  # Train_Raven_quick
+    40: (150, 100),  # Train_Banshee_quick
+    41: (400, 300),  # Train_Battlecruiser_quick
+    42: (150, 100),  # Train_Cyclone_quick
+    43: (300, 200),  # Train_Thor_quick
+    44: (150, 150),  # Train_Liberator_quick
     # --- Protoss buildings ---
-    50: (400, 0),  # Build_Nexus_screen
-    51: (100, 0),  # Build_Pylon_screen
-    52: (150, 0),  # Build_Gateway_screen
-    53: (75, 0),  # Build_Assimilator_screen
-    54: (150, 0),  # Build_CyberneticsCore_screen
-    55: (150, 0),  # Build_Forge_screen
-    56: (150, 0),  # Build_PhotonCannon_screen
-    57: (150, 100),  # Build_RoboticsFacility_screen
-    58: (150, 150),  # Build_Stargate_screen
-    59: (150, 100),  # Build_TwilightCouncil_screen
-    60: (150, 200),  # Build_TemplarArchive_screen
-    61: (150, 150),  # Build_DarkShrine_screen
-    62: (150, 150),  # Build_RoboticsBay_screen
-    63: (300, 200),  # Build_FleetBeacon_screen
-    64: (100, 0),  # Build_ShieldBattery_screen
+    48: (400, 0),  # Build_Nexus_screen
+    49: (100, 0),  # Build_Pylon_screen
+    50: (150, 0),  # Build_Gateway_screen
+    51: (75, 0),  # Build_Assimilator_screen
+    52: (150, 0),  # Build_CyberneticsCore_screen
+    53: (150, 0),  # Build_Forge_screen
+    54: (150, 0),  # Build_PhotonCannon_screen
+    55: (150, 100),  # Build_RoboticsFacility_screen
+    56: (150, 150),  # Build_Stargate_screen
+    57: (150, 100),  # Build_TwilightCouncil_screen
+    58: (150, 200),  # Build_TemplarArchive_screen
+    59: (150, 150),  # Build_DarkShrine_screen
+    60: (150, 150),  # Build_RoboticsBay_screen
+    61: (300, 200),  # Build_FleetBeacon_screen
+    62: (100, 0),  # Build_ShieldBattery_screen
     # --- Protoss units ---
-    65: (50, 0),  # Train_Probe_quick
-    66: (100, 0),  # Train_Zealot_quick
-    67: (125, 50),  # Train_Stalker_quick
-    68: (100, 25),  # Train_Adept_quick
-    69: (50, 150),  # Train_HighTemplar_quick
-    70: (125, 125),  # Train_DarkTemplar_quick
-    71: (50, 100),  # Train_Sentry_quick
-    72: (150, 100),  # Train_Phoenix_quick
-    73: (350, 250),  # Train_Carrier_quick
-    74: (250, 150),  # Train_VoidRay_quick
-    75: (150, 150),  # Train_Oracle_quick
-    76: (300, 200),  # Train_Colossus_quick
-    77: (275, 100),  # Train_Immortal_quick
-    78: (250, 175),  # Train_Tempest_quick
-    79: (150, 150),  # Train_Disruptor_quick
-    81: (400, 400),  # Train_Mothership_quick
+    63: (50, 0),  # Train_Probe_quick
+    64: (100, 0),  # Train_Zealot_quick
+    65: (125, 50),  # Train_Stalker_quick
+    66: (100, 25),  # Train_Adept_quick
+    67: (50, 150),  # Train_HighTemplar_quick
+    68: (125, 125),  # Train_DarkTemplar_quick
+    69: (50, 100),  # Train_Sentry_quick
+    70: (150, 100),  # Train_Phoenix_quick
+    71: (350, 250),  # Train_Carrier_quick
+    72: (250, 150),  # Train_VoidRay_quick
+    73: (150, 150),  # Train_Oracle_quick
+    74: (300, 200),  # Train_Colossus_quick
+    75: (275, 100),  # Train_Immortal_quick
+    76: (250, 175),  # Train_Tempest_quick
+    77: (150, 150),  # Train_Disruptor_quick
+    79: (400, 400),  # Train_Mothership_quick
     # --- Zerg buildings ---
-    82: (300, 0),  # Build_Hatchery_screen
-    83: (200, 0),  # Build_SpawningPool_screen
-    84: (25, 0),  # Build_Extractor_screen
-    85: (75, 0),  # Build_EvolutionChamber_screen
-    86: (100, 100),  # Build_HydraliskDen_screen
-    87: (100, 50),  # Build_BanelingNest_screen
-    88: (150, 0),  # Build_RoachWarren_screen
-    89: (200, 200),  # Build_Spire_screen
-    90: (100, 100),  # Build_InfestationPit_screen
-    91: (150, 200),  # Build_UltraliskCavern_screen
-    93: (100, 0),  # Build_SpineCrawler_screen
-    94: (75, 0),  # Build_SporeCrawler_screen
-    95: (150, 200),  # Build_NydusNetwork_screen
-    96: (100, 150),  # Build_LurkerDen_screen
+    80: (300, 0),  # Build_Hatchery_screen
+    81: (200, 0),  # Build_SpawningPool_screen
+    82: (25, 0),  # Build_Extractor_screen
+    83: (75, 0),  # Build_EvolutionChamber_screen
+    84: (100, 100),  # Build_HydraliskDen_screen
+    85: (100, 50),  # Build_BanelingNest_screen
+    86: (150, 0),  # Build_RoachWarren_screen
+    87: (200, 200),  # Build_Spire_screen
+    88: (100, 100),  # Build_InfestationPit_screen
+    89: (150, 200),  # Build_UltraliskCavern_screen
+    91: (100, 0),  # Build_SpineCrawler_screen
+    92: (75, 0),  # Build_SporeCrawler_screen
+    93: (150, 200),  # Build_NydusNetwork_screen
+    94: (100, 150),  # Build_LurkerDen_screen
     # --- Zerg units ---
-    97: (50, 0),  # Train_Drone_quick
-    98: (100, 0),  # Train_Overlord_quick
-    99: (50, 0),  # Train_Zergling_quick  (produces 2 for 50 minerals)
-    100: (25, 25),  # Train_Baneling_quick  (morph cost delta)
-    101: (75, 25),  # Train_Roach_quick
-    102: (25, 75),  # Train_Ravager_quick   (morph cost delta)
-    103: (100, 50),  # Train_Hydralisk_quick
-    104: (100, 150),  # Train_Infestor_quick
-    105: (100, 75),  # Train_SwarmHost_quick
-    106: (100, 100),  # Train_Mutalisk_quick
-    107: (150, 100),  # Train_Corruptor_quick
-    108: (150, 150),  # Train_BroodLord_quick (morph cost delta)
-    109: (100, 200),  # Train_Viper_quick
-    110: (300, 200),  # Train_Ultralisk_quick
-    111: (50, 100),  # Train_Lurker_quick   (morph cost delta)
-    112: (150, 0),  # Train_Queen_quick
-    113: (150, 100),  # Morph_Lair_quick
-    114: (200, 150),  # Morph_Hive_quick
-    115: (50, 50),  # Morph_Overseer_quick
-    116: (100, 150),  # Morph_GreaterSpire_quick
-    117: (150, 150),  # Morph_BroodLord_quick
+    95: (50, 0),  # Train_Drone_quick
+    96: (100, 0),  # Train_Overlord_quick
+    97: (50, 0),  # Train_Zergling_quick  (produces 2 for 50 minerals)
+    98: (25, 25),  # Train_Baneling_quick  (morph cost delta)
+    99: (75, 25),  # Train_Roach_quick
+    100: (25, 75),  # Train_Ravager_quick   (morph cost delta)
+    101: (100, 50),  # Train_Hydralisk_quick
+    102: (100, 150),  # Train_Infestor_quick
+    103: (100, 75),  # Train_SwarmHost_quick
+    104: (100, 100),  # Train_Mutalisk_quick
+    105: (150, 100),  # Train_Corruptor_quick
+    106: (150, 150),  # Train_BroodLord_quick (morph cost delta)
+    107: (100, 200),  # Train_Viper_quick
+    108: (300, 200),  # Train_Ultralisk_quick
+    109: (50, 100),  # Train_Lurker_quick   (morph cost delta)
+    110: (150, 0),  # Train_Queen_quick
+    111: (150, 100),  # Morph_Lair_quick
+    112: (200, 150),  # Morph_Hive_quick
+    113: (50, 50),  # Morph_Overseer_quick
+    114: (100, 150),  # Morph_GreaterSpire_quick
+    115: (150, 150),  # Morph_BroodLord_quick
 }
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -551,8 +551,8 @@ have to be covered.
 (`minimap_enemy_cx/cy`) that enables the policy to locate the beacon even
 when it is off the current camera view (beacon-idling fix); the `_action_to_call`
 no-spam fix (blocked Move_screen issues select_army once, then no_op on
-consecutive blocked steps); the 118-entry `FUNCTION_IDS` table and the
-`DISCRETE_ACTIONS` uniform `[command × location]` grid (3 583 rows: every
+consecutive blocked steps); the 116-entry `FUNCTION_IDS` table and the
+`DISCRETE_ACTIONS` uniform `[command × location]` grid (3 455 rows: every
 spatial fn_id gets a full 8×8 = 64-cell block, every non-spatial fn_id gets 1
 row); `SPATIAL_FN_IDS` derivation; race gating (`RACE_FUNCTION_IDS`,
 `fn_ids_for_race()`, pairwise-disjoint race-specific sets); the SC2 reward calculator

--- a/tests/test_sc2_actions.py
+++ b/tests/test_sc2_actions.py
@@ -169,12 +169,12 @@ class TestRaceGating(unittest.TestCase):
         terran_ids = fn_ids_for_race("terran")
         # Build_Barracks_screen is fn_idx 8 (Terran)
         self.assertIn(8, terran_ids)
-        # Build_Nexus_screen is fn_idx 50 (Protoss)
-        self.assertNotIn(50, terran_ids)
+        # Build_Nexus_screen is fn_idx 48 (Protoss)
+        self.assertNotIn(48, terran_ids)
 
     def test_protoss_has_nexus_not_barracks(self):
         protoss_ids = fn_ids_for_race("protoss")
-        self.assertIn(50, protoss_ids)  # Build_Nexus_screen
+        self.assertIn(48, protoss_ids)  # Build_Nexus_screen
         self.assertNotIn(8, protoss_ids)  # Build_Barracks_screen
 
     def test_zerg_has_hatchery_not_barracks(self):
@@ -228,7 +228,7 @@ class TestActionToFunctionCall(unittest.TestCase):
 
     def test_select_rect_uses_degenerate_rect(self):
         with patch.dict(sys.modules, _fake_pysc2_modules()):
-            action = np.array([17, 0.5, 0.5, 0.0], dtype=np.float32)  # select_rect
+            action = np.array([15, 0.5, 0.5, 0.0], dtype=np.float32)  # select_rect
             call = action_to_function_call(action, screen_size=64)
         self.assertEqual(call.arguments, [[0], [31, 31], [31, 31]])
 

--- a/tests/test_sc2_client.py
+++ b/tests/test_sc2_client.py
@@ -1097,14 +1097,14 @@ class TestSC2ClientAvailableFnIds(unittest.TestCase):
 
         old_cache = sc2_client_mod._pysc2_id_to_fn_idx
         try:
-            # no_op (0), Build_Barracks_screen (321 -> fn_idx 8), Build_Nexus_screen (882 -> fn_idx 50)
-            sc2_client_mod._pysc2_id_to_fn_idx = {0: 0, 321: 8, 882: 50}
+            # no_op (0), Build_Barracks_screen (321 -> fn_idx 8), Build_Nexus_screen (882 -> fn_idx 48)
+            sc2_client_mod._pysc2_id_to_fn_idx = {0: 0, 321: 8, 882: 48}
             client = SC2Client(map_name="MoveToBeacon")
             client._unit_type_id_to_race = {1: "terran"}
             ob = self._minigame_ob(available_actions=np.array([0, 321, 882], dtype=np.int32))
             ob["feature_units"] = np.array([[1, 1]], dtype=np.int32)  # Terran self unit
             _, info = client._timestep_to_obs_info(_FakeTimeStep(ob))
-            # Build_Nexus (fn_idx=50) is Protoss; race filter drops it.
+            # Build_Nexus (fn_idx=48) is Protoss; race filter drops it.
             self.assertEqual(info["available_fn_ids"], {0, 8})
         finally:
             sc2_client_mod._pysc2_id_to_fn_idx = old_cache

--- a/tests/test_sc2_obs_spec.py
+++ b/tests/test_sc2_obs_spec.py
@@ -35,7 +35,7 @@ class TestSC2ObsSpec(unittest.TestCase):
         self.assertGreater(RICH_OBS_DIM, LADDER_OBS_DIM)
         # Rich spec extended with race-gated available-actions mask, per-unit
         # counts, spatial quadrants, etc. — exact count depends on action space.
-        self.assertEqual(RICH_OBS_DIM, 327)
+        self.assertEqual(RICH_OBS_DIM, 323)
 
     def test_ladder_extends_minigame(self):
         """Ladder spec must contain all minigame names as a prefix."""

--- a/tests/test_sc2_tech_tree.py
+++ b/tests/test_sc2_tech_tree.py
@@ -52,14 +52,14 @@ class TestBuildingPrereqsMet(unittest.TestCase):
 
 class TestFnIdxSatisfiedTerran(unittest.TestCase):
     def test_build_fusion_core_requires_starport(self):
-        """Issue #346 specific: Build_FusionCore_screen (fn_idx=32) must be
+        """Issue #346 specific: Build_FusionCore_screen (fn_idx=30) must be
         unsatisfied with only CC + SCV visible, and satisfied with Starport."""
         # SCV selected, CommandCenter only.
-        self.assertFalse(fn_idx_satisfied(32, frozenset({"CommandCenter"}), frozenset(), _SCV))
+        self.assertFalse(fn_idx_satisfied(30, frozenset({"CommandCenter"}), frozenset(), _SCV))
         # SCV selected, Starport exists.
         self.assertTrue(
             fn_idx_satisfied(
-                32,
+                30,
                 frozenset({"CommandCenter", "Factory", "Starport"}),
                 frozenset(),
                 _SCV,
@@ -82,11 +82,11 @@ class TestFnIdxSatisfiedTerran(unittest.TestCase):
 
     def test_train_marauder_needs_tech_lab(self):
         # Barracks selected but no TechLab → unsatisfied.
-        self.assertFalse(fn_idx_satisfied(35, frozenset({"Barracks"}), frozenset(), _sel("Barracks")))
+        self.assertFalse(fn_idx_satisfied(33, frozenset({"Barracks"}), frozenset(), _sel("Barracks")))
         # BarracksTechLab present → satisfied.
         self.assertTrue(
             fn_idx_satisfied(
-                35,
+                33,
                 frozenset({"Barracks", "BarracksTechLab"}),
                 frozenset(),
                 _sel("Barracks"),
@@ -94,11 +94,11 @@ class TestFnIdxSatisfiedTerran(unittest.TestCase):
         )
 
     def test_train_battlecruiser_chain(self):
-        # fn_idx=43 (Battlecruiser) needs StarportTechLab + FusionCore + Starport selected.
+        # fn_idx=41 (Battlecruiser) needs StarportTechLab + FusionCore + Starport selected.
         # Missing FusionCore.
         self.assertFalse(
             fn_idx_satisfied(
-                43,
+                41,
                 frozenset({"Starport", "StarportTechLab"}),
                 frozenset(),
                 _sel("Starport"),
@@ -107,7 +107,7 @@ class TestFnIdxSatisfiedTerran(unittest.TestCase):
         # Complete chain.
         self.assertTrue(
             fn_idx_satisfied(
-                43,
+                41,
                 frozenset({"Starport", "StarportTechLab", "FusionCore"}),
                 frozenset(),
                 _sel("Starport"),
@@ -116,60 +116,60 @@ class TestFnIdxSatisfiedTerran(unittest.TestCase):
 
     def test_effect_stim_requires_research(self):
         # Marine selected but no Stim research → unsatisfied.
-        self.assertFalse(fn_idx_satisfied(47, frozenset({"Barracks"}), frozenset(), _sel("Marine")))
+        self.assertFalse(fn_idx_satisfied(45, frozenset({"Barracks"}), frozenset(), _sel("Marine")))
         # Stim research completed.
-        self.assertTrue(fn_idx_satisfied(47, frozenset({"Barracks"}), frozenset({"Stimpack"}), _sel("Marine")))
+        self.assertTrue(fn_idx_satisfied(45, frozenset({"Barracks"}), frozenset({"Stimpack"}), _sel("Marine")))
         # Stim research but SCV selected → unsatisfied (Marines/Marauders only).
-        self.assertFalse(fn_idx_satisfied(47, frozenset({"Barracks"}), frozenset({"Stimpack"}), _SCV))
+        self.assertFalse(fn_idx_satisfied(45, frozenset({"Barracks"}), frozenset({"Stimpack"}), _SCV))
 
 
 class TestFnIdxSatisfiedProtoss(unittest.TestCase):
     def test_carrier_needs_fleet_beacon(self):
-        # fn_idx=73 (Carrier) needs Stargate selected + FleetBeacon exists.
-        self.assertFalse(fn_idx_satisfied(73, frozenset({"Stargate"}), frozenset(), _sel("Stargate")))
-        self.assertTrue(fn_idx_satisfied(73, frozenset({"Stargate", "FleetBeacon"}), frozenset(), _sel("Stargate")))
+        # fn_idx=71 (Carrier) needs Stargate selected + FleetBeacon exists.
+        self.assertFalse(fn_idx_satisfied(71, frozenset({"Stargate"}), frozenset(), _sel("Stargate")))
+        self.assertTrue(fn_idx_satisfied(71, frozenset({"Stargate", "FleetBeacon"}), frozenset(), _sel("Stargate")))
 
     def test_stalker_from_gateway_or_warpgate(self):
-        # fn_idx=67 (Stalker) — accept either Gateway or WarpGate as selected.
+        # fn_idx=65 (Stalker) — accept either Gateway or WarpGate as selected.
         for selected in ("Gateway", "WarpGate"):
             with self.subTest(selected=selected):
-                self.assertTrue(fn_idx_satisfied(67, frozenset({"CyberneticsCore"}), frozenset(), _sel(selected)))
+                self.assertTrue(fn_idx_satisfied(65, frozenset({"CyberneticsCore"}), frozenset(), _sel(selected)))
 
 
 class TestFnIdxSatisfiedZerg(unittest.TestCase):
     def test_hive_needs_lair_and_infestation_pit(self):
-        # fn_idx=114 (Morph_Hive_quick) needs Lair selected + InfestationPit exists.
-        self.assertFalse(fn_idx_satisfied(114, frozenset(), frozenset(), _sel("Lair")))
-        self.assertTrue(fn_idx_satisfied(114, frozenset({"InfestationPit"}), frozenset(), _sel("Lair")))
+        # fn_idx=112 (Morph_Hive_quick) needs Lair selected + InfestationPit exists.
+        self.assertFalse(fn_idx_satisfied(112, frozenset(), frozenset(), _sel("Lair")))
+        self.assertTrue(fn_idx_satisfied(112, frozenset({"InfestationPit"}), frozenset(), _sel("Lair")))
 
     def test_lurker_needs_hydra_den(self):
-        # fn_idx=111 (Train_Lurker_quick) morphs Hydralisk + needs LurkerDenMP.
-        self.assertFalse(fn_idx_satisfied(111, frozenset(), frozenset(), _sel("Hydralisk")))
-        self.assertTrue(fn_idx_satisfied(111, frozenset({"LurkerDenMP"}), frozenset(), _sel("Hydralisk")))
+        # fn_idx=109 (Train_Lurker_quick) morphs Hydralisk + needs LurkerDenMP.
+        self.assertFalse(fn_idx_satisfied(109, frozenset(), frozenset(), _sel("Hydralisk")))
+        self.assertTrue(fn_idx_satisfied(109, frozenset({"LurkerDenMP"}), frozenset(), _sel("Hydralisk")))
 
     def test_baneling_morph_consumes_zergling(self):
-        # fn_idx=100 (Train_Baneling) — needs Zergling selected + BanelingNest exists.
-        self.assertFalse(fn_idx_satisfied(100, frozenset(), frozenset(), _sel("Zergling")))
-        self.assertFalse(fn_idx_satisfied(100, frozenset({"BanelingNest"}), frozenset(), _sel("Roach")))
-        self.assertTrue(fn_idx_satisfied(100, frozenset({"BanelingNest"}), frozenset(), _sel("Zergling")))
+        # fn_idx=98 (Train_Baneling) — needs Zergling selected + BanelingNest exists.
+        self.assertFalse(fn_idx_satisfied(98, frozenset(), frozenset(), _sel("Zergling")))
+        self.assertFalse(fn_idx_satisfied(98, frozenset({"BanelingNest"}), frozenset(), _sel("Roach")))
+        self.assertTrue(fn_idx_satisfied(98, frozenset({"BanelingNest"}), frozenset(), _sel("Zergling")))
 
     def test_overseer_needs_lair_or_hive(self):
-        # fn_idx=115 (Morph_Overseer) — Overlord selected + Lair OR Hive exists.
-        self.assertFalse(fn_idx_satisfied(115, frozenset({"Hatchery"}), frozenset(), _sel("Overlord")))
-        self.assertTrue(fn_idx_satisfied(115, frozenset({"Lair"}), frozenset(), _sel("Overlord")))
-        self.assertTrue(fn_idx_satisfied(115, frozenset({"Hive"}), frozenset(), _sel("Overlord")))
+        # fn_idx=113 (Morph_Overseer) — Overlord selected + Lair OR Hive exists.
+        self.assertFalse(fn_idx_satisfied(113, frozenset({"Hatchery"}), frozenset(), _sel("Overlord")))
+        self.assertTrue(fn_idx_satisfied(113, frozenset({"Lair"}), frozenset(), _sel("Overlord")))
+        self.assertTrue(fn_idx_satisfied(113, frozenset({"Hive"}), frozenset(), _sel("Overlord")))
         # Zergling selected (wrong type) → unsatisfied.
-        self.assertFalse(fn_idx_satisfied(115, frozenset({"Lair"}), frozenset(), _sel("Zergling")))
+        self.assertFalse(fn_idx_satisfied(113, frozenset({"Lair"}), frozenset(), _sel("Zergling")))
 
     def test_lair_morph_consumes_hatchery(self):
-        # fn_idx=113 (Morph_Lair) — Hatchery selected + SpawningPool exists.
-        self.assertFalse(fn_idx_satisfied(113, frozenset(), frozenset(), _sel("Hatchery")))
-        self.assertTrue(fn_idx_satisfied(113, frozenset({"SpawningPool"}), frozenset(), _sel("Hatchery")))
+        # fn_idx=111 (Morph_Lair) — Hatchery selected + SpawningPool exists.
+        self.assertFalse(fn_idx_satisfied(111, frozenset(), frozenset(), _sel("Hatchery")))
+        self.assertTrue(fn_idx_satisfied(111, frozenset({"SpawningPool"}), frozenset(), _sel("Hatchery")))
 
     def test_brood_lord_needs_greater_spire(self):
-        # fn_idx=108 (Train_BroodLord_quick) — Corruptor selected + GreaterSpire exists.
-        self.assertFalse(fn_idx_satisfied(108, frozenset({"Spire"}), frozenset(), _sel("Corruptor")))
-        self.assertTrue(fn_idx_satisfied(108, frozenset({"GreaterSpire"}), frozenset(), _sel("Corruptor")))
+        # fn_idx=106 (Train_BroodLord_quick) — Corruptor selected + GreaterSpire exists.
+        self.assertFalse(fn_idx_satisfied(106, frozenset({"Spire"}), frozenset(), _sel("Corruptor")))
+        self.assertTrue(fn_idx_satisfied(106, frozenset({"GreaterSpire"}), frozenset(), _sel("Corruptor")))
 
 
 class TestMorphsFullyIntegrated(unittest.TestCase):
@@ -179,22 +179,22 @@ class TestMorphsFullyIntegrated(unittest.TestCase):
     UNIT_PRODUCERS as the Factory-built unit)."""
 
     def test_archon_accepts_high_or_dark_templar(self):
-        # fn_idx=80 (Morph_Archon) — should accept either templar type.
+        # fn_idx=78 (Morph_Archon) — should accept either templar type.
         for selected in ("HighTemplar", "DarkTemplar"):
             with self.subTest(selected=selected):
-                self.assertTrue(fn_idx_satisfied(80, frozenset({"TemplarArchive"}), frozenset(), _sel(selected)))
+                self.assertTrue(fn_idx_satisfied(78, frozenset({"TemplarArchive"}), frozenset(), _sel(selected)))
         # Zealot is not a templar → unsatisfied.
-        self.assertFalse(fn_idx_satisfied(80, frozenset({"TemplarArchive"}), frozenset(), _sel("Zealot")))
+        self.assertFalse(fn_idx_satisfied(78, frozenset({"TemplarArchive"}), frozenset(), _sel("Zealot")))
 
     def test_siege_mode_consumes_unsieged_tank(self):
-        # fn_idx=48 (Morph_SiegeMode) — SiegeTank selected + FactoryTechLab.
-        self.assertFalse(fn_idx_satisfied(48, frozenset(), frozenset(), _sel("SiegeTank")))
-        self.assertTrue(fn_idx_satisfied(48, frozenset({"FactoryTechLab"}), frozenset(), _sel("SiegeTank")))
+        # fn_idx=46 (Morph_SiegeMode) — SiegeTank selected + FactoryTechLab.
+        self.assertFalse(fn_idx_satisfied(46, frozenset(), frozenset(), _sel("SiegeTank")))
+        self.assertTrue(fn_idx_satisfied(46, frozenset({"FactoryTechLab"}), frozenset(), _sel("SiegeTank")))
 
     def test_unsiege_consumes_sieged_tank(self):
-        # fn_idx=49 (Morph_Unsiege) — SiegeTankSieged selected, no building req.
-        self.assertTrue(fn_idx_satisfied(49, frozenset(), frozenset(), _sel("SiegeTankSieged")))
-        self.assertFalse(fn_idx_satisfied(49, frozenset(), frozenset(), _sel("SiegeTank")))
+        # fn_idx=47 (Morph_Unsiege) — SiegeTankSieged selected, no building req.
+        self.assertTrue(fn_idx_satisfied(47, frozenset(), frozenset(), _sel("SiegeTankSieged")))
+        self.assertFalse(fn_idx_satisfied(47, frozenset(), frozenset(), _sel("SiegeTank")))
 
 
 class TestUniversalActions(unittest.TestCase):
@@ -227,7 +227,7 @@ class TestMixedSelection(unittest.TestCase):
         # containing either should satisfy it (PySC2 applies Stim to both).
         self.assertTrue(
             fn_idx_satisfied(
-                47,
+                45,
                 frozenset({"Barracks"}),
                 frozenset({"Stimpack"}),
                 _sel("Marine", "Marauder"),
@@ -258,16 +258,16 @@ class TestResourceCostFilter(unittest.TestCase):
         self.assertFalse(fn_idx_satisfied(8, frozenset({"SupplyDepot"}), frozenset(), _SCV, minerals=149))
 
     def test_vespene_cost_gating(self):
-        # fn_idx=26 (Build_Factory) costs 150 minerals + 100 vespene.
+        # fn_idx=24 (Build_Factory) costs 150 minerals + 100 vespene.
         # Fail on insufficient vespene even if minerals are sufficient.
-        self.assertFalse(fn_idx_satisfied(26, frozenset({"Barracks"}), frozenset(), _SCV, minerals=200, vespene=99))
-        self.assertTrue(fn_idx_satisfied(26, frozenset({"Barracks"}), frozenset(), _SCV, minerals=150, vespene=100))
+        self.assertFalse(fn_idx_satisfied(24, frozenset({"Barracks"}), frozenset(), _SCV, minerals=200, vespene=99))
+        self.assertTrue(fn_idx_satisfied(24, frozenset({"Barracks"}), frozenset(), _SCV, minerals=150, vespene=100))
 
     def test_battlecruiser_double_cost(self):
-        # fn_idx=43 (Train_Battlecruiser) costs 400 minerals + 300 vespene.
+        # fn_idx=41 (Train_Battlecruiser) costs 400 minerals + 300 vespene.
         self.assertFalse(
             fn_idx_satisfied(
-                43,
+                41,
                 frozenset({"Starport", "StarportTechLab", "FusionCore"}),
                 frozenset(),
                 _sel("Starport"),
@@ -277,7 +277,7 @@ class TestResourceCostFilter(unittest.TestCase):
         )
         self.assertFalse(
             fn_idx_satisfied(
-                43,
+                41,
                 frozenset({"Starport", "StarportTechLab", "FusionCore"}),
                 frozenset(),
                 _sel("Starport"),
@@ -287,7 +287,7 @@ class TestResourceCostFilter(unittest.TestCase):
         )
         self.assertTrue(
             fn_idx_satisfied(
-                43,
+                41,
                 frozenset({"Starport", "StarportTechLab", "FusionCore"}),
                 frozenset(),
                 _sel("Starport"),
@@ -304,12 +304,12 @@ class TestResourceCostFilter(unittest.TestCase):
         self.assertTrue(fn_idx_satisfied(2, frozenset(), frozenset(), _sel("Marine"), minerals=0, vespene=0))
 
     def test_morph_actions_with_zero_cost(self):
-        # Morph_SiegeMode (fn_idx=48) and Morph_Unsiege (fn_idx=49) have no
+        # Morph_SiegeMode (fn_idx=46) and Morph_Unsiege (fn_idx=47) have no
         # resource cost (mode changes only).
-        self.assertFalse(fn_idx_satisfied(48, frozenset(), frozenset(), _sel("SiegeTank"), minerals=0))
+        self.assertFalse(fn_idx_satisfied(46, frozenset(), frozenset(), _sel("SiegeTank"), minerals=0))
         # fails because missing FactoryTechLab prerequisite, not resource cost
-        self.assertTrue(fn_idx_satisfied(48, frozenset({"FactoryTechLab"}), frozenset(), _sel("SiegeTank"), minerals=0))
-        self.assertTrue(fn_idx_satisfied(49, frozenset(), frozenset(), _sel("SiegeTankSieged"), minerals=0))
+        self.assertTrue(fn_idx_satisfied(46, frozenset({"FactoryTechLab"}), frozenset(), _sel("SiegeTank"), minerals=0))
+        self.assertTrue(fn_idx_satisfied(47, frozenset(), frozenset(), _sel("SiegeTankSieged"), minerals=0))
 
     def test_backwards_compat_no_resource_args(self):
         # Calling fn_idx_satisfied without minerals/vespene defaults to inf
@@ -319,19 +319,19 @@ class TestResourceCostFilter(unittest.TestCase):
 
     def test_resource_costs_table_coverage(self):
         # Every fn_idx in RESOURCE_COSTS must be within the known fn_idx range
-        # (0–117 as defined in FUNCTION_IDS) and must appear in PRECONDITIONS.
+        # (0–115 as defined in FUNCTION_IDS) and must appear in PRECONDITIONS.
         # (We avoid importing games.sc2.actions here because it requires numpy.)
         for fn_idx in RESOURCE_COSTS:
             with self.subTest(fn_idx=fn_idx):
                 self.assertIn(fn_idx, PRECONDITIONS, f"fn_idx {fn_idx} in RESOURCE_COSTS but not in PRECONDITIONS")
 
     def test_zerg_morph_cost(self):
-        # fn_idx=113 (Morph_Lair) costs 150 minerals + 100 vespene.
+        # fn_idx=111 (Morph_Lair) costs 150 minerals + 100 vespene.
         self.assertFalse(
-            fn_idx_satisfied(113, frozenset({"SpawningPool"}), frozenset(), _sel("Hatchery"), minerals=100, vespene=100)
+            fn_idx_satisfied(111, frozenset({"SpawningPool"}), frozenset(), _sel("Hatchery"), minerals=100, vespene=100)
         )
         self.assertTrue(
-            fn_idx_satisfied(113, frozenset({"SpawningPool"}), frozenset(), _sel("Hatchery"), minerals=150, vespene=100)
+            fn_idx_satisfied(111, frozenset({"SpawningPool"}), frozenset(), _sel("Hatchery"), minerals=150, vespene=100)
         )
 
 
@@ -348,7 +348,7 @@ class TestPreconditionsTableShape(unittest.TestCase):
     def test_universal_actions_have_no_selection_or_any_unit(self):
         # Universal actions (no_op, select_*, Move_*, Stop, …) should never
         # require a specific selected unit-type.
-        universal = {0, 1, 2, 3, 4, 6, 11, 12, 13, 14, 15, 16, 17, 19, 20, 21, 22}
+        universal = {0, 1, 2, 3, 4, 6, 11, 12, 13, 14, 15, 17, 18, 19, 20}
         for fn_idx in universal:
             with self.subTest(fn_idx=fn_idx):
                 pre = PRECONDITIONS[fn_idx]


### PR DESCRIPTION
The Patrol_screen / Patrol_minimap (follow/patrol-unit) orders are rarely
useful, so make them unreachable in the action space. Remove them from
FUNCTION_IDS, the race fn-id sets, and the tech-tree PRECONDITIONS /
RESOURCE_COSTS tables. All following fn_ids shift down by 2 to keep the
table contiguous (FUNCTION_IDS now has 116 entries, 0-115), so len() and
max()+1 stay consistent across env.py / policies.

The rich obs spec (available_fn_* + last_fn_* one-hots) shrinks by 4 dims
(327 -> 323) and DISCRETE_ACTIONS by 128 rows (two spatial blocks).
Existing SC2 champion weight files migrate via the standard
"missing key -> 0.0" path.

Tests, CHANGELOG, and tests/README updated for the new numbering/dims.