### PR TITLE
SC2: add new_action_unlock_bonus reward for tech-tree unlocks (issue #360)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,12 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ### Added
 - SC2: `new_action_unlock_bonus` reward config key (issue #360). Fires a
-  one-shot bonus per episode the first time a tech-tree-gated action becomes
-  available (e.g. `Build_Barracks_screen` unlocks when a `SupplyDepot`
-  completes). Only actions with at least one `required_buildings` precondition
-  in the tech tree are eligible; selection-only and always-available actions
-  are excluded. Default `0.0` — opt-in. Set in `reward_config.yaml`.
+  one-shot bonus per episode the first time a tech-tree-gated action appears
+  in `available_fn_ids` (i.e. becomes fully executable — prerequisite building
+  exists, correct unit selected, and affordable). Only actions with at least
+  one `required_buildings` precondition are eligible; selection-only and
+  always-available actions are excluded. Default `0.0` — opt-in. Set in
+  `reward_config.yaml`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+### Added
+- SC2: `new_action_unlock_bonus` reward config key (issue #360). Fires a
+  one-shot bonus per episode the first time a tech-tree-gated action becomes
+  available (e.g. `Build_Barracks_screen` unlocks when a `SupplyDepot`
+  completes). Only actions with at least one `required_buildings` precondition
+  in the tech tree are eligible; selection-only and always-available actions
+  are excluded. Default `0.0` — opt-in. Set in `reward_config.yaml`.
 
 ---
 

--- a/games/sc2/analytics.py
+++ b/games/sc2/analytics.py
@@ -84,6 +84,7 @@ _REWARD_COMPONENT_TO_CFG_KEY: dict[str, str] = {
     "attack_bonus": "attack_bonus",
     "attack_friendly_penalty": "attack_friendly_penalty",
     "early_random_action": "early_random_action_bonus",
+    "new_action_unlock": "new_action_unlock_bonus",
     "unit_loss": "unit_loss_penalty",
     "damage_taken": "damage_taken_penalty",
     "passive_under_fire": "passive_under_fire_penalty",

--- a/games/sc2/config/reward_config.yaml
+++ b/games/sc2/config/reward_config.yaml
@@ -138,10 +138,12 @@ small_selection_bonus: 0.0
 economy_weight: 0.001
 
 # --- Tech-tree unlock bonus (issue #360) ---
-# One-shot bonus per fn_idx that becomes newly available for the first time in
-# an episode, restricted to actions whose tech-tree preconditions include at
-# least one required building (e.g. Build_Barracks_screen unlocks when a
-# SupplyDepot is finished; Build_Factory_screen unlocks when Barracks is built).
+# One-shot bonus per fn_idx that appears in available_fn_ids for the first time
+# in an episode, restricted to actions whose tech-tree preconditions include at
+# least one required building.  The bonus fires the first time the action is
+# fully executable (prerequisite building exists AND correct unit selected AND
+# affordable) — not strictly at building-completion (e.g. Build_Barracks_screen
+# triggers when a SupplyDepot exists, an SCV is selected, and minerals suffice).
 # Selection-only actions (Move_screen, Attack_screen, Train_Marine_quick) and
 # always-available actions (no_op, select_army) are excluded.
 # Set to 0.0 to disable (default).  Recommended starting range: 1.0–10.0.

--- a/games/sc2/config/reward_config.yaml
+++ b/games/sc2/config/reward_config.yaml
@@ -136,3 +136,13 @@ small_selection_bonus: 0.0
 # --- Economy delta (mineral + vespene) ---
 # Recommended: 0.001 for ladder maps (Simple64), 0.0 for minigames.
 economy_weight: 0.001
+
+# --- Tech-tree unlock bonus (issue #360) ---
+# One-shot bonus per fn_idx that becomes newly available for the first time in
+# an episode, restricted to actions whose tech-tree preconditions include at
+# least one required building (e.g. Build_Barracks_screen unlocks when a
+# SupplyDepot is finished; Build_Factory_screen unlocks when Barracks is built).
+# Selection-only actions (Move_screen, Attack_screen, Train_Marine_quick) and
+# always-available actions (no_op, select_army) are excluded.
+# Set to 0.0 to disable (default).  Recommended starting range: 1.0–10.0.
+new_action_unlock_bonus: 0.0

--- a/games/sc2/reward.py
+++ b/games/sc2/reward.py
@@ -168,18 +168,22 @@ class SC2RewardConfig:
         ``early_random_action_bonus`` may fire. Outside this window the bonus
         is disabled. Default ``250``.
     new_action_unlock_bonus :
-        One-shot bonus per fn_idx that becomes newly available for the first
-        time in an episode, restricted to actions whose tech-tree preconditions
-        include at least one required building (i.e. the action was gated behind
-        a building that was just completed — e.g. ``Build_Barracks_screen``
-        unlocks when a ``SupplyDepot`` is finished).  Selection-only actions
-        (``Move_screen``, ``Attack_screen``, basic training) and always-available
-        actions (``no_op``, ``select_army``) do not trigger the bonus.  The
-        bonus fires once per qualifying fn_idx per episode; each subsequent step
-        where that fn_idx appears earns no additional reward.  Default ``0.0``
-        — opt-in.  Recommended starting range: ``1.0–10.0`` (much larger than
-        per-step shaping terms so the tech-unlock signal is clearly visible to
-        the policy).
+        One-shot bonus per fn_idx that appears in ``available_fn_ids`` for
+        the first time in an episode, restricted to actions whose tech-tree
+        preconditions include at least one required building.  The bonus fires
+        the first time the action is *fully executable* — meaning the tech-tree
+        prerequisite building exists, the correct unit type is selected, and the
+        action is affordable — not strictly at the moment the prerequisite
+        building completes (e.g. ``Build_Barracks_screen`` first becomes
+        available when a ``SupplyDepot`` exists *and* an SCV is selected and
+        minerals are sufficient).  Selection-only actions (``Move_screen``,
+        ``Attack_screen``, basic training) and always-available actions
+        (``no_op``, ``select_army``) do not trigger the bonus.  The bonus fires
+        once per qualifying fn_idx per episode; each subsequent step where that
+        fn_idx appears earns no additional reward.  Default ``0.0`` — opt-in.
+        Recommended starting range: ``1.0–10.0`` (much larger than per-step
+        shaping terms so the tech-unlock signal is clearly visible to the
+        policy).
     """
 
     score_weight: float = 1.0

--- a/games/sc2/reward.py
+++ b/games/sc2/reward.py
@@ -15,6 +15,7 @@ from typing import Any
 import yaml
 
 from framework.base_reward import RewardCalculatorBase
+from games.sc2.tech_tree import PRECONDITIONS
 
 
 @dataclass
@@ -166,6 +167,19 @@ class SC2RewardConfig:
         Number of episode steps from reset in which
         ``early_random_action_bonus`` may fire. Outside this window the bonus
         is disabled. Default ``250``.
+    new_action_unlock_bonus :
+        One-shot bonus per fn_idx that becomes newly available for the first
+        time in an episode, restricted to actions whose tech-tree preconditions
+        include at least one required building (i.e. the action was gated behind
+        a building that was just completed — e.g. ``Build_Barracks_screen``
+        unlocks when a ``SupplyDepot`` is finished).  Selection-only actions
+        (``Move_screen``, ``Attack_screen``, basic training) and always-available
+        actions (``no_op``, ``select_army``) do not trigger the bonus.  The
+        bonus fires once per qualifying fn_idx per episode; each subsequent step
+        where that fn_idx appears earns no additional reward.  Default ``0.0``
+        — opt-in.  Recommended starting range: ``1.0–10.0`` (much larger than
+        per-step shaping terms so the tech-unlock signal is clearly visible to
+        the policy).
     """
 
     score_weight: float = 1.0
@@ -192,6 +206,7 @@ class SC2RewardConfig:
     attack_bonus: float = 0.0
     early_random_action_bonus: float = 0.0
     early_random_action_window_steps: int = 250
+    new_action_unlock_bonus: float = 0.0
 
     @classmethod
     def from_yaml(cls, path: str) -> SC2RewardConfig:
@@ -271,6 +286,12 @@ class SC2RewardCalculator(RewardCalculatorBase):
     # likely want to widen friendly-fire detection equally.
     _ATTACK_SELF_RADIUS_FRAC: float = 8.0 / 64.0
 
+    # fn_ids whose PRECONDITIONS include at least one required building —
+    # the only actions for which new_action_unlock_bonus fires.
+    _TECH_GATED_FN_IDS: frozenset[int] = frozenset(
+        fn_idx for fn_idx, prec in PRECONDITIONS.items() if prec.required_buildings
+    )
+
     def __init__(self, config: SC2RewardConfig) -> None:
         self.config = config
         self._last_click_x: float | None = None
@@ -283,6 +304,8 @@ class SC2RewardCalculator(RewardCalculatorBase):
         # cell -> env step on which the centroid was last seen in that cell.
         self._visited_unit_cells: dict[tuple[int, int], int] = {}
         self._seen_action_fns: set[int] = set()
+        # tech-gated fn_ids seen so far this episode (for new_action_unlock_bonus).
+        self._unlocked_tech_fn_ids: set[int] = set()
 
     def reset(self) -> None:
         """Clear per-episode state at the start of a new episode."""
@@ -295,6 +318,7 @@ class SC2RewardCalculator(RewardCalculatorBase):
         self._step_count = 0
         self._visited_unit_cells = {}
         self._seen_action_fns = set()
+        self._unlocked_tech_fn_ids = set()
 
     def compute(
         self,
@@ -330,9 +354,9 @@ class SC2RewardCalculator(RewardCalculatorBase):
         ``idle_worker_penalty``, ``idle_bonus``, ``move_exploration``,
         ``move_repeat_penalty``, ``move_self_penalty``, ``attack_move_bonus``,
         ``click_attack_bonus``, ``attack_bonus``, ``attack_friendly_penalty``,
-        ``early_random_action``, ``unit_loss``, ``damage_taken``,
-        ``passive_under_fire``, ``small_selection``, ``step_penalty`` and
-        ``terminal`` separately.
+        ``early_random_action``, ``new_action_unlock``, ``unit_loss``,
+        ``damage_taken``, ``passive_under_fire``, ``small_selection``,
+        ``step_penalty`` and ``terminal`` separately.
         """
         cfg = self.config
         components: dict[str, float] = {}
@@ -420,6 +444,20 @@ class SC2RewardCalculator(RewardCalculatorBase):
         if current_fn_idx != 0:
             self._seen_action_fns.add(current_fn_idx)
         components["early_random_action"] = float(early_random_action)
+
+        # New tech-tree unlock bonus: reward once per qualifying fn_idx that
+        # appears for the first time this episode.  Only fn_ids with at least
+        # one required_building in PRECONDITIONS are eligible (selection-only
+        # and always-available actions are excluded).
+        new_action_unlock = 0.0
+        if cfg.new_action_unlock_bonus != 0.0:
+            available = info.get("available_fn_ids") or set()
+            tech_available = available & self._TECH_GATED_FN_IDS
+            newly_unlocked = tech_available - self._unlocked_tech_fn_ids
+            if newly_unlocked:
+                new_action_unlock = cfg.new_action_unlock_bonus * len(newly_unlocked)
+            self._unlocked_tech_fn_ids |= tech_available
+        components["new_action_unlock"] = float(new_action_unlock)
 
         self_count = float(info.get("screen_self_count", 0.0))
         newly_visited_unit_cell = False

--- a/grid_search.py
+++ b/grid_search.py
@@ -157,6 +157,8 @@ _ABBREV = {
     "passive_under_fire_penalty": "pufp",
     "small_selection_bonus": "ssb",
     "attack_bonus": "atb",
+    "early_random_action_bonus": "erab",
+    "new_action_unlock_bonus": "naub",
     "airborne_penalty": "ap",
     "crash_threshold_m": "ct",
     "off_track_penalty": "otp",

--- a/tests/README.md
+++ b/tests/README.md
@@ -635,6 +635,7 @@ handful of iterations only).
 - passive_under_fire_penalty: fires on no_op or Move_screen when enemies within attack range; suppressed by Attack_screen; skipped when enemy out of range / no enemy / no self; respects explicit self_attack_range_px; n_ticks scaling; disabled by default; appears in components dict
 - small_selection_bonus: fires on unit-targeted commands when selection is a single unit or less than half of visible friendly units; skipped for non-unit-targeted actions and exactly-half selections; appears in components dict
 - attack_bonus: fires on any Attack_screen (fn_idx 3) regardless of target type; persists across carried attack no_op steps; skipped for pure no_op (no prior attack); disabled by default; appears in components dict
+- new_action_unlock_bonus (issue #360): `_TECH_GATED_FN_IDS` class attribute is non-empty and includes fn_idx 8 (`Build_Barracks_screen`); non-gated fn_ids (0, 1, 2) excluded; bonus fires on first appearance of a tech-gated fn_idx in `available_fn_ids`; does not fire again same episode; fires again after `reset()`; scales with count of newly unlocked fn_ids; non-gated actions do not trigger; disabled when bonus is 0.0; missing `available_fn_ids` key does not crash; components sum equals total
 - components sum: new terms included in total (extended sum test)
 
 ### test_sc2_client.py — PySC2 client wrapper

--- a/tests/test_sc2_reward.py
+++ b/tests/test_sc2_reward.py
@@ -1789,5 +1789,122 @@ class TestSC2IdleWorkerPenalty(unittest.TestCase):
         self.assertAlmostEqual(comp["idle_worker_penalty"], -8.0)
 
 
+class TestNewActionUnlockBonus(unittest.TestCase):
+    """Tests for SC2RewardCalculator.new_action_unlock_bonus (issue #360)."""
+
+    def _base_info(self) -> dict:
+        return {
+            "prev_score": 0.0,
+            "score": 0.0,
+            "prev_minerals": 0.0,
+            "minerals": 0.0,
+            "prev_vespene": 0.0,
+            "vespene": 0.0,
+            "action_fn_idx": 0,
+        }
+
+    def _make_calc(self, bonus: float) -> SC2RewardCalculator:
+        return SC2RewardCalculator(
+            SC2RewardConfig(
+                new_action_unlock_bonus=bonus,
+                score_weight=0.0,
+                step_penalty=0.0,
+                economy_weight=0.0,
+                win_bonus=0.0,
+                loss_penalty=0.0,
+                move_exploration_bonus=0.0,
+            )
+        )
+
+    def test_default_is_zero(self):
+        cfg = SC2RewardConfig()
+        self.assertEqual(cfg.new_action_unlock_bonus, 0.0)
+
+    def test_tech_gated_fn_ids_nonempty(self):
+        # Verify the class-level precomputed set has at least some entries.
+        # fn_idx 8 = Build_Barracks_screen (requires SupplyDepot) must be included.
+        self.assertIn(8, SC2RewardCalculator._TECH_GATED_FN_IDS)
+
+    def test_non_gated_fn_ids_excluded(self):
+        # no_op (0), select_army (1), Move_screen (2) have no required_buildings.
+        for fn_idx in (0, 1, 2):
+            self.assertNotIn(fn_idx, SC2RewardCalculator._TECH_GATED_FN_IDS)
+
+    def test_bonus_fires_on_first_appearance(self):
+        calc = self._make_calc(bonus=5.0)
+        info = {**self._base_info(), "available_fn_ids": {8}}  # Build_Barracks_screen
+        total, comp = calc.compute_with_components(
+            prev_state=None, curr_state=None, finished=False, elapsed_s=1.0, info=info
+        )
+        self.assertAlmostEqual(comp["new_action_unlock"], 5.0)
+        self.assertAlmostEqual(total, 5.0)
+
+    def test_bonus_does_not_fire_again_same_episode(self):
+        calc = self._make_calc(bonus=5.0)
+        info = {**self._base_info(), "available_fn_ids": {8}}
+        calc.compute_with_components(prev_state=None, curr_state=None, finished=False, elapsed_s=1.0, info=info)
+        # Second step — same fn_idx still available.
+        _, comp2 = calc.compute_with_components(
+            prev_state=None, curr_state=None, finished=False, elapsed_s=1.0, info=info
+        )
+        self.assertAlmostEqual(comp2["new_action_unlock"], 0.0)
+
+    def test_bonus_fires_again_after_reset(self):
+        calc = self._make_calc(bonus=5.0)
+        info = {**self._base_info(), "available_fn_ids": {8}}
+        calc.compute_with_components(prev_state=None, curr_state=None, finished=False, elapsed_s=1.0, info=info)
+        calc.reset()
+        _, comp = calc.compute_with_components(
+            prev_state=None, curr_state=None, finished=False, elapsed_s=1.0, info=info
+        )
+        self.assertAlmostEqual(comp["new_action_unlock"], 5.0)
+
+    def test_bonus_scales_with_count(self):
+        # Two tech-gated fn_ids unlocked simultaneously → 2× bonus.
+        calc = self._make_calc(bonus=3.0)
+        # fn_idx 8 = Build_Barracks_screen, fn_idx 26 = Build_Factory_screen
+        # (both are building-gated per PRECONDITIONS)
+        tech_gated = SC2RewardCalculator._TECH_GATED_FN_IDS
+        two_gated = set(list(tech_gated)[:2])
+        info = {**self._base_info(), "available_fn_ids": two_gated}
+        _, comp = calc.compute_with_components(
+            prev_state=None, curr_state=None, finished=False, elapsed_s=1.0, info=info
+        )
+        self.assertAlmostEqual(comp["new_action_unlock"], 3.0 * 2)
+
+    def test_non_gated_actions_do_not_trigger(self):
+        calc = self._make_calc(bonus=5.0)
+        # Only non-gated fn_ids in available_fn_ids.
+        info = {**self._base_info(), "available_fn_ids": {0, 1, 2, 3}}
+        _, comp = calc.compute_with_components(
+            prev_state=None, curr_state=None, finished=False, elapsed_s=1.0, info=info
+        )
+        self.assertAlmostEqual(comp["new_action_unlock"], 0.0)
+
+    def test_disabled_when_bonus_is_zero(self):
+        calc = self._make_calc(bonus=0.0)
+        info = {**self._base_info(), "available_fn_ids": {8, 26}}
+        _, comp = calc.compute_with_components(
+            prev_state=None, curr_state=None, finished=False, elapsed_s=1.0, info=info
+        )
+        self.assertAlmostEqual(comp["new_action_unlock"], 0.0)
+
+    def test_missing_available_fn_ids_key_no_crash(self):
+        calc = self._make_calc(bonus=5.0)
+        info = self._base_info()  # no "available_fn_ids" key
+        _, comp = calc.compute_with_components(
+            prev_state=None, curr_state=None, finished=False, elapsed_s=1.0, info=info
+        )
+        self.assertAlmostEqual(comp["new_action_unlock"], 0.0)
+
+    def test_components_sum_equals_total(self):
+        calc = self._make_calc(bonus=5.0)
+        info = {**self._base_info(), "available_fn_ids": {8}}
+        total, comp = calc.compute_with_components(
+            prev_state=None, curr_state=None, finished=False, elapsed_s=1.0, info=info
+        )
+        self.assertAlmostEqual(total, sum(comp.values()), places=5)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Fires a one-shot bonus per episode the first time a tech-tree-gated
action appears in available_fn_ids. Only fn_ids with at least one
required_buildings precondition in PRECONDITIONS are eligible (e.g.
Build_Barracks_screen unlocks when SupplyDepot completes; selection-only
and always-available actions are excluded). Default 0.0 — opt-in.

https://claude.ai/code/session_01Uhy9gB1mWLXKM3TegArm92