### PR TITLE
feat(sc2): add penalty for banking resources

### DIFF
--- a/games/sc2/reward.py
+++ b/games/sc2/reward.py
@@ -166,6 +166,11 @@ class SC2RewardConfig:
         Number of episode steps from reset in which
         ``early_random_action_bonus`` may fire. Outside this window the bonus
         is disabled. Default ``250``.
+    excess_resource_penalty :
+        Per-step penalty for banking more than 300 minerals or 200 gas.
+        The penalty scales linearly with the degree of excess (sum of minerals
+        above 300 and gas above 200). Discourages agents from hoarding resources
+        instead of building or training units. Default ``0.0`` — opt-in.
     """
 
     score_weight: float = 1.0
@@ -192,6 +197,7 @@ class SC2RewardConfig:
     attack_bonus: float = 0.0
     early_random_action_bonus: float = 0.0
     early_random_action_window_steps: int = 250
+    excess_resource_penalty: float = 0.0
 
     @classmethod
     def from_yaml(cls, path: str) -> SC2RewardConfig:
@@ -617,6 +623,15 @@ class SC2RewardCalculator(RewardCalculatorBase):
             elif outcome < 0:
                 terminal = cfg.loss_penalty
         components["terminal"] = float(terminal)
+
+        # Excess resource penalty: penalise banking >300 minerals or >200 gas.
+        excess_pen = 0.0
+        if cfg.excess_resource_penalty != 0.0:
+            excess_min = max(0.0, float(info.get("minerals", 0.0)) - 300.0)
+            excess_gas = max(0.0, float(info.get("vespene", 0.0)) - 200.0)
+            if excess_min > 0 or excess_gas > 0:
+                excess_pen = cfg.excess_resource_penalty * (excess_min + excess_gas) * n_ticks
+        components["excess_resource_penalty"] = float(excess_pen)
 
         reward = float(sum(components.values()))
         return reward, components

--- a/games/sc2/reward.py
+++ b/games/sc2/reward.py
@@ -167,10 +167,18 @@ class SC2RewardConfig:
         ``early_random_action_bonus`` may fire. Outside this window the bonus
         is disabled. Default ``250``.
     excess_resource_penalty :
-        Per-step penalty for banking more than 300 minerals or 200 gas.
-        The penalty scales linearly with the degree of excess (sum of minerals
-        above 300 and gas above 200). Discourages agents from hoarding resources
-        instead of building or training units. Default ``0.0`` — opt-in.
+        Per-step penalty for banking more than ``excess_minerals_threshold``
+        minerals or ``excess_vespene_threshold`` gas. The penalty scales linearly
+        with the degree of excess (sum of minerals above threshold and gas above
+        threshold). Note that this treats one unit of excess mineral as exactly
+        equivalent to one unit of excess gas. Discourages agents from hoarding
+        resources instead of building or training units. Default ``0.0`` — opt-in.
+    excess_minerals_threshold :
+        Amount of minerals the agent can hold before ``excess_resource_penalty``
+        starts applying. Default ``300.0``.
+    excess_vespene_threshold :
+        Amount of vespene gas the agent can hold before ``excess_resource_penalty``
+        starts applying. Default ``200.0``.
     """
 
     score_weight: float = 1.0
@@ -198,6 +206,8 @@ class SC2RewardConfig:
     early_random_action_bonus: float = 0.0
     early_random_action_window_steps: int = 250
     excess_resource_penalty: float = 0.0
+    excess_minerals_threshold: float = 300.0
+    excess_vespene_threshold: float = 200.0
 
     @classmethod
     def from_yaml(cls, path: str) -> SC2RewardConfig:
@@ -624,11 +634,11 @@ class SC2RewardCalculator(RewardCalculatorBase):
                 terminal = cfg.loss_penalty
         components["terminal"] = float(terminal)
 
-        # Excess resource penalty: penalise banking >300 minerals or >200 gas.
+        # Excess resource penalty: penalise banking > threshold minerals or gas.
         excess_pen = 0.0
-        if cfg.excess_resource_penalty != 0.0:
-            excess_min = max(0.0, float(info.get("minerals", 0.0)) - 300.0)
-            excess_gas = max(0.0, float(info.get("vespene", 0.0)) - 200.0)
+        if cfg.excess_resource_penalty < 0.0:
+            excess_min = max(0.0, float(info.get("minerals", 0.0)) - cfg.excess_minerals_threshold)
+            excess_gas = max(0.0, float(info.get("vespene", 0.0)) - cfg.excess_vespene_threshold)
             if excess_min > 0 or excess_gas > 0:
                 excess_pen = cfg.excess_resource_penalty * (excess_min + excess_gas) * n_ticks
         components["excess_resource_penalty"] = float(excess_pen)

--- a/tests/test_sc2_reward.py
+++ b/tests/test_sc2_reward.py
@@ -249,7 +249,7 @@ class TestSC2RewardCalculator(unittest.TestCase):
                 "vespene": 250.0,   # 50 excess
             },
         )
-        # Total excess: 250 * -0.001 = -0.25
+        # Total excess: (200 + 50) * -0.001 = -0.25
         self.assertAlmostEqual(r, -0.25)
 
     def test_excess_resource_penalty_not_applied_below_thresholds(self):
@@ -271,6 +271,62 @@ class TestSC2RewardCalculator(unittest.TestCase):
             },
         )
         self.assertAlmostEqual(r, 0.0)
+
+    def test_excess_resource_penalty_exact_threshold(self):
+        calc = self._make_calc(
+            score_weight=0.0,
+            step_penalty=0.0,
+            excess_resource_penalty=-0.001,
+        )
+        r = calc.compute(
+            prev_state=None,
+            curr_state=None,
+            finished=False,
+            elapsed_s=1.0,
+            info={
+                "prev_score": 0.0,
+                "score": 0.0,
+                "minerals": 300.0,  # exactly threshold
+                "vespene": 200.0,   # exactly threshold
+            },
+        )
+        self.assertAlmostEqual(r, 0.0)
+
+    def test_excess_resource_penalty_one_exceeds(self):
+        calc = self._make_calc(
+            score_weight=0.0,
+            step_penalty=0.0,
+            excess_resource_penalty=-0.001,
+        )
+        # Only minerals exceed
+        r_min = calc.compute(
+            prev_state=None,
+            curr_state=None,
+            finished=False,
+            elapsed_s=1.0,
+            info={
+                "prev_score": 0.0,
+                "score": 0.0,
+                "minerals": 400.0,  # 100 excess
+                "vespene": 0.0,
+            },
+        )
+        self.assertAlmostEqual(r_min, -0.1)
+
+        # Only gas exceeds
+        r_gas = calc.compute(
+            prev_state=None,
+            curr_state=None,
+            finished=False,
+            elapsed_s=1.0,
+            info={
+                "prev_score": 0.0,
+                "score": 0.0,
+                "minerals": 0.0,
+                "vespene": 250.0,  # 50 excess
+            },
+        )
+        self.assertAlmostEqual(r_gas, -0.05)
 
     def test_excess_resource_penalty_scales_with_n_ticks(self):
         calc = self._make_calc(
@@ -759,14 +815,14 @@ class TestSC2RewardComponents(unittest.TestCase):
             self.assertIn(key, comp)
 
     def test_components_sum_equals_total(self):
-        calc = self._calc(score_weight=2.0, economy_weight=0.01, step_penalty=-0.5, win_bonus=200.0)
+        calc = self._calc(score_weight=2.0, economy_weight=0.01, step_penalty=-0.5, win_bonus=200.0, excess_resource_penalty=-0.01)
         info = {
             "prev_score": 5.0,
             "score": 8.0,
             "prev_minerals": 100.0,
-            "minerals": 200.0,
+            "minerals": 400.0,  # 100 excess
             "prev_vespene": 0.0,
-            "vespene": 0.0,
+            "vespene": 250.0,   # 50 excess
             "player_outcome": 1.0,
         }
         total, comp = calc.compute_with_components(
@@ -780,8 +836,9 @@ class TestSC2RewardComponents(unittest.TestCase):
         self.assertAlmostEqual(total, sum(comp.values()), places=5)
         # Spot-check individual contributions.
         self.assertAlmostEqual(comp["score"], 6.0)  # 2.0 * (8 - 5)
-        self.assertAlmostEqual(comp["economy"], 1.0)  # 0.01 * 100
+        self.assertAlmostEqual(comp["economy"], 5.5)  # 0.01 * (300 + 250)
         self.assertAlmostEqual(comp["step_penalty"], -1.0)  # -0.5 * 2
+        self.assertAlmostEqual(comp["excess_resource_penalty"], -3.0)  # -0.01 * 150 * 2
         self.assertAlmostEqual(comp["terminal"], 200.0)  # win_bonus
 
     def test_compute_default_delegates_to_with_components(self):

--- a/tests/test_sc2_reward.py
+++ b/tests/test_sc2_reward.py
@@ -231,6 +231,69 @@ class TestSC2RewardCalculator(unittest.TestCase):
         )
         self.assertAlmostEqual(r, 0.0)
 
+    def test_excess_resource_penalty_when_hoarding(self):
+        calc = self._make_calc(
+            score_weight=0.0,
+            step_penalty=0.0,
+            excess_resource_penalty=-0.001,
+        )
+        r = calc.compute(
+            prev_state=None,
+            curr_state=None,
+            finished=False,
+            elapsed_s=1.0,
+            info={
+                "prev_score": 0.0,
+                "score": 0.0,
+                "minerals": 500.0,  # 200 excess
+                "vespene": 250.0,   # 50 excess
+            },
+        )
+        # Total excess: 250 * -0.001 = -0.25
+        self.assertAlmostEqual(r, -0.25)
+
+    def test_excess_resource_penalty_not_applied_below_thresholds(self):
+        calc = self._make_calc(
+            score_weight=0.0,
+            step_penalty=0.0,
+            excess_resource_penalty=-0.001,
+        )
+        r = calc.compute(
+            prev_state=None,
+            curr_state=None,
+            finished=False,
+            elapsed_s=1.0,
+            info={
+                "prev_score": 0.0,
+                "score": 0.0,
+                "minerals": 300.0,  # 0 excess
+                "vespene": 200.0,   # 0 excess
+            },
+        )
+        self.assertAlmostEqual(r, 0.0)
+
+    def test_excess_resource_penalty_scales_with_n_ticks(self):
+        calc = self._make_calc(
+            score_weight=0.0,
+            step_penalty=0.0,
+            excess_resource_penalty=-0.001,
+        )
+        r = calc.compute(
+            prev_state=None,
+            curr_state=None,
+            finished=False,
+            elapsed_s=1.0,
+            info={
+                "prev_score": 0.0,
+                "score": 0.0,
+                "minerals": 400.0,  # 100 excess
+                "vespene": 0.0,     # 0 excess
+            },
+            n_ticks=4,
+        )
+        # 100 * -0.001 * 4 = -0.4
+        self.assertAlmostEqual(r, -0.4)
+
 
 class TestSC2IdleBonus(unittest.TestCase):
     """Tests for the idle_bonus reward (issue #127)."""
@@ -689,6 +752,7 @@ class TestSC2RewardComponents(unittest.TestCase):
             "attack_friendly_penalty",
             "early_random_action",
             "small_selection",
+            "excess_resource_penalty",
             "step_penalty",
             "terminal",
         ):


### PR DESCRIPTION
Resolves #372. Adds excess_resource_penalty to penalize banking more than 300 minerals or 200 gas.