### PR TITLE
SC2 behaviour cloning: dataset builder, fit, run, and --bc CLI (issues #351–#354)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@ formatting, internal refactors with no behaviour change — can be skipped.
 ## [Unreleased]
 
 ### Added
+- BC warm-start integration with `grid_search.py` (issue #354, [6/6]): two ways
+  to warm-start every combo in a grid search from a behaviour-cloning checkpoint.
+  (1) **Post-hoc warm-start** — pass `--bc-warmstart-dir <path>` pointing to an
+  existing BC experiment directory (one that contains `policy_weights.yaml` +
+  `bc_summary.json`).  Before any combo runs, a policy-compatibility check reads
+  `bc_target` from `bc_summary.json` and validates it against every combo's
+  `policy_type` via `_BC_COMPATIBLE_POLICY_TYPES` (cross-compatibility:
+  `sc2_genetic` ↔ `sc2_cmaes`; all others self-only).  Weight files
+  (`policy_weights.yaml`, `trainer_state.npz`, `policy_weights_qtable.pkl`) are
+  copied into each combo's experiment directory before `train_rl` is called.
+  (2) **Inline BC** — add a `bc:` section to the grid config YAML with at
+  minimum `replay_dir` and optionally `bc_target`, `player_id`, `race`,
+  `bc_epochs`, `bc_learning_rate`, and all other BC knobs.  `grid_search.py`
+  runs BC once into a shared `<base_name>__bc_warmstart/` directory, skips re-run
+  if `policy_weights.yaml` + `bc_summary.json` already exist, then validates
+  compatibility and copies weights into every combo directory.  If both
+  `--bc-warmstart-dir` and an inline `bc:` section are present,
+  `--bc-warmstart-dir` takes precedence with a warning.
+  `_load_grid_config` now returns a 7-tuple including `bc_cfg`.
+  New abbreviated entries added to `_ABBREV` for all `bc_*` config keys.
 - SC2 BC warm-start for all policy families (issue #354, [5/6]): `fit_bc` now
   accepts seven additional targets beyond the original `sc2_reinforce` /
   `sc2_genetic` pair.  `sc2_cmaes` — linear least-squares fit into

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+### Fixed
+- `_fit_bc_tabular()` Q-normalization bug (issue #354): Q-values are now
+  divided by the total state-visit count `_n_s[state]` to produce a proper
+  action-frequency distribution summing to 1.0 per state, rather than dividing
+  each `q[s,a]` by its own `_n_sa[s,a]` (which always yielded 1.0).
+- `_fit_bc_dqn()` terminal transition bug (issue #354): transitions at episode
+  boundaries now store a zero-vector as `next_obs` instead of leaking the first
+  observation of the following episode, which would corrupt the Bellman target.
+- `fit_bc(target="sc2_lstm")` now raises a descriptive `ValueError` listing the
+  missing keys when `episode_starts` / `episode_lengths` are absent from the
+  dataset, rather than propagating a bare `KeyError` from `_iter_episodes_from_dataset`.
+- `_copy_bc_weights()` in `grid_search.py` now also copies `policy_weights.npz`
+  (the `sc2_cnn` weight format) alongside `policy_weights.yaml`, fixing the
+  CNN warm-start path that previously silently left the experiment without weights.
+- `_fit_bc_cnn()` spatial-head OOM (issue #354): replaced the dense
+  `(N × _N_SPATIAL_CELLS)` distance and one-hot matrices with batched distance
+  computation (4096-row chunks) and scatter-add normal equations
+  `(H^T H) W = H^T Y`, reducing peak memory from O(N × S) to O(N × FC_DIM)
+  plus O(FC_DIM × S).
+
 ### Added
 - BC warm-start integration with `grid_search.py` (issue #354, [6/6]): two ways
   to warm-start every combo in a grid search from a behaviour-cloning checkpoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,26 @@ formatting, internal refactors with no behaviour change — can be skipped.
 ## [Unreleased]
 
 ### Added
+- SC2 BC warm-start for all policy families (issue #354, [5/6]): `fit_bc` now
+  accepts seven additional targets beyond the original `sc2_reinforce` /
+  `sc2_genetic` pair.  `sc2_cmaes` — linear least-squares fit into
+  `SC2MultiHeadLinearPolicy`, then seeds `SC2CMAESPolicy.initialize_from_champion`
+  so the CMA-ES distribution mean starts at the fitted weights.  `sc2_neural_net`
+  — mini-batch MSE regression (logit-transformed fn_idx / x / y targets) into
+  `SC2NeuralNetPolicy`.  `sc2_neural_dqn` — pre-fills the `MaskedReplayBuffer`
+  with demo transitions matched to the nearest `DISCRETE_ACTIONS` row by L1
+  distance; BC "loss" is reported as fill fraction.  `sc2_lstm` — collects LSTM
+  hidden states via a full episode-sequence forward pass (with proper h/c resets
+  at episode boundaries), then trains only the output head (`W_out`/`b_out`) via
+  cross-entropy SGD, and seeds `SC2LSTMEvolutionPolicy.initialize_from_champion`.
+  `sc2_cnn` — zeroes the two conv layers and fits a random projection from
+  obs → FC_DIM, then solves for the fn and spatial output heads via closed-form
+  least squares, seeding `SC2CNNEvolutionPolicy._champion` and `_mean`.
+  `epsilon_greedy` / `ucb_q` — seeds `_q_table`, `_n_sa`, and `_n_s` from
+  binned demo (state, action_idx) visits; Q-values are normalised by visit count.
+  SB3 targets raise `ValueError` with an explicit "SB3" message.  New `fit_bc`
+  params: `n_channels` (CNN), `n_bins` (tabular), `bc_lstm_hidden_size` (LSTM).
+  `run()` forwards all new params through to `fit_bc`.
 - SC2 behaviour-cloning core fit + `--bc` entry point (issue #353, [4/6]):
   `fit_bc(dataset, obs_spec, *, target, ...)` in `games/sc2/replay_bc.py`
   pre-trains a policy from a demonstration NPZ: `target="sc2_reinforce"`

--- a/games/sc2/replay_bc.py
+++ b/games/sc2/replay_bc.py
@@ -873,8 +873,496 @@ def _fit_bc_linear(
 
 
 # ---------------------------------------------------------------------------
+# BC fitting — new policy targets (issue #354)
+# ---------------------------------------------------------------------------
+
+
+def _fit_bc_cmaes(
+    obs_arr: np.ndarray,
+    act_arr: np.ndarray,
+    obs_spec: ObsSpec,
+) -> tuple[Any, float]:
+    """BC warm-start for SC2CMAESPolicy via linear fit + champion seeding.
+
+    Fits an SC2MultiHeadLinearPolicy via closed-form least squares (same as
+    ``sc2_genetic``), then seeds an SC2CMAESPolicy's distribution mean and
+    champion from the fitted linear policy.
+
+    Returns (SC2CMAESPolicy, normalised_residual).
+    """
+    from games.sc2.sc2_policies import SC2CMAESPolicy
+
+    linear_policy, bc_loss = _fit_bc_linear(obs_arr, act_arr, obs_spec)
+    policy = SC2CMAESPolicy(obs_spec=obs_spec)
+    policy.initialize_from_champion(linear_policy)
+    return policy, bc_loss
+
+
+def _fit_bc_neural_net(
+    obs_arr: np.ndarray,
+    act_arr: np.ndarray,
+    obs_spec: ObsSpec,
+    *,
+    hidden_sizes: list[int],
+    lr: float,
+    epochs: int,
+    batch_size: int,
+    seed: int | None,
+) -> tuple[Any, float]:
+    """Mini-batch SGD regression BC fit into an SC2NeuralNetPolicy.
+
+    Targets: logit-transformed ``fn_idx / (N_FUNCTION_IDS - 1)``, ``x``, ``y``
+    for the first three output neurons (output[3] = queue, trained toward 0).
+    Loss = MSE on all 4 outputs.
+
+    Returns (SC2NeuralNetPolicy, avg_loss_last_epoch).
+    """
+    from games.sc2.sc2_policies import N_FUNCTION_IDS, SC2NeuralNetPolicy
+
+    policy = SC2NeuralNetPolicy(obs_spec=obs_spec, hidden_sizes=hidden_sizes)
+    rng = np.random.default_rng(seed)
+
+    n = len(obs_arr)
+    scales = obs_spec.scales.astype(np.float64)
+    fn_idx_arr = act_arr[:, 0].astype(np.float64)
+    x_arr = act_arr[:, 1].astype(np.float64)
+    y_arr = act_arr[:, 2].astype(np.float64)
+
+    def _logit(p: np.ndarray) -> np.ndarray:
+        p_clip = np.clip(p, 1e-6, 1.0 - 1e-6)
+        return np.log(p_clip / (1.0 - p_clip))
+
+    # Build regression targets: logit-transform fn_idx/N and x/y
+    fn_norm = np.clip(fn_idx_arr / max(N_FUNCTION_IDS - 1, 1), 1e-6, 1.0 - 1e-6)
+    t0 = _logit(fn_norm)  # (N,) — logit of normalised fn_idx
+    t1 = _logit(x_arr)  # (N,) — logit of x
+    t2 = _logit(y_arr)  # (N,) — logit of y
+    t3 = np.zeros(n, dtype=np.float64)  # queue target = 0
+    targets = np.stack([t0, t1, t2, t3], axis=1)  # (N, 4)
+
+    avg_loss = float("inf")
+    for epoch in range(epochs):
+        order = rng.permutation(n)
+        total_loss = 0.0
+        n_batches = 0
+
+        for start in range(0, n, batch_size):
+            idx = order[start : start + batch_size]
+            obs_b = obs_arr[idx].astype(np.float64)
+            tgt_b = targets[idx]  # (B, 4)
+            B = len(idx)
+
+            # --- forward ---
+            x = obs_b / scales  # (B, D)
+            layer_inputs: list[np.ndarray] = []
+            pre_relus: list[np.ndarray] = []
+            for i, (w, b) in enumerate(zip(policy._weights, policy._biases)):
+                layer_inputs.append(x.copy())
+                z = x @ w.T.astype(np.float64) + b.astype(np.float64)
+                pre_relus.append(z.copy())
+                if i < len(policy._weights) - 1:
+                    x = np.maximum(0.0, z)
+                else:
+                    x = z  # final layer: no activation
+            out = x  # (B, 4)
+
+            # --- MSE loss on all 4 outputs ---
+            diff = out - tgt_b  # (B, 4)
+            mse = float(np.mean(diff**2))
+            total_loss += mse
+            n_batches += 1
+
+            # --- backprop ---
+            g = 2.0 * diff / B  # (B, 4) — dLoss/d_out
+
+            # Backprop through layers (reverse order)
+            for i in range(len(policy._weights) - 1, -1, -1):
+                w_old = policy._weights[i].astype(np.float64)
+                b_old = policy._biases[i].astype(np.float64)
+                h_in = layer_inputs[i]  # (B, fan_in)
+
+                dw = g.T @ h_in  # (fan_out, fan_in)
+                db = g.sum(axis=0)  # (fan_out,)
+
+                policy._weights[i] = (w_old - lr * dw).astype(np.float32)
+                policy._biases[i] = (b_old - lr * db).astype(np.float32)
+
+                if i > 0:
+                    g = g @ w_old  # (B, fan_in)
+                    g = g * (pre_relus[i - 1] > 0)  # backprop through ReLU
+
+        avg_loss = total_loss / max(n_batches, 1)
+        logger.info("BC neural_net epoch %d/%d: avg_loss=%.6f", epoch + 1, epochs, avg_loss)
+
+    return policy, avg_loss
+
+
+def _fit_bc_dqn(
+    obs_arr: np.ndarray,
+    act_arr: np.ndarray,
+    obs_spec: ObsSpec,
+    *,
+    episode_starts: "np.ndarray | None",
+    seed: int | None,
+) -> tuple[Any, float]:
+    """Pre-fill an SC2NeuralDQNPolicy replay buffer with demonstration transitions.
+
+    Each demo step is matched to the nearest row in DISCRETE_ACTIONS by L1
+    distance and pushed into the policy's replay buffer.  The bc_loss returned
+    is the fill fraction (transitions / capacity).
+
+    Returns (SC2NeuralDQNPolicy, fill_fraction).
+    """
+    from games.sc2.actions import DISCRETE_ACTIONS
+    from games.sc2.sc2_policies import SC2NeuralDQNPolicy
+
+    policy = SC2NeuralDQNPolicy(obs_spec=obs_spec, seed=seed)
+    n = len(obs_arr)
+    da = DISCRETE_ACTIONS  # (M, 4)
+
+    # Build done flags: last step of each episode is done.
+    done_flags = np.zeros(n, dtype=bool)
+    if episode_starts is not None:
+        ep_starts = np.asarray(episode_starts, dtype=int)
+        for s in ep_starts[1:]:
+            if 0 < s <= n:
+                done_flags[s - 1] = True
+    done_flags[n - 1] = True
+
+    # Vectorised nearest-action matching: batch to keep memory reasonable.
+    batch = 2048
+    action_indices = np.empty(n, dtype=int)
+    for start in range(0, n, batch):
+        end = min(start + batch, n)
+        acts_b = act_arr[start:end].astype(np.float32)  # (B, 4)
+        diffs = np.abs(da[np.newaxis, :, :] - acts_b[:, np.newaxis, :]).sum(axis=2)  # (B, M)
+        action_indices[start:end] = np.argmin(diffs, axis=1)
+
+    for t in range(n - 1):
+        policy._replay.push(
+            obs_arr[t],
+            int(action_indices[t]),
+            1.0,
+            obs_arr[t + 1],
+            bool(done_flags[t]),
+        )
+    # Last step: use itself as next_obs (terminal)
+    policy._replay.push(
+        obs_arr[n - 1],
+        int(action_indices[n - 1]),
+        1.0,
+        obs_arr[n - 1],
+        True,
+    )
+
+    bc_loss = float(len(policy._replay)) / max(policy._buf_maxlen, 1)
+    return policy, bc_loss
+
+
+def _iter_episodes_from_dataset(dataset: dict) -> "Iterator[tuple[np.ndarray, np.ndarray]]":
+    """Yield ``(obs_seq, act_seq)`` episode pairs from a dataset dict.
+
+    Works with both file-loaded datasets (numpy arrays) and raw dict datasets
+    (numpy arrays or lists).
+    """
+    obs_all = dataset["obs"]
+    act_all = dataset["actions"]
+    ep_starts = np.asarray(dataset["episode_starts"], dtype=int)
+    ep_lengths = np.asarray(dataset["episode_lengths"], dtype=int)
+    for start, length in zip(ep_starts.tolist(), ep_lengths.tolist()):
+        yield obs_all[start : start + length], act_all[start : start + length]
+
+
+def _fit_bc_lstm_supervised(
+    episodes: "list[tuple[np.ndarray, np.ndarray]]",
+    obs_spec: ObsSpec,
+    *,
+    hidden_size: int,
+    lr: float,
+    epochs: int,
+    seed: int | None,
+) -> tuple[Any, float]:
+    """Supervised training of an SC2LSTMPolicy output head from episode sequences.
+
+    Only the output head (W_out, b_out) is trained; LSTM gate weights are kept
+    at their random initialisation.  Forward passes run through the LSTM to
+    collect hidden states, which are then used as inputs to the output head.
+    Loss = cross-entropy on fn_idx head + cross-entropy on spatial cell head.
+
+    Returns (SC2LSTMEvolutionPolicy, avg_loss_last_epoch).
+    """
+    from games.sc2.sc2_policies import (
+        _SPATIAL_GRID,
+        N_FUNCTION_IDS,
+        SC2LSTMEvolutionPolicy,
+        SC2LSTMPolicy,
+    )
+
+    lstm = SC2LSTMPolicy(obs_spec=obs_spec, hidden_size=hidden_size, seed=seed)
+    h_sz = hidden_size
+    scales = obs_spec.scales.astype(np.float32)
+
+    def _vsig(z: np.ndarray) -> np.ndarray:
+        return 1.0 / (1.0 + np.exp(-np.clip(z, -20.0, 20.0)))
+
+    # Collect (h_t, fn_idx_t, cell_idx_t) across all episodes via forward pass.
+    all_h: list[np.ndarray] = []
+    all_fn: list[int] = []
+    all_sp: list[int] = []
+
+    grid = np.array(_SPATIAL_GRID, dtype=np.float64)  # (N_LSTM_SPATIAL_CELLS, 2)
+
+    for obs_ep, act_ep in episodes:
+        h_state = np.zeros(h_sz, dtype=np.float32)
+        c_state = np.zeros(h_sz, dtype=np.float32)
+        for t in range(len(obs_ep)):
+            x = obs_ep[t].astype(np.float32) / scales
+            hx = np.concatenate([h_state, x])
+            f = _vsig(lstm._W_f @ hx + lstm._b_f)
+            ig = _vsig(lstm._W_i @ hx + lstm._b_i)
+            g = np.tanh(lstm._W_g @ hx + lstm._b_g)
+            o = _vsig(lstm._W_o @ hx + lstm._b_o)
+            c_state = f * c_state + ig * g
+            h_state = o * np.tanh(c_state)
+            all_h.append(h_state.copy())
+            all_fn.append(int(act_ep[t, 0]))
+            xy = act_ep[t, 1:3].astype(np.float64)
+            cell_idx = int(np.argmin(np.sum((grid - xy) ** 2, axis=1)))
+            all_sp.append(cell_idx)
+
+    if not all_h:
+        # No steps — return untrained policy
+        evo = SC2LSTMEvolutionPolicy(obs_spec=obs_spec, hidden_size=hidden_size, seed=seed)
+        evo.initialize_from_champion(lstm)
+        return evo, float("inf")
+
+    H_arr = np.array(all_h, dtype=np.float64)  # (N, h_sz)
+    fn_arr = np.array(all_fn, dtype=int)
+    sp_arr = np.array(all_sp, dtype=int)
+    N_total = len(H_arr)
+
+    rng = np.random.default_rng(seed)
+    avg_loss = float("inf")
+    for epoch in range(epochs):
+        order = rng.permutation(N_total)
+        total_loss = 0.0
+        n_batches = 0
+        for start in range(0, N_total, 256):
+            idx = order[start : start + 256]
+            h_b = H_arr[idx]  # (B, h_sz)
+            fn_b = fn_arr[idx]
+            sp_b = sp_arr[idx]
+            B = len(idx)
+
+            W_out = lstm._W_out.astype(np.float64)
+            b_out = lstm._b_out.astype(np.float64)
+            out = h_b @ W_out.T + b_out  # (B, N_OUTPUT)
+
+            fn_logits = out[:, :N_FUNCTION_IDS]
+            sp_logits = out[:, N_FUNCTION_IDS:]
+
+            # --- CE on fn head ---
+            fn_shift = fn_logits - fn_logits.max(axis=1, keepdims=True)
+            exp_fn = np.exp(fn_shift)
+            sm_fn = exp_fn / exp_fn.sum(axis=1, keepdims=True)
+            ce_fn = -float(np.mean(np.log(np.maximum(sm_fn[np.arange(B), fn_b], 1e-10))))
+
+            # --- CE on spatial head ---
+            sp_shift = sp_logits - sp_logits.max(axis=1, keepdims=True)
+            exp_sp = np.exp(sp_shift)
+            sm_sp = exp_sp / exp_sp.sum(axis=1, keepdims=True)
+            ce_sp = -float(np.mean(np.log(np.maximum(sm_sp[np.arange(B), sp_b], 1e-10))))
+
+            total_loss += ce_fn + ce_sp
+            n_batches += 1
+
+            # --- gradients ---
+            d_fn = sm_fn.copy()
+            d_fn[np.arange(B), fn_b] -= 1.0
+            d_fn /= B
+            d_sp = sm_sp.copy()
+            d_sp[np.arange(B), sp_b] -= 1.0
+            d_sp /= B
+            d_out = np.concatenate([d_fn, d_sp], axis=1)  # (B, N_OUTPUT)
+
+            lstm._W_out = (W_out - lr * (d_out.T @ h_b)).astype(np.float32)
+            lstm._b_out = (b_out - lr * d_out.sum(axis=0)).astype(np.float32)
+
+        avg_loss = total_loss / max(n_batches, 1)
+        logger.info("BC lstm epoch %d/%d: avg_loss=%.6f", epoch + 1, epochs, avg_loss)
+
+    # Wrap in evolution policy
+    evo = SC2LSTMEvolutionPolicy(obs_spec=obs_spec, hidden_size=hidden_size, seed=seed)
+    evo.initialize_from_champion(lstm)
+    return evo, avg_loss
+
+
+def _fit_bc_cnn(
+    obs_arr: np.ndarray,
+    act_arr: np.ndarray,
+    obs_spec: ObsSpec,
+    *,
+    n_channels: int,
+    seed: int | None,
+) -> tuple[Any, float]:
+    """Random-projection warm-start for SC2CNNEvolutionPolicy.
+
+    Since the CNN's conv layers cannot be meaningfully fitted from flat
+    observations, the conv weights are zeroed and the FC layer is replaced by
+    a random projection from obs_dim → FC_DIM.  The output heads (W_fn, W_sp)
+    are then fitted via closed-form least squares on the projected features.
+
+    Returns (SC2CNNEvolutionPolicy, mean_squared_residual_on_fn_head).
+    """
+    from games.sc2.cnn_policy import (
+        _GRID_XY,
+        _N_SPATIAL_CELLS,
+        SC2CNNEvolutionPolicy,
+    )
+    from games.sc2.sc2_policies import N_FUNCTION_IDS
+
+    policy = SC2CNNEvolutionPolicy(n_channels=n_channels, obs_spec=obs_spec, seed=seed)
+    model = policy._template  # SC2CNNModel — source of architecture info
+
+    rng = np.random.default_rng(seed)
+    scales = obs_spec.scales.astype(np.float64)
+    obs_dim = obs_spec.dim
+    FC_DIM = model._FC_DIM  # 256
+    pool_flat = model._pool_flat  # 1024
+
+    N = len(obs_arr)
+
+    # Random projection: obs_dim → FC_DIM (replaces conv + pool path with zeros)
+    W3_flat = (rng.standard_normal((FC_DIM, obs_dim)) / np.sqrt(obs_dim)).astype(np.float32)
+    b3 = np.zeros(FC_DIM, dtype=np.float32)
+
+    # Compute projected features H = relu(norm_obs @ W3_flat.T)
+    norm_obs = obs_arr.astype(np.float64) / scales
+    H = np.maximum(0.0, norm_obs @ W3_flat.T.astype(np.float64))  # (N, FC_DIM)
+
+    # --- fn head lstsq ---
+    fn_idx_arr = act_arr[:, 0].astype(int)
+    Y_fn = np.zeros((N, N_FUNCTION_IDS), dtype=np.float64)
+    Y_fn[np.arange(N), fn_idx_arr] = 1.0
+    W_fn_fit, _, _, _ = np.linalg.lstsq(H, Y_fn, rcond=None)  # (FC_DIM, N_FUNCTION_IDS)
+
+    # --- spatial head lstsq ---
+    xy_arr = act_arr[:, 1:3].astype(np.float64)
+    grid_xy = np.array(_GRID_XY, dtype=np.float64)  # (_N_SPATIAL_CELLS, 2)
+    # Find nearest CNN grid cell for each (x, y) demo action
+    dists = np.sum((xy_arr[:, np.newaxis, :] - grid_xy[np.newaxis, :, :]) ** 2, axis=2)  # (N, S)
+    sp_indices = np.argmin(dists, axis=1)  # (N,)
+    Y_sp = np.zeros((N, _N_SPATIAL_CELLS), dtype=np.float64)
+    Y_sp[np.arange(N), sp_indices] = 1.0
+    W_sp_fit, _, _, _ = np.linalg.lstsq(H, Y_sp, rcond=None)  # (FC_DIM, _N_SPATIAL_CELLS)
+
+    # Build champion model with warm weights
+    champion = model.with_flat(model.to_flat())  # structural copy
+    champion.W1 = np.zeros_like(champion.W1)
+    champion.W2 = np.zeros_like(champion.W2)
+    champion.b1 = np.zeros_like(champion.b1)
+    champion.b2 = np.zeros_like(champion.b2)
+    # W3: shape (FC_DIM, pool_flat + obs_dim) — zero the conv portion, use W3_flat for obs portion
+    champion.W3 = np.zeros((FC_DIM, pool_flat + obs_dim), dtype=np.float32)
+    champion.W3[:, pool_flat:] = W3_flat
+    champion.b3 = b3.copy()
+    champion.W_fn = W_fn_fit.T.astype(np.float32)  # (N_FUNCTION_IDS, FC_DIM)
+    champion.b_fn = np.zeros(N_FUNCTION_IDS, dtype=np.float32)
+    champion.W_sp = W_sp_fit.T.astype(np.float32)  # (_N_SPATIAL_CELLS, FC_DIM)
+    champion.b_sp = np.zeros(_N_SPATIAL_CELLS, dtype=np.float32)
+
+    # Seed policy champion and distribution mean
+    policy._champion = champion
+    policy._mean = champion.to_flat().astype(np.float64)
+
+    # BC loss = mean squared residual on fn head predictions
+    H_pred_fn = H @ W_fn_fit  # (N, N_FUNCTION_IDS)
+    bc_loss = float(np.mean((H_pred_fn - Y_fn) ** 2))
+    return policy, bc_loss
+
+
+def _fit_bc_tabular(
+    obs_arr: np.ndarray,
+    act_arr: np.ndarray,
+    obs_spec: ObsSpec,
+    *,
+    target: str,
+    n_bins: int,
+    seed: int | None,
+) -> tuple[Any, float]:
+    """Seed Q-table and visit-count tables from binned demo (state, action_idx) pairs.
+
+    Each demonstration step is discretised into a state key and matched to
+    the nearest row in DISCRETE_ACTIONS by L1 distance.  The Q-table is
+    seeded with normalised visit counts (Q[s][a] = count(s,a)/count(s)) and
+    the count tables are populated for UCB exploration.
+
+    Returns (EpsilonGreedyPolicy or UCBQPolicy, 0.0).
+    """
+    from framework.policies import EpsilonGreedyPolicy, UCBQPolicy, _discretize_obs
+    from games.sc2.actions import DISCRETE_ACTIONS
+
+    da = DISCRETE_ACTIONS
+    n_actions = len(da)
+    scales = obs_spec.scales
+
+    if target == "epsilon_greedy":
+        policy: Any = EpsilonGreedyPolicy(obs_spec, da, n_bins=n_bins)
+    else:
+        policy = UCBQPolicy(obs_spec, da, n_bins=n_bins)
+
+    n = len(obs_arr)
+
+    # Vectorised nearest-action matching
+    batch = 2048
+    action_indices = np.empty(n, dtype=int)
+    for start in range(0, n, batch):
+        end = min(start + batch, n)
+        acts_b = act_arr[start:end].astype(np.float32)
+        diffs = np.abs(da[np.newaxis, :, :] - acts_b[:, np.newaxis, :]).sum(axis=2)
+        action_indices[start:end] = np.argmin(diffs, axis=1)
+
+    for t in range(n):
+        obs = obs_arr[t].astype(np.float32)
+        state = _discretize_obs(obs, scales, n_bins)
+        action_idx = int(action_indices[t])
+
+        if state not in policy._q_table:
+            policy._q_table[state] = np.zeros(n_actions, dtype=np.float32)
+        if state not in policy._n_sa:
+            policy._n_sa[state] = np.zeros(n_actions, dtype=np.float32)
+
+        policy._q_table[state][action_idx] += 1.0
+        policy._n_sa[state][action_idx] += 1.0
+        policy._n_s[state] = policy._n_s.get(state, 0) + 1
+
+    # Normalise Q-values by visit count
+    for state, q in policy._q_table.items():
+        counts = policy._n_sa[state]
+        mask = counts > 0
+        q[mask] /= counts[mask]
+
+    return policy, 0.0
+
+
+# ---------------------------------------------------------------------------
 # Public fit_bc entry point
 # ---------------------------------------------------------------------------
+
+_SB3_TARGETS: frozenset[str] = frozenset({"ppo", "a2c", "sac", "td3", "qr_dqn", "recurrent_ppo"})
+_SUPPORTED_TARGETS: frozenset[str] = frozenset(
+    {
+        "sc2_reinforce",
+        "sc2_genetic",
+        "sc2_cmaes",
+        "sc2_neural_net",
+        "sc2_neural_dqn",
+        "sc2_lstm",
+        "sc2_cnn",
+        "epsilon_greedy",
+        "ucb_q",
+    }
+)
 
 
 def fit_bc(
@@ -888,6 +1376,9 @@ def fit_bc(
     bc_batch_size: int = 256,
     bc_ignore_noop: bool = True,
     seed: int | None = None,
+    n_channels: int = 1,
+    n_bins: int = 3,
+    bc_lstm_hidden_size: int = 64,
 ) -> tuple[Any, float]:
     """Pre-train a policy on a demonstration dataset via behaviour cloning.
 
@@ -899,50 +1390,88 @@ def fit_bc(
     obs_spec :
         Observation spec used to normalise observations before fitting.
     target :
-        Policy architecture to train.
+        Policy architecture to train.  Supported values:
 
-        * ``"sc2_reinforce"`` (default) — two-head MLP
-          (:class:`games.sc2.sc2_policies.SC2REINFORCEPolicy`) trained via
-          mini-batch gradient descent.  Loss = cross-entropy on the fn_idx
-          softmax head + MSE on the sigmoid ``(x, y)`` spatial head for
-          spatial actions only.  Saved weights load via
-          ``SC2REINFORCEPolicy.from_cfg`` so a subsequent ``sc2_reinforce``
-          fine-tuning run resumes from them.
+        * ``"sc2_reinforce"`` (default) — two-head MLP trained via
+          mini-batch gradient descent.
+        * ``"sc2_genetic"`` — linear least-squares fit into
+          ``SC2MultiHeadLinearPolicy``.
+        * ``"sc2_cmaes"`` — same linear fit as ``sc2_genetic``, then seeds
+          the CMA-ES distribution mean.
+        * ``"sc2_neural_net"`` — MSE regression into ``SC2NeuralNetPolicy``
+          via mini-batch SGD.
+        * ``"sc2_neural_dqn"`` — pre-fills the DQN replay buffer with demo
+          transitions matched to the nearest ``DISCRETE_ACTIONS`` row.
+        * ``"sc2_lstm"`` — trains the LSTM output head (W_out/b_out) via
+          cross-entropy SGD while keeping gate weights frozen.
+        * ``"sc2_cnn"`` — random-projection warm-start: zeroes conv weights
+          and fits the FC+head via least squares on projected obs.
+        * ``"epsilon_greedy"`` / ``"ucb_q"`` — seeds the Q-table and visit
+          counts from binned demo (state, action) pairs.
 
-        * ``"sc2_genetic"`` — linear
-          (:class:`games.sc2.sc2_policies.SC2MultiHeadLinearPolicy`) fitted
-          via closed-form least squares.  Saved in ``SC2MultiHeadLinearPolicy``
-          YAML format; compatible with ``sc2_genetic`` fine-tuning.
+        SB3 policies (``"ppo"``, ``"a2c"``, ``"sac"``, ``"td3"``,
+        ``"qr_dqn"``, ``"recurrent_ppo"``) are not supported for SC2 and
+        raise ``ValueError``.
 
     hidden_sizes :
-        MLP trunk hidden-layer widths (``"sc2_reinforce"`` only).
-        Defaults to ``[128, 64]``.
+        MLP trunk hidden-layer widths (``"sc2_reinforce"`` and
+        ``"sc2_neural_net"`` only).  Defaults to ``[128, 64]``.
     bc_epochs :
-        Full passes over the dataset (``"sc2_reinforce"`` only).
+        Full passes over the dataset (gradient targets only).
     bc_learning_rate :
-        Gradient step size (``"sc2_reinforce"`` only).
+        Gradient step size (gradient targets only).
     bc_batch_size :
-        Mini-batch size (``"sc2_reinforce"`` only).
+        Mini-batch size (gradient targets only).
     bc_ignore_noop :
-        Drop steps where ``fn_idx == 0`` (no-op) before fitting so the fn
-        head is not swamped by idle frames.
+        Drop steps where ``fn_idx == 0`` (no-op) before fitting.
+        Not applied to ``"sc2_lstm"`` (which reconstructs per-episode
+        sequences directly from the dataset).
     seed :
         Optional RNG seed for reproducibility.
+    n_channels :
+        Number of CNN spatial channels (``"sc2_cnn"`` only).
+    n_bins :
+        Observation bins per dimension for tabular discretisation
+        (``"epsilon_greedy"`` / ``"ucb_q"`` only).
+    bc_lstm_hidden_size :
+        LSTM hidden state size (``"sc2_lstm"`` only).
 
     Returns
     -------
     (policy, final_bc_loss)
         *policy* is the fitted policy object.  *final_bc_loss* is the
-        average loss over the last epoch for MLP targets, or the normalised
-        residual for the linear target.
+        average loss over the last epoch for gradient targets, the
+        normalised residual for linear targets, the replay-buffer fill
+        fraction for DQN, or ``0.0`` for tabular targets.
 
     Raises
     ------
     ValueError
-        If the dataset is empty after the optional no-op filter.
+        If *target* is an SB3 policy or unknown, or if the dataset is
+        empty after the optional no-op filter.
     """
+    if target in _SB3_TARGETS:
+        raise ValueError(
+            f"BC warm-start for target={target!r} is not supported: SB3 policies are "
+            "gated off SC2 and cannot be seeded from a demonstration dataset."
+        )
+    if target not in _SUPPORTED_TARGETS:
+        raise ValueError(f"Unknown BC target {target!r}. Supported: {sorted(_SUPPORTED_TARGETS)}.")
+
     if not isinstance(dataset, dict):
         dataset = load_dataset(str(dataset))
+
+    # sc2_lstm needs episode sequences — handle before flat filtering
+    if target == "sc2_lstm":
+        episodes = list(_iter_episodes_from_dataset(dataset))
+        return _fit_bc_lstm_supervised(
+            episodes,
+            obs_spec,
+            hidden_size=bc_lstm_hidden_size,
+            lr=bc_learning_rate,
+            epochs=bc_epochs,
+            seed=seed,
+        )
 
     obs_arr = dataset["obs"].astype(np.float32)
     act_arr = dataset["actions"].astype(np.float32)
@@ -953,7 +1482,9 @@ def fit_bc(
         n_before = len(obs_arr)
         obs_arr = obs_arr[keep]
         act_arr = act_arr[keep]
-        logger.info("bc_ignore_noop: kept %d / %d steps (dropped %d no-ops)", len(obs_arr), n_before, n_before - len(obs_arr))
+        logger.info(
+            "bc_ignore_noop: kept %d / %d steps (dropped %d no-ops)", len(obs_arr), n_before, n_before - len(obs_arr)
+        )
 
     if len(obs_arr) == 0:
         raise ValueError("Empty dataset after filtering — no non-noop steps available for BC.")
@@ -961,12 +1492,37 @@ def fit_bc(
     if target == "sc2_genetic":
         return _fit_bc_linear(obs_arr, act_arr, obs_spec)
 
-    if target != "sc2_reinforce":
-        raise ValueError(
-            f"Unknown BC target {target!r}. "
-            "Supported targets: 'sc2_reinforce' (MLP), 'sc2_genetic' (linear)."
+    if target == "sc2_cmaes":
+        return _fit_bc_cmaes(obs_arr, act_arr, obs_spec)
+
+    if target == "sc2_neural_net":
+        return _fit_bc_neural_net(
+            obs_arr,
+            act_arr,
+            obs_spec,
+            hidden_sizes=hidden_sizes if hidden_sizes is not None else [128, 64],
+            lr=bc_learning_rate,
+            epochs=bc_epochs,
+            batch_size=bc_batch_size,
+            seed=seed,
         )
 
+    if target == "sc2_neural_dqn":
+        return _fit_bc_dqn(
+            obs_arr,
+            act_arr,
+            obs_spec,
+            episode_starts=dataset.get("episode_starts"),
+            seed=seed,
+        )
+
+    if target == "sc2_cnn":
+        return _fit_bc_cnn(obs_arr, act_arr, obs_spec, n_channels=n_channels, seed=seed)
+
+    if target in ("epsilon_greedy", "ucb_q"):
+        return _fit_bc_tabular(obs_arr, act_arr, obs_spec, target=target, n_bins=n_bins, seed=seed)
+
+    # sc2_reinforce (default)
     return _fit_bc_mlp(
         obs_arr,
         act_arr,
@@ -1002,6 +1558,9 @@ def run(
     bc_batch_size: int = 256,
     bc_ignore_noop: bool = True,
     seed: int | None = None,
+    n_channels: int = 1,
+    n_bins: int = 3,
+    bc_lstm_hidden_size: int = 64,
 ) -> dict:
     """Orchestrate replay reading, BC fitting, and saving of weights + summary.
 
@@ -1024,7 +1583,8 @@ def run(
         Observation spec — built from ``training_params.yaml`` by the caller.
     target, player_id, race, max_replays, step_mul, screen_size,
     minimap_size, hidden_sizes, bc_epochs, bc_learning_rate,
-    bc_batch_size, bc_ignore_noop, seed :
+    bc_batch_size, bc_ignore_noop, seed, n_channels, n_bins,
+    bc_lstm_hidden_size :
         Forwarded to :func:`build_dataset` and/or :func:`fit_bc`.
 
     Returns
@@ -1038,7 +1598,6 @@ def run(
         If the replay directory is empty, race filter drops all replays, or
         the filtered dataset has no steps.
     """
-    import os
     import tempfile
 
     from framework.policies import BasePolicy, trainer_state_path
@@ -1080,12 +1639,23 @@ def run(
         bc_batch_size=bc_batch_size,
         bc_ignore_noop=bc_ignore_noop,
         seed=seed,
+        n_channels=n_channels,
+        n_bins=n_bins,
+        bc_lstm_hidden_size=bc_lstm_hidden_size,
     )
 
-    # Save policy weights
+    # Save policy weights.
+    # For champion-based policies whose save() writes metadata only (e.g.
+    # SC2CMAESPolicy), save the champion directly in the linear YAML format so
+    # _construct_or_resume can reload it on the next run.
     weights_path = str(experiment_dir / "policy_weights.yaml")
-    policy.save(weights_path)
-    logger.info("BC: saved policy weights → %s", weights_path)
+    champion = getattr(policy, "_champion", None)
+    if champion is not None and hasattr(champion, "save") and callable(champion.save):
+        champion.save(weights_path)
+        logger.info("BC: saved champion weights → %s", weights_path)
+    else:
+        policy.save(weights_path)
+        logger.info("BC: saved policy weights → %s", weights_path)
 
     # Save trainer state for policies that carry one (e.g. SC2REINFORCEPolicy)
     if isinstance(policy, BasePolicy):

--- a/games/sc2/replay_bc.py
+++ b/games/sc2/replay_bc.py
@@ -1039,19 +1039,21 @@ def _fit_bc_dqn(
         action_indices[start:end] = np.argmin(diffs, axis=1)
 
     for t in range(n - 1):
+        done = bool(done_flags[t])
+        next_obs = np.zeros_like(obs_arr[t]) if done else obs_arr[t + 1]
         policy._replay.push(
             obs_arr[t],
             int(action_indices[t]),
             1.0,
-            obs_arr[t + 1],
-            bool(done_flags[t]),
+            next_obs,
+            done,
         )
-    # Last step: use itself as next_obs (terminal)
+    # Last step: terminal — zero next_obs so the Bellman target is unaffected
     policy._replay.push(
         obs_arr[n - 1],
         int(action_indices[n - 1]),
         1.0,
-        obs_arr[n - 1],
+        np.zeros_like(obs_arr[n - 1]),
         True,
     )
 
@@ -1247,14 +1249,24 @@ def _fit_bc_cnn(
     W_fn_fit, _, _, _ = np.linalg.lstsq(H, Y_fn, rcond=None)  # (FC_DIM, N_FUNCTION_IDS)
 
     # --- spatial head lstsq ---
+    # Use batched distance computation to avoid the (N, _N_SPATIAL_CELLS) OOM matrix.
+    # Then solve H^T H W = H^T Y via scatter-add rather than materialising Y_sp.
     xy_arr = act_arr[:, 1:3].astype(np.float64)
     grid_xy = np.array(_GRID_XY, dtype=np.float64)  # (_N_SPATIAL_CELLS, 2)
-    # Find nearest CNN grid cell for each (x, y) demo action
-    dists = np.sum((xy_arr[:, np.newaxis, :] - grid_xy[np.newaxis, :, :]) ** 2, axis=2)  # (N, S)
-    sp_indices = np.argmin(dists, axis=1)  # (N,)
-    Y_sp = np.zeros((N, _N_SPATIAL_CELLS), dtype=np.float64)
-    Y_sp[np.arange(N), sp_indices] = 1.0
-    W_sp_fit, _, _, _ = np.linalg.lstsq(H, Y_sp, rcond=None)  # (FC_DIM, _N_SPATIAL_CELLS)
+    _DIST_BATCH = 4096
+    sp_indices = np.empty(N, dtype=np.intp)
+    for _s in range(0, N, _DIST_BATCH):
+        _e = min(_s + _DIST_BATCH, N)
+        _d = np.sum(
+            (xy_arr[_s:_e, np.newaxis, :] - grid_xy[np.newaxis, :, :]) ** 2, axis=2
+        )
+        sp_indices[_s:_e] = np.argmin(_d, axis=1)
+    # Normal equations: (H^T H) W_sp = H^T Y_sp
+    # H^T Y_sp[j, c] = sum_{t: sp_indices[t]==c} H[t, j]; use scatter-add on H^T Y_sp.T
+    HtH = H.T @ H  # (FC_DIM, FC_DIM)
+    HtY_sp = np.zeros((FC_DIM, _N_SPATIAL_CELLS), dtype=np.float64)
+    np.add.at(HtY_sp.T, sp_indices, H)
+    W_sp_fit, _, _, _ = np.linalg.lstsq(HtH, HtY_sp, rcond=None)  # (FC_DIM, _N_SPATIAL_CELLS)
 
     # Build champion model with warm weights
     champion = model.with_flat(model.to_flat())  # structural copy
@@ -1336,11 +1348,11 @@ def _fit_bc_tabular(
         policy._n_sa[state][action_idx] += 1.0
         policy._n_s[state] = policy._n_s.get(state, 0) + 1
 
-    # Normalise Q-values by visit count
+    # Normalise Q-values to action-frequency distribution: q[s,a] = count(s,a)/count(s)
     for state, q in policy._q_table.items():
-        counts = policy._n_sa[state]
-        mask = counts > 0
-        q[mask] /= counts[mask]
+        total = policy._n_s[state]
+        if total > 0:
+            q /= total
 
     return policy, 0.0
 
@@ -1463,6 +1475,12 @@ def fit_bc(
 
     # sc2_lstm needs episode sequences — handle before flat filtering
     if target == "sc2_lstm":
+        missing = [k for k in ("episode_starts", "episode_lengths") if k not in dataset]
+        if missing:
+            raise ValueError(
+                f"Dataset is missing keys required for sc2_lstm BC: {missing}. "
+                "Re-extract the dataset with episode boundary tracking enabled."
+            )
         episodes = list(_iter_episodes_from_dataset(dataset))
         return _fit_bc_lstm_supervised(
             episodes,

--- a/grid_search.py
+++ b/grid_search.py
@@ -350,13 +350,19 @@ def _validate_bc_warmstart_combos(
 def _copy_bc_weights(bc_warmstart_dir: str, experiment_dir: str) -> None:
     """Copy BC-trained weight files from *bc_warmstart_dir* into *experiment_dir*.
 
-    Copies ``policy_weights.yaml`` (required), ``trainer_state.npz`` (MLP
+    Copies ``policy_weights.yaml`` (evolutionary/gradient targets),
+    ``policy_weights.npz`` (``sc2_cnn``), ``trainer_state.npz`` (MLP
     gradient targets such as ``sc2_reinforce``), and
     ``policy_weights_qtable.pkl`` (tabular targets ``epsilon_greedy`` /
     ``ucb_q``) when they exist in *bc_warmstart_dir*.
     """
     copied = []
-    for fname in ("policy_weights.yaml", "trainer_state.npz", "policy_weights_qtable.pkl"):
+    for fname in (
+        "policy_weights.yaml",
+        "policy_weights.npz",
+        "trainer_state.npz",
+        "policy_weights_qtable.pkl",
+    ):
         src = os.path.join(bc_warmstart_dir, fname)
         if os.path.exists(src):
             dst = os.path.join(experiment_dir, fname)
@@ -364,7 +370,8 @@ def _copy_bc_weights(bc_warmstart_dir: str, experiment_dir: str) -> None:
             copied.append(fname)
     if not copied:
         raise FileNotFoundError(
-            f"No BC weight files found in {bc_warmstart_dir!r}. Expected at least policy_weights.yaml."
+            f"No BC weight files found in {bc_warmstart_dir!r}. "
+            "Expected at least policy_weights.yaml or policy_weights.npz."
         )
     logger.debug("BC warm-start: copied %s → %s", copied, experiment_dir)
 

--- a/grid_search.py
+++ b/grid_search.py
@@ -26,8 +26,10 @@ from __future__ import annotations
 
 import argparse
 import itertools
+import json
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import uuid as _uuid
@@ -173,6 +175,15 @@ _ABBREV = {
     "action_mode": "actm",
     # atari params
     "clip_sign": "csign",
+    # behaviour-cloning params
+    "bc_target": "bct",
+    "bc_player_id": "bcpid",
+    "bc_race": "bcrace",
+    "bc_step_mul": "bcstm",
+    "bc_epochs": "bcep",
+    "bc_learning_rate": "bclr",
+    "bc_batch_size": "bcbs",
+    "bc_ignore_noop": "bcin",
     # curiosity params (issue #24)
     "curiosity_type": "ck",
     "curiosity_weight": "cwgt",
@@ -269,6 +280,203 @@ def _validate_policy_param_map() -> None:
 _validate_policy_param_map()
 
 
+# ---------------------------------------------------------------------------
+# BC warm-start helpers
+# ---------------------------------------------------------------------------
+
+# Maps bc_target → frozenset of compatible training policy_type values.
+# sc2_genetic and sc2_cmaes share the SC2MultiHeadLinearPolicy weight format
+# and are cross-compatible for warm-starting.
+_BC_COMPATIBLE_POLICY_TYPES: dict[str, frozenset[str]] = {
+    "sc2_genetic": frozenset({"sc2_genetic", "sc2_cmaes"}),
+    "sc2_cmaes": frozenset({"sc2_cmaes", "sc2_genetic"}),
+    "sc2_reinforce": frozenset({"sc2_reinforce"}),
+    "sc2_neural_net": frozenset({"sc2_neural_net"}),
+    "sc2_neural_dqn": frozenset({"sc2_neural_dqn"}),
+    "sc2_lstm": frozenset({"sc2_lstm"}),
+    "sc2_cnn": frozenset({"sc2_cnn"}),
+    "epsilon_greedy": frozenset({"epsilon_greedy"}),
+    "ucb_q": frozenset({"ucb_q"}),
+}
+
+
+def _validate_bc_warmstart_combos(
+    bc_warmstart_dir: str,
+    combos: list[dict[str, Any]],
+    names: list[str],
+) -> str:
+    """Check every combo's policy_type is compatible with the BC target.
+
+    Reads ``bc_summary.json`` from *bc_warmstart_dir*, then for every
+    combo checks that ``policy_type`` is in
+    ``_BC_COMPATIBLE_POLICY_TYPES[bc_target]``.  All incompatible combos
+    are collected and reported in a single ``ValueError`` so the user can
+    fix them all at once.
+
+    Returns the ``bc_target`` string from the summary on success.
+    """
+    summary_path = os.path.join(bc_warmstart_dir, "bc_summary.json")
+    if not os.path.exists(summary_path):
+        raise ValueError(
+            f"No bc_summary.json found in {bc_warmstart_dir!r}. "
+            "Cannot verify policy compatibility. "
+            "Run BC pre-training first: python main.py <exp> --game sc2 --bc"
+        )
+    with open(summary_path) as f:
+        summary = json.load(f)
+    bc_target = summary.get("bc_target")
+    if not bc_target:
+        raise ValueError(f"bc_summary.json in {bc_warmstart_dir!r} is missing the 'bc_target' field.")
+    compatible = _BC_COMPATIBLE_POLICY_TYPES.get(bc_target, frozenset())
+    errors = []
+    for name, combo in zip(names, combos):
+        t = combo["training_params"]
+        policy_type = t.get("policy_type", "sc2_genetic")
+        if policy_type not in compatible:
+            errors.append(f"  {name}: bc_target={bc_target!r} incompatible with policy_type={policy_type!r}")
+    if errors:
+        raise ValueError(
+            f"BC warm-start (target={bc_target!r}) is incompatible with the following "
+            "combo(s):\n" + "\n".join(errors) + f"\nCompatible policy_type values: {sorted(compatible)}"
+        )
+    logger.info(
+        "BC warm-start compatibility check passed: target=%s compatible with all %d combo(s).",
+        bc_target,
+        len(combos),
+    )
+    return bc_target
+
+
+def _copy_bc_weights(bc_warmstart_dir: str, experiment_dir: str) -> None:
+    """Copy BC-trained weight files from *bc_warmstart_dir* into *experiment_dir*.
+
+    Copies ``policy_weights.yaml`` (required), ``trainer_state.npz`` (MLP
+    gradient targets such as ``sc2_reinforce``), and
+    ``policy_weights_qtable.pkl`` (tabular targets ``epsilon_greedy`` /
+    ``ucb_q``) when they exist in *bc_warmstart_dir*.
+    """
+    copied = []
+    for fname in ("policy_weights.yaml", "trainer_state.npz", "policy_weights_qtable.pkl"):
+        src = os.path.join(bc_warmstart_dir, fname)
+        if os.path.exists(src):
+            dst = os.path.join(experiment_dir, fname)
+            shutil.copy2(src, dst)
+            copied.append(fname)
+    if not copied:
+        raise FileNotFoundError(
+            f"No BC weight files found in {bc_warmstart_dir!r}. Expected at least policy_weights.yaml."
+        )
+    logger.debug("BC warm-start: copied %s → %s", copied, experiment_dir)
+
+
+def _run_inline_bc(
+    bc_cfg: dict[str, Any],
+    adapter: Any,
+    base_name: str,
+    training_spec: dict[str, Any],
+    track_override: str | None,
+    game_name: str,
+) -> str:
+    """Run BC pre-training from the grid config ``bc:`` section.
+
+    Creates a shared ``<base_name>__bc_warmstart`` experiment directory
+    adjacent to the grid experiments.  If that directory already contains
+    ``policy_weights.yaml`` and ``bc_summary.json`` the BC step is skipped,
+    so restarting a grid run after an interruption is cheap.
+
+    Returns the path to the BC experiment directory.
+
+    Raises ``ValueError`` if *game_name* is not ``"sc2"`` or ``bc.replay_dir``
+    is missing.  Raises ``SystemExit`` when the SC2/PySC2 stack cannot be
+    imported.
+    """
+    if game_name != "sc2":
+        raise ValueError(
+            f"Inline BC pre-training (grid config 'bc:' section) is only supported for game='sc2', got {game_name!r}."
+        )
+    try:
+        from games.sc2.adapter import _get_obs_spec  # noqa: PLC0415
+        from games.sc2.replay_bc import run as bc_run  # noqa: PLC0415
+    except ImportError as exc:
+        raise SystemExit(f"Cannot import SC2 BC dependencies: {exc}\nInstall with: poetry install --with sc2") from exc
+
+    replay_dir = bc_cfg.get("replay_dir") or bc_cfg.get("bc_replay_dir")
+    if not replay_dir:
+        raise ValueError("Grid config 'bc.replay_dir' is required when a 'bc:' section is present.")
+
+    # Build obs_spec from the base training spec (before grid expansion).
+    map_name = training_spec.get("map_name", "MoveToBeacon")
+    obs_spec_preset = training_spec.get("obs_spec_preset")
+    enable_belief = bool(training_spec.get("enable_belief", False))
+    obs_spec = _get_obs_spec(map_name, obs_spec_preset, enable_belief)
+
+    # BC experiment dir is a sibling of the per-combo experiment dirs.
+    summary_root = adapter.experiment_dir_root(training_spec, track_override)
+    bc_dir = os.path.join(summary_root, f"{base_name}__bc_warmstart")
+    os.makedirs(bc_dir, exist_ok=True)
+
+    # Skip if already completed.
+    bc_summary_path = os.path.join(bc_dir, "bc_summary.json")
+    weights_path = os.path.join(bc_dir, "policy_weights.yaml")
+    if os.path.exists(bc_summary_path) and os.path.exists(weights_path):
+        logger.info(
+            "BC warm-start already exists at %s — skipping re-run. Delete %s to force a fresh BC run.",
+            bc_dir,
+            bc_dir,
+        )
+        return bc_dir
+
+    # Resolve BC options; bc_cfg keys take precedence over training_spec fallbacks.
+    bc_target = bc_cfg.get("bc_target") or bc_cfg.get("target") or training_spec.get("bc_target", "sc2_reinforce")
+    player_id: str | int = bc_cfg.get("player_id") or bc_cfg.get("bc_player_id", "winner")
+    if player_id in ("1", "2"):
+        player_id = int(player_id)
+    race = bc_cfg.get("race") or bc_cfg.get("bc_race", "any")
+    max_replays = bc_cfg.get("max_replays") or bc_cfg.get("bc_max_replays")
+    step_mul = bc_cfg.get("step_mul") or bc_cfg.get("bc_step_mul") or training_spec.get("step_mul", 1)
+    screen_size = bc_cfg.get("screen_size") or training_spec.get("screen_size", 64)
+    minimap_size = bc_cfg.get("minimap_size") or training_spec.get("minimap_size", 64)
+    bc_epochs = bc_cfg.get("bc_epochs") or bc_cfg.get("epochs", 10)
+    bc_lr = bc_cfg.get("bc_learning_rate") or bc_cfg.get("learning_rate", 1e-3)
+    bc_batch = bc_cfg.get("bc_batch_size") or bc_cfg.get("batch_size", 256)
+    # bc_ignore_noop may legitimately be False, so don't use `or`.
+    if "bc_ignore_noop" in bc_cfg:
+        bc_ignore_noop = bool(bc_cfg["bc_ignore_noop"])
+    elif "ignore_noop" in bc_cfg:
+        bc_ignore_noop = bool(bc_cfg["ignore_noop"])
+    else:
+        bc_ignore_noop = True
+
+    logger.info(
+        "=== Inline BC pre-training (target=%s, replay_dir=%s) ===",
+        bc_target,
+        replay_dir,
+    )
+    bc_run(
+        replay_dir,
+        bc_dir,
+        obs_spec,
+        target=bc_target,
+        player_id=player_id,
+        race=race,
+        max_replays=max_replays,
+        step_mul=step_mul,
+        screen_size=screen_size,
+        minimap_size=minimap_size,
+        bc_epochs=bc_epochs,
+        bc_learning_rate=bc_lr,
+        bc_batch_size=bc_batch,
+        bc_ignore_noop=bc_ignore_noop,
+        seed=bc_cfg.get("seed"),
+        n_channels=bc_cfg.get("n_channels", 1),
+        n_bins=bc_cfg.get("n_bins", 3),
+        bc_lstm_hidden_size=bc_cfg.get("bc_lstm_hidden_size") or bc_cfg.get("lstm_hidden_size", 64),
+        hidden_sizes=bc_cfg.get("hidden_sizes"),
+    )
+    logger.info("=== Inline BC pre-training complete → %s ===", bc_dir)
+    return bc_dir
+
+
 def _fmt_value(v: Any) -> str:
     """Format a param value for use in a directory name.
 
@@ -309,8 +517,13 @@ def _split_grid_run_name(name: str) -> tuple[str, str | None]:
 
 def _load_grid_config(
     path: str,
-) -> tuple[str, str, str, dict[str, Any], dict[str, Any], dict[str, Any]]:
-    """Load grid config YAML. Returns (base_name, game, track, training_spec, reward_spec, distribute_cfg)."""
+) -> tuple[str, str, str, dict[str, Any], dict[str, Any], dict[str, Any], dict[str, Any]]:
+    """Load grid config YAML.
+
+    Returns ``(base_name, game, track, training_spec, reward_spec, distribute_cfg, bc_cfg)``.
+    *bc_cfg* is the optional ``bc:`` section used for inline BC pre-training; it is
+    an empty dict when the section is absent.
+    """
     with open(path) as f:
         cfg = yaml.safe_load(f)
     base_name = cfg.get("base_name", "gs")
@@ -319,7 +532,8 @@ def _load_grid_config(
     training_spec = cfg.get("training_params", {})
     reward_spec = cfg.get("reward_params", {})
     distribute_cfg = cfg.get("distribute", {})
-    return base_name, game, track, training_spec, reward_spec, distribute_cfg
+    bc_cfg = cfg.get("bc", {})
+    return base_name, game, track, training_spec, reward_spec, distribute_cfg, bc_cfg
 
 
 def _expand_grid(training_spec: dict[str, Any], reward_spec: dict[str, Any]) -> tuple[list[dict[str, Any]], list[str]]:
@@ -428,6 +642,7 @@ def _run_local(
     track_override: str | None,
     no_interrupt: bool,
     re_initialize: bool,
+    bc_warmstart_dir: str | None = None,
 ) -> list[tuple[str, Any]]:
     """Run all combos sequentially on this machine. Returns list of (name, ExperimentData)."""
     from framework.analytics import save_experiment_data_json
@@ -440,6 +655,9 @@ def _run_local(
         logger.info("=== Run %d/%d: %s ===", i, n, name)
 
         experiment_dir, weights_file, reward_cfg_file = _setup_experiment_dir(adapter, name, t, r, track_override)
+
+        if bc_warmstart_dir is not None:
+            _copy_bc_weights(bc_warmstart_dir, experiment_dir)
 
         # Merge promoted policy params so grid axes like `epsilon: [0.5, 1.0]` work.
         t_with_pp = dict(t)
@@ -488,6 +706,7 @@ def _run_distributed(
     local_worker_start_stagger_s: float = 5.0,
     no_interrupt: bool = False,
     re_initialize: bool = False,
+    bc_warmstart_dir: str | None = None,
 ) -> list[tuple[str, Any]]:
     """Start coordinator, write local config files, block until all results arrive."""
 
@@ -497,7 +716,9 @@ def _run_distributed(
     for combo, name in zip(combos, names):
         t = combo["training_params"]
         r = combo["reward_params"]
-        _setup_experiment_dir(adapter, name, t, r, track_override)
+        experiment_dir, _, _ = _setup_experiment_dir(adapter, name, t, r, track_override)
+        if bc_warmstart_dir is not None:
+            _copy_bc_weights(bc_warmstart_dir, experiment_dir)
         track = adapter.track_label(t, track_override)
         combo_specs.append(
             ComboSpec(
@@ -836,6 +1057,18 @@ def main() -> None:
         "(issue #254). Set to 0 to disable.",
     )
     parser.add_argument(
+        "--bc-warmstart-dir",
+        default=None,
+        metavar="DIR",
+        help=(
+            "Path to an existing BC-trained experiment directory containing "
+            "policy_weights.yaml and bc_summary.json.  Every grid combo will be "
+            "warm-started from those weights.  A policy-compatibility check is "
+            "performed before any training starts.  Mutually exclusive with an "
+            "inline 'bc:' section in the grid config YAML."
+        ),
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -865,7 +1098,9 @@ def main() -> None:
     if args.local_workers not in (None, 0) and not args.distribute:
         parser.error("--local-workers requires --distribute")
 
-    base_name, game_name, track_override, training_spec, reward_spec, distribute_cfg = _load_grid_config(args.config)
+    base_name, game_name, track_override, training_spec, reward_spec, distribute_cfg, bc_cfg = _load_grid_config(
+        args.config
+    )
 
     # CLI --game / --track override YAML values
     game_name = getattr(args, "game", None) or game_name
@@ -901,6 +1136,24 @@ def main() -> None:
         name = _make_experiment_name(base_name, c.get("_flat", {}), varied_keys)
         names.append(name)
         logger.info("  %s", name)
+
+    # ------------------------------------------------------------------
+    # BC warm-start: resolve warmstart dir, then validate compatibility.
+    # ------------------------------------------------------------------
+    bc_warmstart_dir: str | None = None
+    if args.bc_warmstart_dir and bc_cfg:
+        logger.warning(
+            "--bc-warmstart-dir and an inline 'bc:' section are both present; "
+            "--bc-warmstart-dir takes precedence and the 'bc:' section will be ignored."
+        )
+    if args.bc_warmstart_dir:
+        bc_warmstart_dir = args.bc_warmstart_dir
+    elif bc_cfg:
+        bc_warmstart_dir = _run_inline_bc(bc_cfg, adapter, base_name, training_spec, track_override, game_name)
+
+    if bc_warmstart_dir is not None:
+        _validate_bc_warmstart_combos(bc_warmstart_dir, combos, names)
+        logger.info("BC warm-start directory: %s", bc_warmstart_dir)
 
     if args.distribute:
         if args.local_workers is not None:
@@ -954,6 +1207,7 @@ def main() -> None:
             local_worker_start_stagger_s=local_worker_stagger,
             no_interrupt=args.no_interrupt,
             re_initialize=args.re_initialize,
+            bc_warmstart_dir=bc_warmstart_dir,
         )
     else:
         all_runs = _run_local(
@@ -963,6 +1217,7 @@ def main() -> None:
             track_override=track_override,
             no_interrupt=args.no_interrupt,
             re_initialize=args.re_initialize,
+            bc_warmstart_dir=bc_warmstart_dir,
         )
 
     # Final summary table

--- a/main.py
+++ b/main.py
@@ -406,10 +406,7 @@ def _run_bc_sc2(args: argparse.Namespace) -> None:
     # CLI flags override config; config overrides hard-wired defaults.
     replay_dir = getattr(args, "replay_dir", None) or p.get("bc_replay_dir")
     if not replay_dir:
-        raise SystemExit(
-            "--replay-dir must be specified for --bc mode "
-            "(or set bc_replay_dir in training_params.yaml)"
-        )
+        raise SystemExit("--replay-dir must be specified for --bc mode (or set bc_replay_dir in training_params.yaml)")
 
     player_id: str | int = getattr(args, "bc_player", None) or p.get("bc_player_id", "winner")
     # Coerce "1"/"2" string choices to int so _resolve_player_id works

--- a/tests/README.md
+++ b/tests/README.md
@@ -287,6 +287,10 @@ worker mechanics are unit-tested with a dummy env.
 - promoted-keys: no params returns empty / lstm hidden_size / reinforce baseline / genetic mutation_scale + mutation_share / keys in map with correct names
 - format helpers: int / float strips zeros / negative float / string
 - `--game` flag: default tmnf / honoured / track field / track none / unaffected by game field
+- BC config section: no `bc:` key returns empty dict / `bc:` contents returned verbatim / 7-tuple unpacking still valid
+- BC compatible policy types: `sc2_genetic`↔`sc2_cmaes` cross-compatible / `sc2_reinforce` self-only / tabular policies self-only / all nine targets are keys
+- BC warmstart validation (`_validate_bc_warmstart_combos`): passing compatible target returns `bc_target` string / `sc2_genetic` warmstart accepted by `sc2_cmaes` combo / incompatible target raises `ValueError` mentioning "incompatible" / error lists all failing combos but not passing ones / missing `bc_summary.json` raises / missing `bc_target` field in summary raises
+- BC weight copy (`_copy_bc_weights`): copies `policy_weights.yaml` / copies `trainer_state.npz` when present / copies `policy_weights_qtable.pkl` when present / silently skips absent optional files / raises `FileNotFoundError` when no weight files at all / never copies `bc_summary.json`
 
 ### test_info_gain.py — staleness-based intrinsic reward
 - initial staleness all 1; never-observed = max; just-observed near zero; grows linearly

--- a/tests/README.md
+++ b/tests/README.md
@@ -290,7 +290,7 @@ worker mechanics are unit-tested with a dummy env.
 - BC config section: no `bc:` key returns empty dict / `bc:` contents returned verbatim / 7-tuple unpacking still valid
 - BC compatible policy types: `sc2_genetic`↔`sc2_cmaes` cross-compatible / `sc2_reinforce` self-only / tabular policies self-only / all nine targets are keys
 - BC warmstart validation (`_validate_bc_warmstart_combos`): passing compatible target returns `bc_target` string / `sc2_genetic` warmstart accepted by `sc2_cmaes` combo / incompatible target raises `ValueError` mentioning "incompatible" / error lists all failing combos but not passing ones / missing `bc_summary.json` raises / missing `bc_target` field in summary raises
-- BC weight copy (`_copy_bc_weights`): copies `policy_weights.yaml` / copies `trainer_state.npz` when present / copies `policy_weights_qtable.pkl` when present / silently skips absent optional files / raises `FileNotFoundError` when no weight files at all / never copies `bc_summary.json`
+- BC weight copy (`_copy_bc_weights`): copies `policy_weights.yaml` / copies `policy_weights.npz` (sc2_cnn) / copies `trainer_state.npz` when present / copies `policy_weights_qtable.pkl` when present / silently skips absent optional files / raises `FileNotFoundError` when no weight files at all / never copies `bc_summary.json`
 
 ### test_info_gain.py — staleness-based intrinsic reward
 - initial staleness all 1; never-observed = max; just-observed near zero; grows linearly
@@ -880,6 +880,9 @@ handful of iterations only); reading real `.SC2Replay` files end-to-end
 - `TestFitBCUnknownTarget` (issue #354): SB3 targets (`ppo`, `a2c`, `sac`, `td3`, `qr_dqn`,
   `recurrent_ppo`) each raise `ValueError` mentioning "SB3"; completely unknown targets raise
   `ValueError` with the target name in the message; error message lists supported targets
+- `TestBugFixes354`: tabular Q-values sum to exactly 1.0 per state (not per-action count-divided);
+  DQN terminal transitions store a zero-vector `next_obs` (not the next episode's first obs);
+  `sc2_lstm` raises `ValueError` with "episode_starts" in the message when those keys are absent
 
 ## Rocket League
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -72,7 +72,7 @@
   - [test\_sc2\_simple64\_training.py — Simple64 ladder integration](#test_sc2_simple64_trainingpy--simple64-ladder-integration)
   - [test\_sc2\_self\_play.py — `SelfPlayManager` (three self-play opponent modes)](#test_sc2_self_playpy--selfplaymanager-three-self-play-opponent-modes)
   - [test\_sc2\_analytics.py — SC2-specific analytics plots and flags](#test_sc2_analyticspy--sc2-specific-analytics-plots-and-flags)
-  - [test\_sc2\_replay\_bc.py — SC2 replay BC: dataset, fit, run, and `--bc` CLI (issues #351–#353)](#test_sc2_replay_bcpy--sc2-replay-bc-dataset-fit-run-and---bc-cli-issues-351353)
+  - [test\_sc2\_replay\_bc.py — SC2 replay BC: dataset, fit, run, and `--bc` CLI (issues #351–#354)](#test_sc2_replay_bcpy--sc2-replay-bc-dataset-fit-run-and---bc-cli-issues-351354)
 - [Rocket League](#rocket-league)
   - [test\_rocket\_league\_obs\_spec.py — Rocket League observation spec (142-dim)](#test_rocket_league_obs_specpy--rocket-league-observation-spec-142-dim)
   - [test\_rocket\_league\_reward.py — Rocket League reward calc](#test_rocket_league_rewardpy--rocket-league-reward-calc)
@@ -589,14 +589,18 @@ and `SelfPlayManager` — all three opponent modes (`exact`, `mutated`, `top_n`)
 pool growth/eviction semantics, and wiring through `train_rl`.
 
 The offline replay-reader and BC fit modules (`games/sc2/replay_bc.py`, issues
-#351–#353) are covered in `test_sc2_replay_bc.py`: the full PySC2 replay API
+#351–#354) are covered in `test_sc2_replay_bc.py`: the full PySC2 replay API
 (run_config, controller, features) is replaced by lightweight fakes injected
 into `sys.modules` before import, so the suite runs with no SC2 binary or
 PySC2 package installed. `validate_replay_dir` (issue #352) is tested against
 real temp-dir fixtures — no fakes needed since it only touches the filesystem.
 `fit_bc` (MLP and linear paths), `run` (full pipeline), and the `main.py --bc`
 entry point are all unit-tested with synthetic numpy datasets and mocked
-pipeline helpers (issue #353).
+pipeline helpers (issue #353).  The policy-agnostic warm-start extension
+(issue #354) adds round-trip tests for all SC2-compatible policy families:
+`sc2_cmaes`, `sc2_neural_net`, `sc2_neural_dqn`, `sc2_lstm`, `sc2_cnn`,
+`epsilon_greedy`, and `ucb_q`, plus error-path tests for SB3 targets and
+unknown target names.
 
 **Not tested.** PySC2 against the actual Blizzard SC2 binary; real
 1v1 games against the built-in bot; minimap rendering; the deferred
@@ -805,7 +809,7 @@ handful of iterations only); reading real `.SC2Replay` files end-to-end
 - `save_grid_summary`: forwards config-normalized rewards **and per-component contributions** using `v / max(abs(weight), 1.0)` — weights ≥ 1.0 are divided (making large-weight components comparable across grid-search runs), weights < 1.0 use the raw value (which already encodes the weight, so dividing would amplify by ×1000); wires SC2 extra-plot hook into framework summary generation; covers no-components fallback, multi-sim normalization, malformed YAML fallback, non-mapping YAML fallback, non-numeric weight fallback, allow-listed `scout` component (no unmapped-key warning), step_penalty with sub-1.0 weight passes through raw (-0.5 not -500), idle_penalty with sub-1.0 weight passes through raw, any sub-1.0 weight (0.0001 or 0.001) both use scale=1.0, the new `unit_loss` / `damage_taken` / `passive_under_fire` components normalize through their config weights without unmapped-key warnings, realistic positive reward stays positive after normalization (313.5 ✓), and emits SC2 cross-run charts + summary links; passes `task_metric_fn`, `task_metric_fmt` (percentage formatter) to framework; `attack_bonus` mapped to `attack_bonus` config key in normalisation
 - `_sc2_task_metric`: empty sims → 0.0; win+finish counted as success; loss/timeout/None/other not counted; all-wins → 1.0; `_GS_SUCCESS_REASONS` constant contains win+finish, excludes loss+timeout
 
-### test_sc2_replay_bc.py — SC2 replay BC: dataset, fit, run, and `--bc` CLI (issues #351–#353)
+### test_sc2_replay_bc.py — SC2 replay BC: dataset, fit, run, and `--bc` CLI (issues #351–#354)
 - `TestValidateReplayDir`: nonexistent folder raises `ValueError`; file path raises `ValueError`; empty
   folder raises with "No .SC2Replay files found"; returns only `.SC2Replay` files sorted; race filter warning
   emitted when race is non-null/non-"any"; no warning for `race="any"` or `race=None`; version mismatch
@@ -854,6 +858,24 @@ handful of iterations only); reading real `.SC2Replay` files end-to-end
   `winner`/`1`/`2` are valid `--bc-player` choices; all four race choices accepted for `--bc-race`;
   `sc2_reinforce`/`sc2_genetic` accepted for `--bc-target`; `--bc` with `--game != sc2` raises
   `SystemExit`; `--bc` and `--play` are mutually exclusive; `--bc` and `--eval` are mutually exclusive
+- `TestFitBCCMAES` (issue #354): returns `SC2CMAESPolicy`; `_champion` is set after fit; distribution
+  mean equals `champion.to_flat()`; champion callable → `(4,)` action
+- `TestFitBCNeuralNet` (issue #354): returns `SC2NeuralNetPolicy`; layer weight shapes match
+  `[obs_dim, hidden, 4]`; callable → `(4,)` action after fit; loss decreases over more epochs; round-trip
+  save+reload via `SC2NeuralNetPolicy.from_cfg`
+- `TestFitBCDQN` (issue #354): returns `SC2NeuralDQNPolicy`; replay buffer has transitions after fill;
+  `bc_loss` equals fill fraction `len(replay) / capacity`; episode boundary steps marked done
+- `TestFitBCLSTM` (issue #354): returns `SC2LSTMEvolutionPolicy`; `_champion` is set; champion callable;
+  loss is finite and non-negative; `_mean` equals `champion.to_flat()`; round-trip save+reload via
+  `SC2LSTMPolicy.from_cfg`
+- `TestFitBCCNN` (issue #354): returns `SC2CNNEvolutionPolicy`; `_champion` is set; `_mean` equals
+  `champion.to_flat()`; `W1`/`W2` (conv layers) are zeroed; obs-portion of `W3` is non-zero
+- `TestFitBCTabular` (issue #354): `epsilon_greedy` returns `EpsilonGreedyPolicy`; `ucb_q` returns
+  `UCBQPolicy`; Q-table populated after seeding; `_n_sa` populated; Q-values normalised by visit count
+  in `[0, 1]`; `epsilon_greedy` callable → `(4,)` action
+- `TestFitBCUnknownTarget` (issue #354): SB3 targets (`ppo`, `a2c`, `sac`, `td3`, `qr_dqn`,
+  `recurrent_ppo`) each raise `ValueError` mentioning "SB3"; completely unknown targets raise
+  `ValueError` with the target name in the message; error message lists supported targets
 
 ## Rocket League
 

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -12,8 +12,10 @@ import yaml
 
 from grid_search import (
     _ABBREV,
+    _BC_COMPATIBLE_POLICY_TYPES,
     _POLICY_PARAM_MAP,
     _build_policy_params,
+    _copy_bc_weights,
     _expand_grid,
     _fmt_value,
     _launch_local_workers,
@@ -22,6 +24,7 @@ from grid_search import (
     _parse_non_negative_int,
     _split_grid_run_name,
     _stop_local_workers,
+    _validate_bc_warmstart_combos,
 )
 
 
@@ -218,7 +221,7 @@ class TestLoadGridConfig:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump({"base_name": "test", "training_params": {"n_sims": 10}}, f)
             f.flush()
-            base_name, game, track, t, r, d = _load_grid_config(f.name)
+            base_name, game, track, t, r, d, bc = _load_grid_config(f.name)
         os.unlink(f.name)
         assert game == "tmnf"
 
@@ -226,7 +229,7 @@ class TestLoadGridConfig:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump({"base_name": "test", "game": "torcs", "training_params": {"n_sims": 10}}, f)
             f.flush()
-            base_name, game, track, t, r, d = _load_grid_config(f.name)
+            base_name, game, track, t, r, d, bc = _load_grid_config(f.name)
         os.unlink(f.name)
         assert game == "torcs"
 
@@ -234,7 +237,7 @@ class TestLoadGridConfig:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump({"base_name": "test", "track": "aalborg", "training_params": {"n_sims": 10}}, f)
             f.flush()
-            base_name, game, track, t, r, d = _load_grid_config(f.name)
+            base_name, game, track, t, r, d, bc = _load_grid_config(f.name)
         os.unlink(f.name)
         assert track == "aalborg"
 
@@ -242,7 +245,7 @@ class TestLoadGridConfig:
         with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump({"base_name": "test", "training_params": {"n_sims": 10}}, f)
             f.flush()
-            base_name, game, track, t, r, d = _load_grid_config(f.name)
+            base_name, game, track, t, r, d, bc = _load_grid_config(f.name)
         os.unlink(f.name)
         assert track is None
 
@@ -259,7 +262,7 @@ class TestLoadGridConfig:
                 f,
             )
             f.flush()
-            _, _, _, t, r, _ = _load_grid_config(f.name)
+            _, _, _, t, r, _, _ = _load_grid_config(f.name)
         os.unlink(f.name)
         combos, varied = _expand_grid(t, r)
         assert len(combos) == 2
@@ -526,3 +529,203 @@ class TestSc2NeuralNetTemplate:
         reward = data.get("reward_params") or {}
         assert reward.get("early_random_action_bonus") == 10.0
         assert reward.get("early_random_action_window_steps") == 300
+
+
+class TestLoadGridConfigBcSection:
+    """_load_grid_config returns bc_cfg as the 7th element."""
+
+    def test_no_bc_section_returns_empty_dict(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump({"base_name": "test", "training_params": {}}, f)
+            f.flush()
+            *_, bc = _load_grid_config(f.name)
+        os.unlink(f.name)
+        assert bc == {}
+
+    def test_bc_section_is_returned(self):
+        cfg = {
+            "base_name": "test",
+            "training_params": {},
+            "bc": {"replay_dir": "/replays", "bc_target": "sc2_genetic"},
+        }
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump(cfg, f)
+            f.flush()
+            *_, bc = _load_grid_config(f.name)
+        os.unlink(f.name)
+        assert bc["replay_dir"] == "/replays"
+        assert bc["bc_target"] == "sc2_genetic"
+
+    def test_existing_six_element_destructuring_still_works(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            yaml.dump({"base_name": "test", "game": "sc2", "training_params": {}}, f)
+            f.flush()
+            base_name, game, track, t, r, d, bc = _load_grid_config(f.name)
+        os.unlink(f.name)
+        assert base_name == "test"
+        assert game == "sc2"
+        assert bc == {}
+
+
+class TestBcCompatiblePolicyTypes:
+    """_BC_COMPATIBLE_POLICY_TYPES encodes the correct cross-compatibility."""
+
+    def test_sc2_genetic_and_sc2_cmaes_are_cross_compatible(self):
+        assert "sc2_cmaes" in _BC_COMPATIBLE_POLICY_TYPES["sc2_genetic"]
+        assert "sc2_genetic" in _BC_COMPATIBLE_POLICY_TYPES["sc2_cmaes"]
+
+    def test_sc2_reinforce_only_compatible_with_itself(self):
+        assert _BC_COMPATIBLE_POLICY_TYPES["sc2_reinforce"] == frozenset({"sc2_reinforce"})
+
+    def test_tabular_policies_only_compatible_with_themselves(self):
+        assert _BC_COMPATIBLE_POLICY_TYPES["epsilon_greedy"] == frozenset({"epsilon_greedy"})
+        assert _BC_COMPATIBLE_POLICY_TYPES["ucb_q"] == frozenset({"ucb_q"})
+
+    def test_all_supported_bc_targets_are_keys(self):
+        expected = {
+            "sc2_genetic",
+            "sc2_cmaes",
+            "sc2_reinforce",
+            "sc2_neural_net",
+            "sc2_neural_dqn",
+            "sc2_lstm",
+            "sc2_cnn",
+            "epsilon_greedy",
+            "ucb_q",
+        }
+        assert set(_BC_COMPATIBLE_POLICY_TYPES.keys()) == expected
+
+
+class TestValidateBcWarmstartCombos:
+    """_validate_bc_warmstart_combos raises ValueError on incompatibility."""
+
+    def _make_bc_dir(self, tmp_dir: str, bc_target: str) -> str:
+        import json
+
+        bc_dir = os.path.join(tmp_dir, "bc_warmstart")
+        os.makedirs(bc_dir, exist_ok=True)
+        with open(os.path.join(bc_dir, "bc_summary.json"), "w") as f:
+            json.dump({"bc_target": bc_target, "final_bc_loss": 0.5}, f)
+        open(os.path.join(bc_dir, "policy_weights.yaml"), "w").close()
+        return bc_dir
+
+    def _make_combos(self, policy_type: str) -> tuple[list, list]:
+        combos = [{"training_params": {"policy_type": policy_type}, "reward_params": {}}]
+        names = [f"gs__{policy_type}"]
+        return combos, names
+
+    def test_compatible_target_passes(self, tmp_path):
+        bc_dir = self._make_bc_dir(str(tmp_path), "sc2_genetic")
+        combos, names = self._make_combos("sc2_genetic")
+        result = _validate_bc_warmstart_combos(str(bc_dir), combos, names)
+        assert result == "sc2_genetic"
+
+    def test_sc2_genetic_warmstarts_sc2_cmaes(self, tmp_path):
+        bc_dir = self._make_bc_dir(str(tmp_path), "sc2_genetic")
+        combos, names = self._make_combos("sc2_cmaes")
+        result = _validate_bc_warmstart_combos(str(bc_dir), combos, names)
+        assert result == "sc2_genetic"
+
+    def test_incompatible_target_raises(self, tmp_path):
+        bc_dir = self._make_bc_dir(str(tmp_path), "sc2_reinforce")
+        combos, names = self._make_combos("sc2_genetic")
+        with pytest.raises(ValueError, match="incompatible"):
+            _validate_bc_warmstart_combos(str(bc_dir), combos, names)
+
+    def test_error_message_lists_all_incompatible_combos(self, tmp_path):
+        bc_dir = self._make_bc_dir(str(tmp_path), "sc2_reinforce")
+        combos = [
+            {"training_params": {"policy_type": "sc2_genetic"}, "reward_params": {}},
+            {"training_params": {"policy_type": "sc2_reinforce"}, "reward_params": {}},
+            {"training_params": {"policy_type": "sc2_neural_net"}, "reward_params": {}},
+        ]
+        names = ["gs__pt_genetic", "gs__pt_reinforce", "gs__pt_neural_net"]
+        with pytest.raises(ValueError) as exc_info:
+            _validate_bc_warmstart_combos(str(bc_dir), combos, names)
+        msg = str(exc_info.value)
+        assert "gs__pt_genetic" in msg
+        assert "gs__pt_neural_net" in msg
+        # sc2_reinforce combo should NOT appear in the error
+        assert "gs__pt_reinforce" not in msg
+
+    def test_missing_bc_summary_raises(self, tmp_path):
+        bc_dir = str(tmp_path / "empty_bc")
+        os.makedirs(bc_dir)
+        combos, names = self._make_combos("sc2_genetic")
+        with pytest.raises(ValueError, match="bc_summary.json"):
+            _validate_bc_warmstart_combos(bc_dir, combos, names)
+
+    def test_missing_bc_target_field_raises(self, tmp_path):
+        import json
+
+        bc_dir = str(tmp_path / "bad_bc")
+        os.makedirs(bc_dir)
+        with open(os.path.join(bc_dir, "bc_summary.json"), "w") as f:
+            json.dump({"final_bc_loss": 0.1}, f)  # no bc_target key
+        combos, names = self._make_combos("sc2_genetic")
+        with pytest.raises(ValueError, match="bc_target"):
+            _validate_bc_warmstart_combos(bc_dir, combos, names)
+
+
+class TestCopyBcWeights:
+    """_copy_bc_weights copies the correct files."""
+
+    def test_copies_weights_yaml(self, tmp_path):
+        src_dir = tmp_path / "bc"
+        dst_dir = tmp_path / "combo"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        (src_dir / "policy_weights.yaml").write_text("weights: {}")
+        _copy_bc_weights(str(src_dir), str(dst_dir))
+        assert (dst_dir / "policy_weights.yaml").exists()
+
+    def test_copies_trainer_state_when_present(self, tmp_path):
+        src_dir = tmp_path / "bc"
+        dst_dir = tmp_path / "combo"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        (src_dir / "policy_weights.yaml").write_text("weights: {}")
+        (src_dir / "trainer_state.npz").write_bytes(b"\x93NUMPY")
+        _copy_bc_weights(str(src_dir), str(dst_dir))
+        assert (dst_dir / "trainer_state.npz").exists()
+
+    def test_copies_qtable_pkl_when_present(self, tmp_path):
+        src_dir = tmp_path / "bc"
+        dst_dir = tmp_path / "combo"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        (src_dir / "policy_weights.yaml").write_text("weights: {}")
+        (src_dir / "policy_weights_qtable.pkl").write_bytes(b"PK")
+        _copy_bc_weights(str(src_dir), str(dst_dir))
+        assert (dst_dir / "policy_weights_qtable.pkl").exists()
+
+    def test_skips_missing_optional_files(self, tmp_path):
+        src_dir = tmp_path / "bc"
+        dst_dir = tmp_path / "combo"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        (src_dir / "policy_weights.yaml").write_text("weights: {}")
+        _copy_bc_weights(str(src_dir), str(dst_dir))
+        assert not (dst_dir / "trainer_state.npz").exists()
+        assert not (dst_dir / "policy_weights_qtable.pkl").exists()
+
+    def test_raises_when_no_weight_files(self, tmp_path):
+        src_dir = tmp_path / "bc"
+        dst_dir = tmp_path / "combo"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        with pytest.raises(FileNotFoundError, match="policy_weights.yaml"):
+            _copy_bc_weights(str(src_dir), str(dst_dir))
+
+    def test_does_not_copy_bc_summary(self, tmp_path):
+        import json
+
+        src_dir = tmp_path / "bc"
+        dst_dir = tmp_path / "combo"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        (src_dir / "policy_weights.yaml").write_text("weights: {}")
+        with open(src_dir / "bc_summary.json", "w") as f:
+            json.dump({"bc_target": "sc2_genetic"}, f)
+        _copy_bc_weights(str(src_dir), str(dst_dir))
+        assert not (dst_dir / "bc_summary.json").exists()

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -709,12 +709,21 @@ class TestCopyBcWeights:
         assert not (dst_dir / "trainer_state.npz").exists()
         assert not (dst_dir / "policy_weights_qtable.pkl").exists()
 
+    def test_copies_weights_npz_for_cnn(self, tmp_path):
+        src_dir = tmp_path / "bc"
+        dst_dir = tmp_path / "combo"
+        src_dir.mkdir()
+        dst_dir.mkdir()
+        (src_dir / "policy_weights.npz").write_bytes(b"\x93NUMPY")
+        _copy_bc_weights(str(src_dir), str(dst_dir))
+        assert (dst_dir / "policy_weights.npz").exists()
+
     def test_raises_when_no_weight_files(self, tmp_path):
         src_dir = tmp_path / "bc"
         dst_dir = tmp_path / "combo"
         src_dir.mkdir()
         dst_dir.mkdir()
-        with pytest.raises(FileNotFoundError, match="policy_weights.yaml"):
+        with pytest.raises(FileNotFoundError, match="policy_weights"):
             _copy_bc_weights(str(src_dir), str(dst_dir))
 
     def test_does_not_copy_bc_summary(self, tmp_path):

--- a/tests/test_sc2_replay_bc.py
+++ b/tests/test_sc2_replay_bc.py
@@ -113,8 +113,6 @@ _s2_pkg, _sc2_api_mod = _make_fake_s2api()
 
 from games.sc2.obs_spec import SC2_MINIGAME_OBS_SPEC  # noqa: E402
 from games.sc2.replay_bc import (  # noqa: E402
-    _fit_bc_linear,
-    _fit_bc_mlp,
     _parse_replay_info,
     _pick_best_action,
     _read_one_replay,
@@ -124,8 +122,10 @@ from games.sc2.replay_bc import (  # noqa: E402
     iter_replays,
     load_dataset,
     replay_observations,
-    run as bc_run,
     validate_replay_dir,
+)
+from games.sc2.replay_bc import (
+    run as bc_run,
 )
 
 _OBS_DIM = len(SC2_MINIGAME_OBS_SPEC.names)
@@ -1050,14 +1050,26 @@ class TestFitBCMLP(unittest.TestCase):
         """BC loss on a simple separable dataset must fall with more epochs."""
         dataset = self._make_separable_dataset(n=400, fn_idx_label=2)
         _, loss_few = fit_bc(
-            dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_reinforce",
-            hidden_sizes=[16, 8], bc_epochs=1, bc_learning_rate=0.01,
-            bc_batch_size=64, bc_ignore_noop=False, seed=42,
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_reinforce",
+            hidden_sizes=[16, 8],
+            bc_epochs=1,
+            bc_learning_rate=0.01,
+            bc_batch_size=64,
+            bc_ignore_noop=False,
+            seed=42,
         )
         _, loss_more = fit_bc(
-            dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_reinforce",
-            hidden_sizes=[16, 8], bc_epochs=20, bc_learning_rate=0.01,
-            bc_batch_size=64, bc_ignore_noop=False, seed=42,
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_reinforce",
+            hidden_sizes=[16, 8],
+            bc_epochs=20,
+            bc_learning_rate=0.01,
+            bc_batch_size=64,
+            bc_ignore_noop=False,
+            seed=42,
         )
         self.assertLess(loss_more, loss_few, "Loss after 20 epochs must be lower than after 1")
 
@@ -1069,9 +1081,15 @@ class TestFitBCMLP(unittest.TestCase):
 
         dataset = self._make_separable_dataset(n=100, fn_idx_label=1)
         policy, _ = fit_bc(
-            dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_reinforce",
-            hidden_sizes=[8], bc_epochs=2, bc_learning_rate=0.01,
-            bc_batch_size=50, bc_ignore_noop=False, seed=1,
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_reinforce",
+            hidden_sizes=[8],
+            bc_epochs=2,
+            bc_learning_rate=0.01,
+            bc_batch_size=50,
+            bc_ignore_noop=False,
+            seed=1,
         )
         with tempfile.TemporaryDirectory() as tmp:
             path = Path(tmp) / "policy_weights.yaml"
@@ -1091,8 +1109,7 @@ class TestFitBCMLP(unittest.TestCase):
         actions = np.zeros((10, 4), dtype=np.float32)  # fn_idx=0 everywhere
         dataset = {"obs": obs, "actions": actions}
         with self.assertRaises(ValueError):
-            fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_reinforce",
-                   bc_ignore_noop=True, bc_epochs=1, seed=0)
+            fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_reinforce", bc_ignore_noop=True, bc_epochs=1, seed=0)
 
     def test_bc_ignore_noop_false_keeps_all_steps(self):
         """bc_ignore_noop=False must not filter any steps."""
@@ -1101,9 +1118,14 @@ class TestFitBCMLP(unittest.TestCase):
         dataset = {"obs": obs, "actions": actions}
         # Should not raise — 10 steps are kept
         policy, _ = fit_bc(
-            dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_reinforce",
-            bc_ignore_noop=False, bc_epochs=1, bc_learning_rate=0.001,
-            bc_batch_size=10, seed=0,
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_reinforce",
+            bc_ignore_noop=False,
+            bc_epochs=1,
+            bc_learning_rate=0.001,
+            bc_batch_size=10,
+            seed=0,
         )
         self.assertIsNotNone(policy)
 
@@ -1124,15 +1146,28 @@ class TestFitBCMLP(unittest.TestCase):
         raw = rng.standard_normal((n, _OBS_DIM)).astype(np.float32)
         obs = (raw * SC2_MINIGAME_OBS_SPEC.scales).astype(np.float32)
         fn_labels = np.where(obs[:, 0] > 0, 2, 1).astype(int)
-        actions = np.stack([fn_labels.astype(np.float32), np.full(n, 0.5, dtype=np.float32),
-                            np.full(n, 0.5, dtype=np.float32), np.zeros(n, np.float32)], axis=1)
+        actions = np.stack(
+            [
+                fn_labels.astype(np.float32),
+                np.full(n, 0.5, dtype=np.float32),
+                np.full(n, 0.5, dtype=np.float32),
+                np.zeros(n, np.float32),
+            ],
+            axis=1,
+        )
         dataset = {"obs": obs, "actions": actions}
 
         # Linear model (no trunk): gradient is direct, convergence is fast and reliable.
         policy, _ = fit_bc(
-            dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_reinforce",
-            hidden_sizes=[], bc_epochs=20, bc_learning_rate=0.05,
-            bc_batch_size=64, bc_ignore_noop=False, seed=7,
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_reinforce",
+            hidden_sizes=[],
+            bc_epochs=20,
+            bc_learning_rate=0.05,
+            bc_batch_size=64,
+            bc_ignore_noop=False,
+            seed=7,
         )
         # Pairwise accuracy: correct class logit > other class logit (1 vs 2 only).
         # h_last = obs_norm when there is no trunk.
@@ -1151,22 +1186,33 @@ class TestFitBCMLP(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             p = Path(tmp) / "demos.npz"
             obs = np.zeros((20, _OBS_DIM), dtype=np.float32)
-            actions = np.column_stack([
-                np.full(20, 2, dtype=np.float32),
-                np.full(20, 0.3, dtype=np.float32),
-                np.full(20, 0.7, dtype=np.float32),
-                np.zeros(20, np.float32),
-            ])
+            actions = np.column_stack(
+                [
+                    np.full(20, 2, dtype=np.float32),
+                    np.full(20, 0.3, dtype=np.float32),
+                    np.full(20, 0.7, dtype=np.float32),
+                    np.zeros(20, np.float32),
+                ]
+            )
             ep_id = np.zeros(20, dtype=np.int64)
             np.savez_compressed(
-                str(p), obs=obs, actions=actions,
+                str(p),
+                obs=obs,
+                actions=actions,
                 episode_starts=np.array([0], dtype=np.int64),
                 episode_lengths=np.array([20], dtype=np.int64),
                 episode_id=ep_id,
                 meta=np.array(json.dumps({"n_episodes": 1})),
             )
-            policy, loss = fit_bc(p, SC2_MINIGAME_OBS_SPEC, target="sc2_reinforce",
-                                   bc_epochs=1, bc_learning_rate=0.001, bc_ignore_noop=False, seed=0)
+            policy, loss = fit_bc(
+                p,
+                SC2_MINIGAME_OBS_SPEC,
+                target="sc2_reinforce",
+                bc_epochs=1,
+                bc_learning_rate=0.001,
+                bc_ignore_noop=False,
+                seed=0,
+            )
         self.assertIsNotNone(policy)
         self.assertIsInstance(loss, float)
 
@@ -1182,12 +1228,14 @@ class TestFitBCLinear(unittest.TestCase):
     def _make_dataset(self, n: int = 100, fn_idx_label: int = 2) -> dict:
         rng = np.random.default_rng(0)
         obs = rng.standard_normal((n, _OBS_DIM)).astype(np.float32)
-        actions = np.column_stack([
-            np.full(n, fn_idx_label, np.float32),
-            np.full(n, 0.6, np.float32),
-            np.full(n, 0.4, np.float32),
-            np.zeros(n, np.float32),
-        ])
+        actions = np.column_stack(
+            [
+                np.full(n, fn_idx_label, np.float32),
+                np.full(n, 0.6, np.float32),
+                np.full(n, 0.4, np.float32),
+                np.zeros(n, np.float32),
+            ]
+        )
         return {"obs": obs, "actions": actions}
 
     def test_returns_loadable_sc2_multihead_policy(self):
@@ -1196,7 +1244,9 @@ class TestFitBCLinear(unittest.TestCase):
 
         dataset = self._make_dataset(n=80, fn_idx_label=2)
         policy, loss = fit_bc(
-            dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_genetic",
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_genetic",
             bc_ignore_noop=False,
         )
         self.assertIsInstance(policy, SC2MultiHeadLinearPolicy)
@@ -1210,7 +1260,9 @@ class TestFitBCLinear(unittest.TestCase):
 
         dataset = self._make_dataset(n=50, fn_idx_label=1)
         policy, _ = fit_bc(
-            dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_genetic",
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_genetic",
             bc_ignore_noop=False,
         )
         with tempfile.TemporaryDirectory() as tmp:
@@ -1227,7 +1279,9 @@ class TestFitBCLinear(unittest.TestCase):
 
         dataset = self._make_dataset(n=60)
         policy, _ = fit_bc(
-            dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_genetic",
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_genetic",
             bc_ignore_noop=False,
         )
         self.assertEqual(policy._fn_weights.shape, (N_FUNCTION_IDS, _OBS_DIM))
@@ -1236,7 +1290,9 @@ class TestFitBCLinear(unittest.TestCase):
         """sp_weights must have shape (2, obs_dim)."""
         dataset = self._make_dataset(n=60, fn_idx_label=2)  # Move_screen is spatial
         policy, _ = fit_bc(
-            dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_genetic",
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_genetic",
             bc_ignore_noop=False,
         )
         self.assertEqual(policy._sp_weights.shape, (2, _OBS_DIM))
@@ -1249,7 +1305,9 @@ class TestFitBCLinear(unittest.TestCase):
         non_spatial = min(k for k in range(118) if k not in SPATIAL_FN_IDS and k != 0)
         dataset = self._make_dataset(n=60, fn_idx_label=non_spatial)
         policy, _ = fit_bc(
-            dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_genetic",
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_genetic",
             bc_ignore_noop=False,
         )
         np.testing.assert_array_equal(policy._sp_weights, np.zeros((2, _OBS_DIM), dtype=np.float32))
@@ -1265,15 +1323,18 @@ class TestRunBC(unittest.TestCase):
 
     def _synthetic_dataset_dict(self, n: int = 30) -> dict:
         obs = np.zeros((n, _OBS_DIM), dtype=np.float32)
-        actions = np.column_stack([
-            np.full(n, 2, np.float32),
-            np.full(n, 0.5, np.float32),
-            np.full(n, 0.5, np.float32),
-            np.zeros(n, np.float32),
-        ])
+        actions = np.column_stack(
+            [
+                np.full(n, 2, np.float32),
+                np.full(n, 0.5, np.float32),
+                np.full(n, 0.5, np.float32),
+                np.zeros(n, np.float32),
+            ]
+        )
         ep_id = np.zeros(n, dtype=np.int64)
         return {
-            "obs": obs, "actions": actions,
+            "obs": obs,
+            "actions": actions,
             "episode_starts": np.array([0], dtype=np.int64),
             "episode_lengths": np.array([n], dtype=np.int64),
             "episode_id": ep_id,
@@ -1285,9 +1346,12 @@ class TestRunBC(unittest.TestCase):
         from unittest.mock import patch
 
         meta_return = {
-            "n_episodes": 1, "n_steps": dataset_dict["obs"].shape[0],
-            "obs_dim": _OBS_DIM, "n_replays_skipped_race": 0,
-            "player_id": "winner", "race_filter": None,
+            "n_episodes": 1,
+            "n_steps": dataset_dict["obs"].shape[0],
+            "obs_dim": _OBS_DIM,
+            "n_replays_skipped_race": 0,
+            "player_id": "winner",
+            "race_filter": None,
         }
         return patch.multiple(
             "games.sc2.replay_bc",
@@ -1307,9 +1371,15 @@ class TestRunBC(unittest.TestCase):
             dataset = self._synthetic_dataset_dict()
             with self._patch_run(dataset, target="sc2_reinforce"):
                 bc_run(
-                    replay_dir, experiment_dir, SC2_MINIGAME_OBS_SPEC,
-                    target="sc2_reinforce", bc_epochs=1, bc_learning_rate=0.001,
-                    bc_batch_size=10, bc_ignore_noop=False, seed=0,
+                    replay_dir,
+                    experiment_dir,
+                    SC2_MINIGAME_OBS_SPEC,
+                    target="sc2_reinforce",
+                    bc_epochs=1,
+                    bc_learning_rate=0.001,
+                    bc_batch_size=10,
+                    bc_ignore_noop=False,
+                    seed=0,
                 )
             self.assertTrue((experiment_dir / "policy_weights.yaml").exists())
 
@@ -1323,16 +1393,30 @@ class TestRunBC(unittest.TestCase):
             (replay_dir / "g.SC2Replay").touch()
             dataset = self._synthetic_dataset_dict()
             with self._patch_run(dataset):
-                summary = bc_run(
-                    replay_dir, experiment_dir, SC2_MINIGAME_OBS_SPEC,
-                    target="sc2_reinforce", bc_epochs=1, bc_learning_rate=0.001,
-                    bc_batch_size=10, bc_ignore_noop=False, seed=0,
+                bc_run(
+                    replay_dir,
+                    experiment_dir,
+                    SC2_MINIGAME_OBS_SPEC,
+                    target="sc2_reinforce",
+                    bc_epochs=1,
+                    bc_learning_rate=0.001,
+                    bc_batch_size=10,
+                    bc_ignore_noop=False,
+                    seed=0,
                 )
             summary_file = experiment_dir / "bc_summary.json"
             self.assertTrue(summary_file.exists())
             loaded = json.loads(summary_file.read_text())
-            for key in ("n_replays_kept", "n_episodes", "n_pairs", "fn_idx_histogram",
-                        "bc_player_id", "bc_race", "bc_target", "final_bc_loss"):
+            for key in (
+                "n_replays_kept",
+                "n_episodes",
+                "n_pairs",
+                "fn_idx_histogram",
+                "bc_player_id",
+                "bc_race",
+                "bc_target",
+                "final_bc_loss",
+            ):
                 self.assertIn(key, loaded, f"Missing key '{key}' in bc_summary.json")
 
     def test_summary_fn_idx_histogram_covers_actions(self):
@@ -1346,9 +1430,14 @@ class TestRunBC(unittest.TestCase):
             dataset = self._synthetic_dataset_dict(n=30)  # all fn_idx=2
             with self._patch_run(dataset):
                 summary = bc_run(
-                    replay_dir, experiment_dir, SC2_MINIGAME_OBS_SPEC,
-                    target="sc2_reinforce", bc_epochs=1, bc_batch_size=10,
-                    bc_ignore_noop=False, seed=0,
+                    replay_dir,
+                    experiment_dir,
+                    SC2_MINIGAME_OBS_SPEC,
+                    target="sc2_reinforce",
+                    bc_epochs=1,
+                    bc_batch_size=10,
+                    bc_ignore_noop=False,
+                    seed=0,
                 )
             histogram = summary["fn_idx_histogram"]
             self.assertIn(2, histogram)
@@ -1366,9 +1455,14 @@ class TestRunBC(unittest.TestCase):
             dataset = self._synthetic_dataset_dict()
             with self._patch_run(dataset, target="sc2_reinforce"):
                 bc_run(
-                    replay_dir, experiment_dir, SC2_MINIGAME_OBS_SPEC,
-                    target="sc2_reinforce", bc_epochs=1, bc_batch_size=10,
-                    bc_ignore_noop=False, seed=0,
+                    replay_dir,
+                    experiment_dir,
+                    SC2_MINIGAME_OBS_SPEC,
+                    target="sc2_reinforce",
+                    bc_epochs=1,
+                    bc_batch_size=10,
+                    bc_ignore_noop=False,
+                    seed=0,
                 )
             self.assertTrue((experiment_dir / "trainer_state.npz").exists())
 
@@ -1383,8 +1477,11 @@ class TestRunBC(unittest.TestCase):
             dataset = self._synthetic_dataset_dict()
             with self._patch_run(dataset, target="sc2_genetic"):
                 bc_run(
-                    replay_dir, experiment_dir, SC2_MINIGAME_OBS_SPEC,
-                    target="sc2_genetic", bc_ignore_noop=False,
+                    replay_dir,
+                    experiment_dir,
+                    SC2_MINIGAME_OBS_SPEC,
+                    target="sc2_genetic",
+                    bc_ignore_noop=False,
                 )
             self.assertTrue((experiment_dir / "policy_weights.yaml").exists())
             summary_file = experiment_dir / "bc_summary.json"
@@ -1404,9 +1501,14 @@ class TestRunBC(unittest.TestCase):
             dataset = self._synthetic_dataset_dict()
             with self._patch_run(dataset):
                 summary = bc_run(
-                    replay_dir, experiment_dir, SC2_MINIGAME_OBS_SPEC,
-                    target="sc2_reinforce", bc_epochs=1, bc_batch_size=10,
-                    bc_ignore_noop=False, seed=0,
+                    replay_dir,
+                    experiment_dir,
+                    SC2_MINIGAME_OBS_SPEC,
+                    target="sc2_reinforce",
+                    bc_epochs=1,
+                    bc_batch_size=10,
+                    bc_ignore_noop=False,
+                    seed=0,
                     # Do NOT pass player_id — should default to "winner"
                 )
             self.assertEqual(summary["bc_player_id"], "winner")
@@ -1423,10 +1525,15 @@ class TestRunBC(unittest.TestCase):
             dataset = self._synthetic_dataset_dict()
             with self._patch_run(dataset):
                 summary = bc_run(
-                    replay_dir, experiment_dir, SC2_MINIGAME_OBS_SPEC,
-                    target="sc2_reinforce", race="terran",
-                    bc_epochs=1, bc_batch_size=10,
-                    bc_ignore_noop=False, seed=0,
+                    replay_dir,
+                    experiment_dir,
+                    SC2_MINIGAME_OBS_SPEC,
+                    target="sc2_reinforce",
+                    race="terran",
+                    bc_epochs=1,
+                    bc_batch_size=10,
+                    bc_ignore_noop=False,
+                    seed=0,
                 )
             self.assertEqual(summary["bc_race"], "terran")
 
@@ -1439,7 +1546,7 @@ class TestRunBC(unittest.TestCase):
 class TestBCCLIMain(unittest.TestCase):
     """Tests for --bc CLI flag behaviour in main.py."""
 
-    def _parse(self, argv: list[str]) -> "argparse.Namespace":
+    def _parse(self, argv: list[str]) -> "argparse.Namespace":  # noqa: F821
         from main import _build_arg_parser
 
         return _build_arg_parser().parse_args(argv)
@@ -1456,25 +1563,21 @@ class TestBCCLIMain(unittest.TestCase):
 
     def test_bc_player_choices(self):
         for choice in ["winner", "1", "2"]:
-            args = self._parse(["myexp", "--game", "sc2", "--bc",
-                                 "--replay-dir", "/r", "--bc-player", choice])
+            args = self._parse(["myexp", "--game", "sc2", "--bc", "--replay-dir", "/r", "--bc-player", choice])
             self.assertEqual(args.bc_player, choice)
 
     def test_bc_race_choices(self):
         for race in ["terran", "protoss", "zerg", "any"]:
-            args = self._parse(["myexp", "--game", "sc2", "--bc",
-                                 "--replay-dir", "/r", "--bc-race", race])
+            args = self._parse(["myexp", "--game", "sc2", "--bc", "--replay-dir", "/r", "--bc-race", race])
             self.assertEqual(args.bc_race, race)
 
     def test_bc_target_choices(self):
         for target in ["sc2_reinforce", "sc2_genetic"]:
-            args = self._parse(["myexp", "--game", "sc2", "--bc",
-                                 "--replay-dir", "/r", "--bc-target", target])
+            args = self._parse(["myexp", "--game", "sc2", "--bc", "--replay-dir", "/r", "--bc-target", target])
             self.assertEqual(args.bc_target, target)
 
     def test_bc_rejected_for_non_sc2(self):
         """--bc with --game != sc2 must raise SystemExit."""
-        import argparse as _ap
 
         from main import main as main_fn
 
@@ -1487,16 +1590,639 @@ class TestBCCLIMain(unittest.TestCase):
         self.assertNotEqual(ctx.exception.code, 0)
 
     def test_bc_mutually_exclusive_with_play(self):
-        import argparse
-
         with self.assertRaises(SystemExit):
             self._parse(["myexp", "--game", "sc2", "--bc", "--play", "--replay-dir", "/r"])
 
     def test_bc_mutually_exclusive_with_eval(self):
-        import argparse
-
         with self.assertRaises(SystemExit):
             self._parse(["myexp", "--game", "sc2", "--bc", "--eval", "--replay-dir", "/r"])
+
+
+# ---------------------------------------------------------------------------
+# Tests: fit_bc — new policy targets (issue #354)
+# ---------------------------------------------------------------------------
+
+
+def _make_flat_dataset(n: int = 80, fn_idx_label: int = 2) -> dict:
+    """Build a minimal flat dataset dict for non-LSTM BC tests."""
+    rng = np.random.default_rng(42)
+    obs = rng.standard_normal((n, _OBS_DIM)).astype(np.float32)
+    actions = np.column_stack(
+        [
+            np.full(n, fn_idx_label, np.float32),
+            np.full(n, 0.5, np.float32),
+            np.full(n, 0.5, np.float32),
+            np.zeros(n, np.float32),
+        ]
+    )
+    ep_starts = np.array([0, n // 2], dtype=np.int64)
+    ep_lengths = np.array([n // 2, n // 2], dtype=np.int64)
+    ep_id = np.concatenate([np.zeros(n // 2, np.int64), np.ones(n // 2, np.int64)])
+    return {
+        "obs": obs,
+        "actions": actions,
+        "episode_starts": ep_starts,
+        "episode_lengths": ep_lengths,
+        "episode_id": ep_id,
+        "meta": {"n_episodes": 2, "n_steps": n},
+    }
+
+
+class TestFitBCCMAES(unittest.TestCase):
+    """Tests for fit_bc with target='sc2_cmaes' (issue #354)."""
+
+    def _make_dataset(self, n: int = 80) -> dict:
+        return _make_flat_dataset(n=n, fn_idx_label=2)
+
+    def test_returns_sc2cmaes_policy(self):
+        """fit_bc sc2_cmaes must return an SC2CMAESPolicy."""
+        from games.sc2.sc2_policies import SC2CMAESPolicy
+
+        dataset = self._make_dataset()
+        policy, loss = fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_cmaes", bc_ignore_noop=False)
+        self.assertIsInstance(policy, SC2CMAESPolicy)
+        self.assertIsInstance(loss, float)
+
+    def test_champion_is_set(self):
+        """After BC fit, _champion should not be None."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_cmaes", bc_ignore_noop=False)
+        self.assertIsNotNone(policy._champion)
+
+    def test_dist_mean_equals_champion_flat(self):
+        """Distribution mean must equal champion.to_flat()."""
+
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_cmaes", bc_ignore_noop=False)
+        np.testing.assert_allclose(
+            policy._dist._mean,
+            policy._champion.to_flat().astype(np.float64),
+            rtol=1e-5,
+        )
+
+    def test_champion_callable(self):
+        """Champion policy should produce a valid 4-element action."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="sc2_cmaes", bc_ignore_noop=False)
+        obs = np.zeros(_OBS_DIM, dtype=np.float32)
+        action = policy(obs)
+        self.assertEqual(action.shape, (4,))
+
+
+class TestFitBCNeuralNet(unittest.TestCase):
+    """Tests for fit_bc with target='sc2_neural_net' (issue #354)."""
+
+    def _make_dataset(self, n: int = 60) -> dict:
+        return _make_flat_dataset(n=n, fn_idx_label=2)
+
+    def test_returns_sc2neuralnet_policy(self):
+        """fit_bc sc2_neural_net must return an SC2NeuralNetPolicy."""
+        from games.sc2.sc2_policies import SC2NeuralNetPolicy
+
+        dataset = self._make_dataset()
+        policy, loss = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_net",
+            hidden_sizes=[8],
+            bc_epochs=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertIsInstance(policy, SC2NeuralNetPolicy)
+        self.assertIsInstance(loss, float)
+        self.assertGreaterEqual(loss, 0.0)
+
+    def test_weight_shapes_match_architecture(self):
+        """Layer weight shapes must match [obs_dim, hidden, 4]."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_net",
+            hidden_sizes=[8, 8],
+            bc_epochs=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertEqual(policy._weights[0].shape, (8, _OBS_DIM))
+        self.assertEqual(policy._weights[1].shape, (8, 8))
+        self.assertEqual(policy._weights[2].shape, (4, 8))
+
+    def test_callable_after_fit(self):
+        """Policy must produce a (4,) action after BC fit."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_net",
+            hidden_sizes=[4],
+            bc_epochs=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        obs = np.zeros(_OBS_DIM, dtype=np.float32)
+        action = policy(obs)
+        self.assertEqual(action.shape, (4,))
+
+    def test_loss_decreases_over_epochs(self):
+        """Loss should decrease (or stay flat) over multiple epochs on a small dataset."""
+        rng = np.random.default_rng(10)
+        n = 200
+        raw_obs = rng.standard_normal((n, _OBS_DIM)).astype(np.float32)
+        obs = (raw_obs * SC2_MINIGAME_OBS_SPEC.scales).astype(np.float32)
+        # All same fn_idx: simple regression target
+        actions = np.column_stack(
+            [
+                np.full(n, 2, np.float32),
+                np.full(n, 0.7, np.float32),
+                np.full(n, 0.3, np.float32),
+                np.zeros(n, np.float32),
+            ]
+        )
+        dataset = {"obs": obs, "actions": actions}
+        _, loss_1 = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_net",
+            hidden_sizes=[],
+            bc_epochs=1,
+            bc_learning_rate=0.01,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        _, loss_20 = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_net",
+            hidden_sizes=[],
+            bc_epochs=20,
+            bc_learning_rate=0.01,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertLessEqual(loss_20, loss_1 + 1e-3, "Loss should not increase over more epochs")
+
+    def test_saved_weights_reload(self):
+        """SC2NeuralNetPolicy.to_cfg() / from_cfg() round-trip after BC."""
+        import tempfile
+
+        from games.sc2.sc2_policies import SC2NeuralNetPolicy
+
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_net",
+            hidden_sizes=[4],
+            bc_epochs=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path as _Path
+
+            path = str(_Path(tmp) / "policy_weights.yaml")
+            policy.save(path)
+            loaded = SC2NeuralNetPolicy.from_cfg(__import__("yaml").safe_load(open(path)), SC2_MINIGAME_OBS_SPEC)
+        obs = np.zeros(_OBS_DIM, dtype=np.float32)
+        action = loaded(obs)
+        self.assertEqual(action.shape, (4,))
+
+
+class TestFitBCDQN(unittest.TestCase):
+    """Tests for fit_bc with target='sc2_neural_dqn' (issue #354)."""
+
+    def _make_dataset(self, n: int = 60, fn_idx_label: int = 2) -> dict:
+        return _make_flat_dataset(n=n, fn_idx_label=fn_idx_label)
+
+    def test_returns_sc2neuraldqn_policy(self):
+        """fit_bc sc2_neural_dqn must return an SC2NeuralDQNPolicy."""
+        from games.sc2.sc2_policies import SC2NeuralDQNPolicy
+
+        dataset = self._make_dataset()
+        policy, loss = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_dqn",
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertIsInstance(policy, SC2NeuralDQNPolicy)
+        self.assertIsInstance(loss, float)
+        self.assertGreaterEqual(loss, 0.0)
+
+    def test_replay_buffer_filled(self):
+        """Replay buffer should have transitions after BC fill."""
+        dataset = self._make_dataset(n=40)
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_dqn",
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        # Should have n transitions pushed
+        self.assertGreater(len(policy._replay), 0)
+
+    def test_fill_fraction_as_bc_loss(self):
+        """bc_loss should be fill_fraction = transitions / buffer_capacity."""
+        n = 50
+        dataset = self._make_dataset(n=n)
+        policy, bc_loss = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_dqn",
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        expected = len(policy._replay) / max(policy._buf_maxlen, 1)
+        self.assertAlmostEqual(bc_loss, expected, places=6)
+
+    def test_episode_starts_used_for_done_flags(self):
+        """Transitions at episode boundaries should be marked done."""
+        n = 10
+        obs = np.zeros((n, _OBS_DIM), dtype=np.float32)
+        actions = np.column_stack(
+            [
+                np.full(n, 2, np.float32),
+                np.full(n, 0.5, np.float32),
+                np.full(n, 0.5, np.float32),
+                np.zeros(n, np.float32),
+            ]
+        )
+        # Two episodes: [0..4] and [5..9]
+        dataset = {
+            "obs": obs,
+            "actions": actions,
+            "episode_starts": np.array([0, 5], dtype=np.int64),
+            "episode_lengths": np.array([5, 5], dtype=np.int64),
+            "episode_id": np.array([0] * 5 + [1] * 5, dtype=np.int64),
+            "meta": {"n_episodes": 2, "n_steps": n},
+        }
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_dqn",
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        # Check that step 4 (last of episode 0) is marked done in the buffer.
+        buf = list(policy._replay._buf)
+        done_flags = [entry[4] for entry in buf]
+        self.assertGreater(sum(done_flags), 0)
+
+
+class TestFitBCLSTM(unittest.TestCase):
+    """Tests for fit_bc with target='sc2_lstm' (issue #354)."""
+
+    def _make_dataset(self, n: int = 40) -> dict:
+        return _make_flat_dataset(n=n, fn_idx_label=2)
+
+    def test_returns_sc2lstmevolution_policy(self):
+        """fit_bc sc2_lstm must return an SC2LSTMEvolutionPolicy."""
+        from games.sc2.sc2_policies import SC2LSTMEvolutionPolicy
+
+        dataset = self._make_dataset()
+        policy, loss = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_lstm",
+            bc_lstm_hidden_size=8,
+            bc_epochs=1,
+            bc_learning_rate=0.001,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertIsInstance(policy, SC2LSTMEvolutionPolicy)
+        self.assertIsInstance(loss, float)
+
+    def test_champion_is_set(self):
+        """After BC fit, _champion must not be None."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_lstm",
+            bc_lstm_hidden_size=8,
+            bc_epochs=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertIsNotNone(policy._champion)
+
+    def test_champion_callable(self):
+        """Champion must produce a (4,) action."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_lstm",
+            bc_lstm_hidden_size=8,
+            bc_epochs=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        obs = np.zeros(_OBS_DIM, dtype=np.float32)
+        action = policy(obs)
+        self.assertEqual(action.shape, (4,))
+
+    def test_loss_is_finite(self):
+        """BC loss must be a finite non-negative float."""
+        dataset = self._make_dataset()
+        _, loss = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_lstm",
+            bc_lstm_hidden_size=8,
+            bc_epochs=2,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertFalse(np.isinf(loss))
+        self.assertGreaterEqual(loss, 0.0)
+
+    def test_mean_matches_champion_flat(self):
+        """Evolution mean should equal champion.to_flat() after seeding."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_lstm",
+            bc_lstm_hidden_size=8,
+            bc_epochs=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        np.testing.assert_allclose(
+            policy._mean,
+            policy._champion.to_flat().astype(np.float64),
+            rtol=1e-5,
+        )
+
+    def test_saved_weights_load_as_sc2_lstm(self):
+        """Saved LSTM BC policy must reload cleanly via SC2LSTMPolicy.from_cfg."""
+        import tempfile
+
+        from games.sc2.sc2_policies import SC2LSTMPolicy
+
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_lstm",
+            bc_lstm_hidden_size=8,
+            bc_epochs=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            from pathlib import Path as _Path
+
+            path = str(_Path(tmp) / "policy_weights.yaml")
+            policy.save(path)
+            loaded = SC2LSTMPolicy.from_cfg(__import__("yaml").safe_load(open(path)), SC2_MINIGAME_OBS_SPEC)
+        self.assertEqual(loaded._hidden_size, 8)
+        obs = np.zeros(_OBS_DIM, dtype=np.float32)
+        action = loaded(obs)
+        self.assertEqual(action.shape, (4,))
+
+
+class TestFitBCCNN(unittest.TestCase):
+    """Tests for fit_bc with target='sc2_cnn' (issue #354)."""
+
+    def _make_dataset(self, n: int = 60) -> dict:
+        return _make_flat_dataset(n=n, fn_idx_label=2)
+
+    def test_returns_sc2cnn_evolution_policy(self):
+        """fit_bc sc2_cnn must return an SC2CNNEvolutionPolicy."""
+        from games.sc2.cnn_policy import SC2CNNEvolutionPolicy
+
+        dataset = self._make_dataset()
+        policy, loss = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_cnn",
+            n_channels=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertIsInstance(policy, SC2CNNEvolutionPolicy)
+        self.assertIsInstance(loss, float)
+        self.assertGreaterEqual(loss, 0.0)
+
+    def test_champion_is_set(self):
+        """_champion must be set after CNN BC fit."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_cnn",
+            n_channels=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertIsNotNone(policy._champion)
+
+    def test_mean_matches_champion_flat(self):
+        """_mean should equal champion.to_flat() after seeding."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_cnn",
+            n_channels=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        np.testing.assert_allclose(
+            policy._mean,
+            policy._champion.to_flat().astype(np.float64),
+            rtol=1e-5,
+        )
+
+    def test_conv_weights_zeroed(self):
+        """W1 and W2 (conv layers) must be zeroed in the warm-start champion."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_cnn",
+            n_channels=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        champ = policy._champion
+        np.testing.assert_array_equal(champ.W1, np.zeros_like(champ.W1))
+        np.testing.assert_array_equal(champ.W2, np.zeros_like(champ.W2))
+
+    def test_w3_obs_portion_nonzero(self):
+        """The obs-portion of W3 should be non-zero (random projection)."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_cnn",
+            n_channels=1,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        champ = policy._champion
+        pool_flat = champ._pool_flat
+        obs_portion = champ.W3[:, pool_flat:]
+        self.assertFalse(np.all(obs_portion == 0), "W3 obs portion should be non-zero")
+
+
+class TestFitBCTabular(unittest.TestCase):
+    """Tests for fit_bc with targets 'epsilon_greedy' / 'ucb_q' (issue #354)."""
+
+    def _make_dataset(self, n: int = 60) -> dict:
+        return _make_flat_dataset(n=n, fn_idx_label=2)
+
+    def test_epsilon_greedy_returns_correct_type(self):
+        """fit_bc epsilon_greedy must return an EpsilonGreedyPolicy."""
+        from framework.policies import EpsilonGreedyPolicy
+
+        dataset = self._make_dataset()
+        policy, loss = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="epsilon_greedy",
+            n_bins=2,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertIsInstance(policy, EpsilonGreedyPolicy)
+        self.assertEqual(loss, 0.0)
+
+    def test_ucb_q_returns_correct_type(self):
+        """fit_bc ucb_q must return a UCBQPolicy."""
+        from framework.policies import UCBQPolicy
+
+        dataset = self._make_dataset()
+        policy, loss = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="ucb_q",
+            n_bins=2,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertIsInstance(policy, UCBQPolicy)
+        self.assertEqual(loss, 0.0)
+
+    def test_q_table_populated(self):
+        """Q-table should have entries after seeding."""
+        dataset = self._make_dataset(n=40)
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="epsilon_greedy",
+            n_bins=2,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertGreater(len(policy._q_table), 0)
+
+    def test_n_sa_populated(self):
+        """Visit count table _n_sa should be populated."""
+        dataset = self._make_dataset(n=40)
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="ucb_q",
+            n_bins=2,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        self.assertGreater(len(policy._n_sa), 0)
+
+    def test_q_values_normalised(self):
+        """Q-values should be normalised by visit count (sum over actions = 1 for seeded states)."""
+        dataset = self._make_dataset(n=60)
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="epsilon_greedy",
+            n_bins=2,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        for state, q in policy._q_table.items():
+            counts = policy._n_sa.get(state, np.zeros_like(q))
+            if counts.sum() > 0:
+                # Q-values for seeded actions should be in [0, 1]
+                seeded_q = q[counts > 0]
+                self.assertTrue(np.all(seeded_q >= 0.0))
+                self.assertTrue(np.all(seeded_q <= 1.0 + 1e-6))
+
+    def test_epsilon_greedy_callable(self):
+        """Policy must return a (4,) action without raising."""
+        dataset = self._make_dataset()
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="epsilon_greedy",
+            n_bins=2,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        obs = np.zeros(_OBS_DIM, dtype=np.float32)
+        action = policy(obs)
+        self.assertEqual(action.shape, (4,))
+
+
+class TestFitBCUnknownTarget(unittest.TestCase):
+    """Tests for fit_bc error handling with invalid/unsupported targets (issue #354)."""
+
+    def _make_dataset(self) -> dict:
+        return _make_flat_dataset(n=20, fn_idx_label=1)
+
+    def test_sb3_ppo_raises_value_error(self):
+        """SB3 policy targets must raise ValueError."""
+        dataset = self._make_dataset()
+        with self.assertRaises(ValueError) as ctx:
+            fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="ppo", bc_ignore_noop=False)
+        self.assertIn("SB3", str(ctx.exception))
+
+    def test_sb3_a2c_raises_value_error(self):
+        dataset = self._make_dataset()
+        with self.assertRaises(ValueError):
+            fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="a2c", bc_ignore_noop=False)
+
+    def test_sb3_sac_raises_value_error(self):
+        dataset = self._make_dataset()
+        with self.assertRaises(ValueError):
+            fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="sac", bc_ignore_noop=False)
+
+    def test_sb3_td3_raises_value_error(self):
+        dataset = self._make_dataset()
+        with self.assertRaises(ValueError):
+            fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="td3", bc_ignore_noop=False)
+
+    def test_sb3_qr_dqn_raises_value_error(self):
+        dataset = self._make_dataset()
+        with self.assertRaises(ValueError):
+            fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="qr_dqn", bc_ignore_noop=False)
+
+    def test_sb3_recurrent_ppo_raises_value_error(self):
+        dataset = self._make_dataset()
+        with self.assertRaises(ValueError):
+            fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="recurrent_ppo", bc_ignore_noop=False)
+
+    def test_unknown_target_raises_value_error(self):
+        """Completely unknown target names must raise ValueError."""
+        dataset = self._make_dataset()
+        with self.assertRaises(ValueError) as ctx:
+            fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="banana", bc_ignore_noop=False)
+        self.assertIn("banana", str(ctx.exception))
+
+    def test_error_message_lists_supported_targets(self):
+        """ValueError for unknown target should list the supported targets."""
+        dataset = self._make_dataset()
+        with self.assertRaises(ValueError) as ctx:
+            fit_bc(dataset, SC2_MINIGAME_OBS_SPEC, target="xyz", bc_ignore_noop=False)
+        self.assertIn("Supported", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_sc2_replay_bc.py
+++ b/tests/test_sc2_replay_bc.py
@@ -2225,5 +2225,92 @@ class TestFitBCUnknownTarget(unittest.TestCase):
         self.assertIn("Supported", str(ctx.exception))
 
 
+class TestBugFixes354(unittest.TestCase):
+    """Regression tests for bugs fixed in issue #354 Copilot review."""
+
+    # --- Fix 1: Q-normalization sums to 1 per state ---
+
+    def test_tabular_q_sums_to_one_per_state(self):
+        """After BC fit, Q-values across actions must sum to 1.0 for every state."""
+        dataset = _make_flat_dataset(n=60, fn_idx_label=2)
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="epsilon_greedy",
+            n_bins=2,
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        for state, q in policy._q_table.items():
+            self.assertAlmostEqual(float(q.sum()), 1.0, places=5,
+                                   msg=f"Q sums to {q.sum():.6f} for state {state}")
+
+    # --- Fix 2: DQN terminal transitions have zero next_obs ---
+
+    def test_dqn_terminal_next_obs_is_zeros(self):
+        """Transitions marked done=True must have a zero-vector next_obs in the replay buffer."""
+        n = 10
+        obs = np.ones((n, _OBS_DIM), dtype=np.float32)
+        actions = np.column_stack(
+            [
+                np.full(n, 2, np.float32),
+                np.full(n, 0.5, np.float32),
+                np.full(n, 0.5, np.float32),
+                np.zeros(n, np.float32),
+            ]
+        )
+        dataset = {
+            "obs": obs,
+            "actions": actions,
+            "episode_starts": np.array([0, 5], dtype=np.int64),
+            "episode_lengths": np.array([5, 5], dtype=np.int64),
+            "episode_id": np.array([0] * 5 + [1] * 5, dtype=np.int64),
+            "meta": {"n_episodes": 2, "n_steps": n},
+        }
+        policy, _ = fit_bc(
+            dataset,
+            SC2_MINIGAME_OBS_SPEC,
+            target="sc2_neural_dqn",
+            bc_ignore_noop=False,
+            seed=0,
+        )
+        buf = list(policy._replay._buf)
+        for entry in buf:
+            # Entry is (obs, action_idx, reward, next_obs, done[, mask])
+            next_obs, done = entry[3], entry[4]
+            if done:
+                np.testing.assert_array_equal(
+                    next_obs, np.zeros_like(next_obs),
+                    err_msg="next_obs should be zeros for terminal transitions",
+                )
+
+    # --- Fix 3: LSTM missing episode keys raises ValueError ---
+
+    def test_lstm_missing_episode_keys_raises_value_error(self):
+        """fit_bc sc2_lstm must raise ValueError when episode boundary keys are absent."""
+        rng = np.random.default_rng(0)
+        obs = rng.standard_normal((20, _OBS_DIM)).astype(np.float32)
+        actions = np.column_stack(
+            [
+                np.full(20, 2, np.float32),
+                np.full(20, 0.5, np.float32),
+                np.full(20, 0.5, np.float32),
+                np.zeros(20, np.float32),
+            ]
+        )
+        dataset_no_boundaries = {"obs": obs, "actions": actions}
+        with self.assertRaises(ValueError) as ctx:
+            fit_bc(
+                dataset_no_boundaries,
+                SC2_MINIGAME_OBS_SPEC,
+                target="sc2_lstm",
+                bc_lstm_hidden_size=8,
+                bc_epochs=1,
+                bc_ignore_noop=False,
+                seed=0,
+            )
+        self.assertIn("episode_starts", str(ctx.exception))
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #351 #352 #353 #354

## Summary

- **Issue #351**: Added `games/sc2/replay_bc.py` — complete behaviour-cloning dataset builder and fitter for StarCraft II. Reads `.SC2Replay` files, extracts observations and actions, builds flat or episodic datasets, and fits policies via supervised learning.
- **Issue #352**: Added `validate_replay_dir()` to validate replay directories with optional race/version cross-checks and helpful error messages.
- **Issue #353**: Added `fit_bc()` and `run()` functions to fit BC policies from datasets or replay directories directly, with configurable epochs, learning rate, batch size, and no-op filtering.
- **Issue #354**: Integrated BC warm-start into `grid_search.py` with two modes: post-hoc warm-start from an existing BC checkpoint, and inline BC pre-training before grid search. Added `--bc`, `--replay-dir`, and `--bc-warmstart-dir` CLI flags to `main.py`.

## Related issues

Refs #350 (shared `extract_flat_obs` code path between live client and replay reader).

## Validation

```bash
PYTHONPATH=. poetry run python -m pytest tests/test_sc2_replay_bc.py -v
PYTHONPATH=. poetry run python -m pytest tests/test_grid_search.py -v
PYTHONPATH=. poetry run python -m pytest tests/test_sc2_actions.py::TestFunctionCallToAction -v
PYTHONPATH=. poetry run python -m pytest tests/ \
    --ignore=tests/test_env_termination.py \
    --ignore=tests/integration/
```

## Feature details

**User problem:**  
Behaviour cloning from expert demonstrations (replays) is a standard pre-training technique in RL. Users needed a way to extract observations and actions from SC2 replays, build datasets, fit policies, and warm-start training runs.

**Proposed solution:**  
- `replay_observations()`: Stream (obs, action) pairs from a single replay, handling PySC2 lazy imports, player resolution, and multi-action disambiguation.
- `build_dataset()`: Aggregate replays into flat or episodic `.npz` datasets with optional race/player filtering.
- `load_dataset()`: Load saved datasets as flat arrays or per-episode sequences.
- `fit_bc()`: Supervised learning on a dataset with configurable epochs, learning rate, batch size, and no-op filtering.
- `run()`: Full pipeline — replays → dataset → fit → save weights + summary JSON.
- `validate_replay_dir()`: Pre-flight checks with helpful warnings for race/version mismatches.
- Grid search integration: `--bc-warmstart-dir` for post-hoc warm-start, or inline BC pre-training before combos run.
- CLI flags: `--bc`, `--replay-dir`, `--bc-player`, `--bc-race`, `--bc-target`, `--bc-epochs`, `--bc-learning-rate`, `--bc-batch-size`, `--bc-ignore-noop`, `--bc-warmstart-dir`.

**Trade-offs / follow-ups:**  
- PySC2 imports remain lazy (matching existing SC2 convention) so the module can be imported without the SC2 binary.
- Multi-action handling defaults to "first_non_noop" (skip no-ops, fall back to first action) but is configurable.
- No-op filtering in `fit_bc()` is optional to preserve temporal structure if needed.
- BC weights are saved in the same format as the target policy (e.g., `SC2MultiHeadLinearPolicy` for `sc2_genetic`/`sc2_cmaes`).

## Refactor / docs / chore details

- **Extracted `extract_flat_obs()` to module level** in `games/sc2/client.py` (issue #350) so both the live client and replay reader share one code path. Cross-step state (explored-mask, last-action one-hot, unit-type cache)

https://claude.ai/code/session_01CcJs5JfU4yEtavHvRP7kPb