### PR TITLE
Add SC2 hierarchical action space with two-stage policy (issue #388)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+### Added
+- **SC2 hierarchical action space** (issue #388): actions are now grouped into
+  five meta-categories (`move`, `attack`, `build`, `train`, `upgrade`).
+  `ACTION_CATEGORIES`, `CATEGORY_NAMES`, `N_CATEGORIES`, and
+  `FN_IDX_TO_CATEGORY` exported from `games.sc2.actions`.
+- `SC2HierarchicalLinearPolicy`: two-stage linear policy that first selects a
+  meta-category via one weight head, then selects a specific action within that
+  category via a second head.  Also adds a learned `queue` head so orders can
+  be queued or issued immediately.
+- `SC2HierarchicalGeneticPolicy` (`policy_type: sc2_hierarchical`): evolutionary
+  search over `SC2HierarchicalLinearPolicy` individuals; drop-in replacement for
+  `sc2_genetic` with the narrowed action-selection structure.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,7 +309,7 @@ make it `copy.deepcopy`-able) and drop it from
 | Discrete control with a mature on-policy SB3 baseline | `ppo` | Strong first choice when you want a standard library implementation instead of the pure-numpy policies. |
 | Tiny discrete state space after coarse binning | `epsilon_greedy` or `ucb_q` | Tabular methods are only practical when `n_bins` stays small enough that the table is still visitable. |
 | Cloneable deterministic simulator and you explicitly want planning | `alphazero_mcts` | Only appropriate when the env can be cloned cheaply; all currently supported games are gated off today. |
-| Any SC2 run | `sc2_genetic`, `sc2_cmaes`, `sc2_reinforce`, `sc2_neural_dqn`, `sc2_lstm`, `sc2_cnn`, or `sc2_neural_net` | The generic continuous-action framework policies (`hill_climbing`, `neural_net`, `genetic`, `cmaes`, `neural_dqn`, `reinforce`, `lstm`) and all SB3 policies are structurally incompatible with SC2's `[fn_idx, x, y, queue]` action encoding. Only the SC2-native wrappers (plus tabular `epsilon_greedy` / `ucb_q`) should be considered there. |
+| Any SC2 run | `sc2_genetic`, `sc2_hierarchical`, `sc2_cmaes`, `sc2_reinforce`, `sc2_neural_dqn`, `sc2_lstm`, `sc2_cnn`, or `sc2_neural_net` | The generic continuous-action framework policies (`hill_climbing`, `neural_net`, `genetic`, `cmaes`, `neural_dqn`, `reinforce`, `lstm`) and all SB3 policies are structurally incompatible with SC2's `[fn_idx, x, y, queue]` action encoding. Only the SC2-native wrappers (plus tabular `epsilon_greedy` / `ucb_q`) should be considered there. |
 
 ### Sizing a run
 
@@ -1056,6 +1056,7 @@ and thresholds `x`/`y` to binary — use `sc2_genetic` instead.
 | `policy_type` | Algorithm | Notes |
 |---|---|---|
 | `sc2_genetic` | Evolutionary (population of `SC2MultiHeadLinearPolicy`) | Default; recommended. Separate fn_idx (6×obs_dim) and sigmoid spatial (2×obs_dim) heads. |
+| `sc2_hierarchical` | Evolutionary (population of `SC2HierarchicalLinearPolicy`) | Hierarchical action space (issue #388): first selects meta-category (move/attack/build/train/upgrade), then fn_idx within it, then spatial + queue. |
 | `sc2_reinforce` | Two-head REINFORCE MLP (softmax fn + sigmoid spatial) | `games/sc2/sc2_policies.py`; gradient-trained per episode |
 | `sc2_cmaes` | (μ/μ_w, λ)-CMA-ES over `SC2MultiHeadLinearPolicy` flat weights | `games/sc2/sc2_policies.py` |
 | `sc2_lstm` | LSTM with SC2-native action encoding, trained by isotropic ES | `games/sc2/sc2_policies.py` |

--- a/games/sc2/README.md
+++ b/games/sc2/README.md
@@ -425,6 +425,7 @@ SC2-compatible policies are listed below. The framework's generic `hill_climbing
 | `policy_type` | Algorithm | Notes |
 |---|---|---|
 | `sc2_genetic` | Population of `SC2MultiHeadLinearPolicy`, evolutionary crossover+mutation | **Recommended default.** SC2-native multi-head individuals; separate fn_idx (6×obs_dim) and sigmoid spatial (2×obs_dim) heads |
+| `sc2_hierarchical` | Population of `SC2HierarchicalLinearPolicy`, same evolutionary mechanics | **Hierarchical action space (issue #388).** First selects a meta-category (move/attack/build/train/upgrade), then a specific fn_idx within it; also learns a queue flag. Narrower effective action space at each stage. |
 | `sc2_neural_net` | TMNF-style hill-climbing MLP | Uses `hidden_sizes` list (e.g. `[16, 64, 64, 16]`); outputs SC2-native `[fn_idx, x, y, queue]` |
 | `sc2_reinforce` | Two-head REINFORCE MLP (softmax fn + sigmoid spatial) | Gradient-trained; recommended over legacy `reinforce` for SC2 |
 | `sc2_cmaes` | (μ/μ_w, λ)-CMA-ES over `SC2MultiHeadLinearPolicy` flat weights | Recommended over legacy `cmaes` for SC2 |

--- a/games/sc2/actions.py
+++ b/games/sc2/actions.py
@@ -443,6 +443,162 @@ def discrete_action_to_fn_id(cell_idx: int) -> int:
     return int(DISCRETE_ACTIONS[cell_idx, 0])
 
 
+# ---------------------------------------------------------------------------
+# Meta-action categories (issue #388) — hierarchical action space
+# ---------------------------------------------------------------------------
+# Actions are grouped into five logical tiers so a hierarchical policy can
+# first choose a category, then a specific action within it.  Every fn_idx
+# in FUNCTION_IDS belongs to exactly one category.
+
+ACTION_CATEGORIES: dict[str, list[int]] = {
+    "move": [
+        0,  # no_op
+        1,  # select_army
+        2,  # Move_screen
+        4,  # select_idle_worker
+        5,  # Harvest_Gather_screen
+        6,  # select_point
+        11,  # Move_minimap
+        12,  # HoldPosition_quick
+        13,  # Stop_quick
+        15,  # select_rect
+        16,  # Harvest_Return_quick
+        17,  # Rally_Units_screen
+        18,  # Rally_Workers_screen
+        19,  # Rally_Units_minimap
+        20,  # Rally_Workers_minimap
+    ],
+    "attack": [
+        3,  # Attack_screen
+        14,  # Attack_minimap
+        45,  # Effect_Stim_quick
+    ],
+    "build": [
+        # Terran buildings + addons
+        8,
+        9,
+        21,
+        22,
+        23,
+        24,
+        25,
+        26,
+        27,
+        28,
+        29,
+        30,
+        31,
+        32,
+        # Protoss buildings
+        48,
+        49,
+        50,
+        51,
+        52,
+        53,
+        54,
+        55,
+        56,
+        57,
+        58,
+        59,
+        60,
+        61,
+        62,
+        # Zerg buildings
+        80,
+        81,
+        82,
+        83,
+        84,
+        85,
+        86,
+        87,
+        88,
+        89,
+        90,
+        91,
+        92,
+        93,
+        94,
+    ],
+    "train": [
+        # Terran units
+        7,
+        10,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42,
+        43,
+        44,
+        # Protoss units + Archon-producing morph omitted (in upgrade)
+        63,
+        64,
+        65,
+        66,
+        67,
+        68,
+        69,
+        70,
+        71,
+        72,
+        73,
+        74,
+        75,
+        76,
+        77,
+        79,
+        # Zerg units
+        95,
+        96,
+        97,
+        98,
+        99,
+        100,
+        101,
+        102,
+        103,
+        104,
+        105,
+        106,
+        107,
+        108,
+        109,
+        110,
+    ],
+    "upgrade": [
+        # Terran unit-state morphs
+        46,  # Morph_SiegeMode_quick
+        47,  # Morph_Unsiege_quick
+        # Protoss unit merge
+        78,  # Morph_Archon_quick
+        # Zerg building and unit morphs
+        111,  # Morph_Lair_quick
+        112,  # Morph_Hive_quick
+        113,  # Morph_Overseer_quick
+        114,  # Morph_GreaterSpire_quick
+        115,  # Morph_BroodLord_quick
+    ],
+}
+
+#: Canonical ordering of category names for weight-matrix row indices.
+CATEGORY_NAMES: list[str] = ["move", "attack", "build", "train", "upgrade"]
+
+#: Total number of meta-action categories.
+N_CATEGORIES: int = len(CATEGORY_NAMES)
+
+#: Inverse map: fn_idx → category name.  Every fn_idx in FUNCTION_IDS has
+#: exactly one entry.
+FN_IDX_TO_CATEGORY: dict[int, str] = {fn_idx: cat for cat, fn_idxs in ACTION_CATEGORIES.items() for fn_idx in fn_idxs}
+
+
 def pysc2_ids_to_internal_fn_idx(pysc2_available_ids: set[int]) -> set[int]:
     """Convert a set of raw PySC2 function IDs to internal fn_idx values.
 

--- a/games/sc2/actions.py
+++ b/games/sc2/actions.py
@@ -462,6 +462,8 @@ ACTION_CATEGORIES: dict[str, list[int]] = {
         12,  # HoldPosition_quick
         13,  # Stop_quick
         15,  # select_rect
+        46,  # Morph_SiegeMode_quick — positional combat stance
+        47,  # Morph_Unsiege_quick
         16,  # Harvest_Return_quick
         17,  # Rally_Units_screen
         18,  # Rally_Workers_screen
@@ -538,7 +540,7 @@ ACTION_CATEGORIES: dict[str, list[int]] = {
         42,
         43,
         44,
-        # Protoss units + Archon-producing morph omitted (in upgrade)
+        # Protoss units
         63,
         64,
         65,
@@ -554,6 +556,7 @@ ACTION_CATEGORIES: dict[str, list[int]] = {
         75,
         76,
         77,
+        78,  # Morph_Archon_quick — produces a new unit type
         79,
         # Zerg units
         95,
@@ -574,11 +577,6 @@ ACTION_CATEGORIES: dict[str, list[int]] = {
         110,
     ],
     "upgrade": [
-        # Terran unit-state morphs
-        46,  # Morph_SiegeMode_quick
-        47,  # Morph_Unsiege_quick
-        # Protoss unit merge
-        78,  # Morph_Archon_quick
         # Zerg building and unit morphs
         111,  # Morph_Lair_quick
         112,  # Morph_Hive_quick

--- a/games/sc2/sc2_policies.py
+++ b/games/sc2/sc2_policies.py
@@ -41,7 +41,15 @@ from framework.policies import BasePolicy, GeneticPolicy, register_policy, train
 from framework.reinforce import (  # noqa: F401 — _GradEntry re-exported for test compatibility
     TwoHeadREINFORCEPolicy as _FrameworkTwoHeadREINFORCE,
 )
-from games.sc2.actions import DISCRETE_ACTIONS, FUNCTION_IDS, build_available_actions_mask, fn_ids_for_race
+from games.sc2.actions import (
+    ACTION_CATEGORIES,
+    CATEGORY_NAMES,
+    DISCRETE_ACTIONS,
+    FUNCTION_IDS,
+    N_CATEGORIES,
+    build_available_actions_mask,
+    fn_ids_for_race,
+)
 from games.sc2.obs_spec import SC2_MINIGAME_OBS_SPEC
 
 logger = logging.getLogger(__name__)
@@ -67,6 +75,13 @@ N_GRID_CELLS: int = N_SPATIAL_ROWS
 _FN_HEAD_NAMES: list[str] = [f"fn_idx_{i}" for i in range(N_FUNCTION_IDS)]
 _SPATIAL_HEAD_NAMES: list[str] = ["x", "y"]
 _ALL_ROW_NAMES: list[str] = _FN_HEAD_NAMES + _SPATIAL_HEAD_NAMES
+
+# Head names for SC2HierarchicalLinearPolicy (issue #388).
+_META_HEAD_NAMES: list[str] = [f"meta_{i}" for i in range(N_CATEGORIES)]
+_QUEUE_HEAD_NAME: str = "queue"
+_ALL_HIERARCHICAL_ROW_NAMES: list[str] = _META_HEAD_NAMES + _FN_HEAD_NAMES + _SPATIAL_HEAD_NAMES + [_QUEUE_HEAD_NAME]
+#: Number of queue output rows (one sigmoid logit).
+N_QUEUE_ROWS: int = 1
 
 
 def _sigmoid(x: float) -> float:
@@ -492,6 +507,403 @@ class SC2GeneticPolicy(GeneticPolicy):
         else:
             policy.initialize_random()
             logger.info("[SC2GeneticPolicy] random population of %d", policy._pop_size)
+        return policy
+
+
+# ---------------------------------------------------------------------------
+# SC2HierarchicalLinearPolicy (issue #388)
+# ---------------------------------------------------------------------------
+
+
+class SC2HierarchicalLinearPolicy:
+    """Hierarchical multi-head linear policy for StarCraft 2 (issue #388).
+
+    Selects actions in four sequential stages:
+
+    1. **Meta-category** — ``meta_weights @ obs`` → argmax over
+       :data:`games.sc2.actions.N_CATEGORIES` scores selects one of
+       ``move``, ``attack``, ``build``, ``train``, or ``upgrade``.
+       Categories whose fn_ids are all unavailable are masked to ``-inf``
+       so the agent never gets stuck in an empty tier.
+    2. **fn_idx** — ``fn_weights @ obs`` → masked argmax within the
+       selected category's fn_ids (intersected with race + availability
+       masks) gives the concrete function ID.
+    3. **Spatial** — ``spatial_weights @ obs`` → sigmoid →
+       ``(x, y) ∈ [0, 1]²`` screen coordinates (continuous; used for
+       all ``_screen`` / ``_minimap`` actions).
+    4. **Queue** — ``queue_weights @ obs`` → sign → ``queue ∈ {0, 1}``.
+       Positive logit queues the order; negative or zero issues it
+       immediately.
+
+    YAML serialisation uses one ``{head}_{row}_weights`` key per matrix
+    row so :meth:`framework.policies.GeneticPolicy._crossover` works
+    without modification.
+    """
+
+    def __init__(
+        self,
+        obs_spec: ObsSpec,
+        meta_weights: np.ndarray | None = None,
+        fn_weights: np.ndarray | None = None,
+        spatial_weights: np.ndarray | None = None,
+        queue_weights: np.ndarray | None = None,
+        race: str = "random",
+    ) -> None:
+        self._obs_spec = obs_spec
+        obs_dim = obs_spec.dim
+        rng = np.random.default_rng()
+
+        self._meta_weights: np.ndarray = (
+            meta_weights.astype(np.float32)
+            if meta_weights is not None
+            else rng.standard_normal((N_CATEGORIES, obs_dim)).astype(np.float32)
+        )
+        self._fn_weights: np.ndarray = (
+            fn_weights.astype(np.float32)
+            if fn_weights is not None
+            else rng.standard_normal((N_FUNCTION_IDS, obs_dim)).astype(np.float32)
+        )
+        self._sp_weights: np.ndarray = (
+            spatial_weights.astype(np.float32)
+            if spatial_weights is not None
+            else rng.standard_normal((N_SPATIAL_ROWS, obs_dim)).astype(np.float32)
+        )
+        self._q_weights: np.ndarray = (
+            queue_weights.astype(np.float32)
+            if queue_weights is not None
+            else rng.standard_normal((N_QUEUE_ROWS, obs_dim)).astype(np.float32)
+        )
+
+        self._race: str = race
+        self._race_fn_ids: frozenset[int] = fn_ids_for_race(race)
+        self._available_fn_ids: set[int] | None = None
+
+    # ------------------------------------------------------------------
+    # Callable interface
+    # ------------------------------------------------------------------
+
+    def __call__(self, obs: np.ndarray) -> np.ndarray:
+        """Select action via hierarchical two-stage fn_idx selection.
+
+        Returns
+        -------
+        np.ndarray
+            4-vector ``[fn_idx, x, y, queue]`` compatible with ``SC2Env``.
+        """
+        norm_obs = obs / self._obs_spec.scales
+
+        # Effective fn_ids: permanent race mask ∩ per-step availability.
+        effective_fn_ids: frozenset[int] | set[int] = self._race_fn_ids
+        if self._available_fn_ids is not None:
+            effective_fn_ids = self._race_fn_ids & self._available_fn_ids
+
+        # Stage 1: select meta-category.
+        meta_scores = self._meta_weights @ norm_obs  # (N_CATEGORIES,)
+        for cat_i, cat_name in enumerate(CATEGORY_NAMES):
+            if not any(f in effective_fn_ids for f in ACTION_CATEGORIES[cat_name]):
+                meta_scores[cat_i] = -np.inf
+        if not np.any(np.isfinite(meta_scores)):
+            # move always contains no_op so this branch is unreachable in
+            # a correctly configured env, but guard anyway.
+            meta_scores[0] = 0.0
+        meta_idx = int(np.argmax(meta_scores))
+        selected_category = CATEGORY_NAMES[meta_idx]
+        category_fn_ids = set(ACTION_CATEGORIES[selected_category])
+
+        # Stage 2: select fn_idx within category.
+        fn_scores = self._fn_weights @ norm_obs  # (N_FUNCTION_IDS,)
+        for i in range(N_FUNCTION_IDS):
+            if i not in category_fn_ids or i not in effective_fn_ids:
+                fn_scores[i] = -np.inf
+        if not np.any(np.isfinite(fn_scores)):
+            fn_scores[0] = 0.0  # no_op fallback
+        fn_idx = int(np.argmax(fn_scores))
+
+        # Stage 3: continuous spatial target.
+        sp_scores = self._sp_weights @ norm_obs  # (2,)
+        x = _sigmoid(float(sp_scores[0]))
+        y = _sigmoid(float(sp_scores[1]))
+
+        # Stage 4: queue decision.
+        q_score = float((self._q_weights @ norm_obs)[0])
+        queue = 1.0 if q_score > 0.0 else 0.0
+
+        return np.array([fn_idx, x, y, queue], dtype=np.float32)
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_cfg(self) -> dict:
+        """Return a YAML-serialisable dict.
+
+        Format::
+
+            meta_0_weights: {obs_name: float, ...}
+            ...
+            meta_4_weights: {...}
+            fn_idx_0_weights: {...}
+            ...
+            fn_idx_115_weights: {...}
+            x_weights: {...}
+            y_weights: {...}
+            queue_weights: {...}
+        """
+        names = self._obs_spec.names
+        cfg: dict = {}
+        for i, row_name in enumerate(_META_HEAD_NAMES):
+            cfg[f"{row_name}_weights"] = {n: float(self._meta_weights[i, j]) for j, n in enumerate(names)}
+        for i, row_name in enumerate(_FN_HEAD_NAMES):
+            cfg[f"{row_name}_weights"] = {n: float(self._fn_weights[i, j]) for j, n in enumerate(names)}
+        for i, row_name in enumerate(_SPATIAL_HEAD_NAMES):
+            cfg[f"{row_name}_weights"] = {n: float(self._sp_weights[i, j]) for j, n in enumerate(names)}
+        cfg[f"{_QUEUE_HEAD_NAME}_weights"] = {n: float(self._q_weights[0, j]) for j, n in enumerate(names)}
+        return cfg
+
+    def save(self, path: str) -> None:
+        """Write ``to_cfg()`` to YAML at *path*."""
+        with open(path, "w") as f:
+            yaml.dump(self.to_cfg(), f, default_flow_style=False, sort_keys=False)
+
+    @classmethod
+    def from_cfg(
+        cls,
+        cfg: dict,
+        obs_spec: ObsSpec,
+        race: str = "random",
+    ) -> "SC2HierarchicalLinearPolicy":
+        """Reconstruct from a ``to_cfg()`` dict.
+
+        Unknown keys and missing observation features default to 0.0,
+        matching the same migration behaviour as ``SC2MultiHeadLinearPolicy``.
+        """
+        names = obs_spec.names
+        obs_dim = obs_spec.dim
+
+        meta_weights = np.zeros((N_CATEGORIES, obs_dim), dtype=np.float32)
+        fn_weights = np.zeros((N_FUNCTION_IDS, obs_dim), dtype=np.float32)
+        sp_weights = np.zeros((N_SPATIAL_ROWS, obs_dim), dtype=np.float32)
+        q_weights = np.zeros((N_QUEUE_ROWS, obs_dim), dtype=np.float32)
+
+        for i, row_name in enumerate(_META_HEAD_NAMES):
+            row_cfg = cfg.get(f"{row_name}_weights", {})
+            for j, n in enumerate(names):
+                meta_weights[i, j] = float(row_cfg.get(n, 0.0))
+
+        for i, row_name in enumerate(_FN_HEAD_NAMES):
+            row_cfg = cfg.get(f"{row_name}_weights", {})
+            for j, n in enumerate(names):
+                fn_weights[i, j] = float(row_cfg.get(n, 0.0))
+
+        for i, row_name in enumerate(_SPATIAL_HEAD_NAMES):
+            row_cfg = cfg.get(f"{row_name}_weights", {})
+            for j, n in enumerate(names):
+                sp_weights[i, j] = float(row_cfg.get(n, 0.0))
+
+        row_cfg = cfg.get(f"{_QUEUE_HEAD_NAME}_weights", {})
+        for j, n in enumerate(names):
+            q_weights[0, j] = float(row_cfg.get(n, 0.0))
+
+        return cls(
+            obs_spec,
+            meta_weights=meta_weights,
+            fn_weights=fn_weights,
+            spatial_weights=sp_weights,
+            queue_weights=q_weights,
+            race=race,
+        )
+
+    @classmethod
+    def load(cls, path: str, obs_spec: ObsSpec, race: str = "random") -> "SC2HierarchicalLinearPolicy":
+        """Load from a YAML file written by :meth:`save`."""
+        with open(path) as f:
+            cfg = yaml.safe_load(f) or {}
+        return cls.from_cfg(cfg, obs_spec, race=race)
+
+    # ------------------------------------------------------------------
+    # Flat-weight interface (CMA-ES / mutation)
+    # ------------------------------------------------------------------
+
+    def to_flat(self) -> np.ndarray:
+        """Return all weights as a single ``float32`` vector.
+
+        Layout: ``[meta | fn | spatial | queue]``.
+        Total: ``(N_CATEGORIES + N_FUNCTION_IDS + N_SPATIAL_ROWS + N_QUEUE_ROWS) × obs_dim``.
+        """
+        return np.concatenate(
+            [
+                self._meta_weights.ravel(),
+                self._fn_weights.ravel(),
+                self._sp_weights.ravel(),
+                self._q_weights.ravel(),
+            ]
+        ).astype(np.float32)
+
+    def with_flat(self, flat: np.ndarray) -> "SC2HierarchicalLinearPolicy":
+        """Return a new policy from a flat weight vector."""
+        obs_dim = self._obs_spec.dim
+        meta_size = N_CATEGORIES * obs_dim
+        fn_size = N_FUNCTION_IDS * obs_dim
+        sp_size = N_SPATIAL_ROWS * obs_dim
+        q_size = N_QUEUE_ROWS * obs_dim
+        i0, i1 = 0, meta_size
+        meta_w = flat[i0:i1].reshape(N_CATEGORIES, obs_dim).astype(np.float32)
+        i0, i1 = i1, i1 + fn_size
+        fn_w = flat[i0:i1].reshape(N_FUNCTION_IDS, obs_dim).astype(np.float32)
+        i0, i1 = i1, i1 + sp_size
+        sp_w = flat[i0:i1].reshape(N_SPATIAL_ROWS, obs_dim).astype(np.float32)
+        i0, i1 = i1, i1 + q_size
+        q_w = flat[i0:i1].reshape(N_QUEUE_ROWS, obs_dim).astype(np.float32)
+        return SC2HierarchicalLinearPolicy(self._obs_spec, meta_w, fn_w, sp_w, q_w, race=self._race)
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def mutated(self, scale: float = 0.1, share: float = 1.0) -> "SC2HierarchicalLinearPolicy":
+        """Return a new policy with Gaussian perturbation on a random weight subset."""
+        rng = np.random.default_rng()
+        flat = self.to_flat()
+        new_flat = flat.copy()
+        if share >= 1.0:
+            new_flat += rng.normal(0.0, scale, len(flat)).astype(np.float32)
+        else:
+            mask = rng.random(len(flat)) < share
+            idx = np.where(mask)[0]
+            if len(idx) > 0:
+                new_flat[idx] += rng.normal(0.0, scale, len(idx)).astype(np.float32)
+        return self.with_flat(new_flat)
+
+    # ------------------------------------------------------------------
+    # Framework compatibility shims
+    # ------------------------------------------------------------------
+
+    def on_episode_start(self, **kwargs) -> None:
+        info = kwargs.get("info") or {}
+        available = info.get("available_fn_ids")
+        self._available_fn_ids = set(available) if available is not None else None
+
+    def update(
+        self, obs: np.ndarray, action: np.ndarray, reward: float, next_obs: np.ndarray, done: bool, **kwargs
+    ) -> None:
+        info = kwargs.get("info") or {}
+        available = info.get("available_fn_ids")
+        self._available_fn_ids = set(available) if available is not None else None
+
+
+# ---------------------------------------------------------------------------
+# SC2HierarchicalGeneticPolicy
+# ---------------------------------------------------------------------------
+
+
+@register_policy
+class SC2HierarchicalGeneticPolicy(GeneticPolicy):
+    """SC2 genetic policy using the hierarchical two-stage action selection (issue #388).
+
+    Each individual is an :class:`SC2HierarchicalLinearPolicy` — the agent
+    first selects a meta-category (``move`` / ``attack`` / ``build`` /
+    ``train`` / ``upgrade``), then selects a specific action within that
+    category, then picks spatial coordinates and a queue flag.
+
+    Evolutionary mechanics (uniform crossover, Gaussian mutation, elite
+    selection, champion tracking) are unchanged from
+    :class:`SC2GeneticPolicy`.
+
+    Register as ``sc2_hierarchical``.
+    """
+
+    POLICY_TYPE = "sc2_hierarchical"
+    LOOP_TYPE = "genetic"
+    VALID_POLICY_PARAMS = frozenset(
+        {
+            "population_size",
+            "elite_k",
+            "mutation_scale",
+            "mutation_share",
+            "eval_episodes",
+        }
+    )
+
+    @classmethod
+    def compatible_with(cls, game_name: str) -> tuple[bool, str | None]:
+        if game_name != "sc2":
+            return False, "This policy is SC2-specific; use game='sc2'."
+        return True, None
+
+    def __init__(
+        self,
+        obs_spec: ObsSpec = SC2_MINIGAME_OBS_SPEC,
+        population_size: int = 30,
+        elite_k: int = 5,
+        mutation_scale: float = 0.1,
+        mutation_share: float = 0.3,
+        eval_episodes: int = 2,
+        race: str = "random",
+    ) -> None:
+        super().__init__(
+            obs_spec=obs_spec,
+            head_names=_ALL_HIERARCHICAL_ROW_NAMES,
+            population_size=population_size,
+            elite_k=elite_k,
+            mutation_scale=mutation_scale,
+            mutation_share=mutation_share,
+            eval_episodes=eval_episodes,
+        )
+        self._race = race
+
+    def _make_member(self, cfg: dict) -> SC2HierarchicalLinearPolicy:  # type: ignore[override]
+        return SC2HierarchicalLinearPolicy.from_cfg(cfg, self._obs_spec, race=self._race)
+
+    def initialize_from_file(self, path: str) -> None:
+        champion = SC2HierarchicalLinearPolicy.load(path, self._obs_spec, race=self._race)
+        self.initialize_from_champion(champion)
+        logger.info("[SC2HierarchicalGeneticPolicy] seeded population from champion at %s", path)
+
+    def to_cfg(self) -> dict:
+        cfg = super().to_cfg()
+        cfg["policy_type"] = "sc2_hierarchical"
+        return cfg
+
+    def save(self, path: str) -> None:
+        if self._champion is not None:
+            self._champion.save(path)
+
+    @classmethod
+    def from_cfg(cls, cfg: dict, obs_spec: ObsSpec = SC2_MINIGAME_OBS_SPEC) -> "SC2HierarchicalGeneticPolicy":
+        policy = cls(
+            obs_spec=obs_spec,
+            population_size=cfg.get("population_size", 30),
+            elite_k=cfg.get("elite_k", 5),
+            mutation_scale=float(cfg.get("mutation_scale", 0.1)),
+            mutation_share=float(cfg.get("mutation_share", 0.3)),
+            eval_episodes=int(cfg.get("eval_episodes", 2)),
+            race=cfg.get("race", "random"),
+        )
+        champion_cfg = cfg.get("champion_weights")
+        if champion_cfg and isinstance(champion_cfg, dict):
+            policy._champion = SC2HierarchicalLinearPolicy.from_cfg(champion_cfg, obs_spec, race=policy._race)
+            policy._champion_reward = float(cfg.get("champion_reward", float("-inf")))
+        return policy
+
+    @classmethod
+    def _construct_or_resume(
+        cls, *, obs_spec, head_names, discrete_actions, weights_file, policy_params, re_initialize
+    ):
+        pp = policy_params
+        policy = cls(
+            obs_spec=obs_spec,
+            population_size=pp.get("population_size", 30),
+            elite_k=pp.get("elite_k", 5),
+            mutation_scale=float(pp.get("mutation_scale", 0.1)),
+            mutation_share=float(pp.get("mutation_share", 0.3)),
+            eval_episodes=int(pp.get("eval_episodes", 2)),
+            race=pp.get("_agent_race", "random"),
+        )
+        if os.path.exists(weights_file) and not re_initialize:
+            policy.initialize_from_file(weights_file)
+        else:
+            policy.initialize_random()
+            logger.info("[SC2HierarchicalGeneticPolicy] random population of %d", policy._pop_size)
         return policy
 
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -63,6 +63,7 @@
   - [test\_sc2\_cmaes\_policy.py — `SC2CMAESPolicy` (CMA-ES over multi-head linear policy)](#test_sc2_cmaes_policypy--sc2cmaespolicy-cma-es-over-multi-head-linear-policy)
   - [test\_sc2\_lstm\_policy.py — `SC2LSTMPolicy` + `SC2LSTMEvolutionPolicy` (thin framework subclass)](#test_sc2_lstm_policypy--sc2lstmpolicy--sc2lstmevolutionpolicy-thin-framework-subclass)
   - [test\_sc2\_genetic\_policy.py — `SC2MultiHeadLinearPolicy` + genetic trainer](#test_sc2_genetic_policypy--sc2multiheadlinearpolicy--genetic-trainer)
+  - [test\_sc2\_hierarchical\_policy.py — `SC2HierarchicalLinearPolicy` + `SC2HierarchicalGeneticPolicy` (issue #388)](#test_sc2_hierarchical_policypy--sc2hierarchicallinearpolicy--sc2hierarchicalgeneticpolicy-issue-388)
   - [test\_sc2\_neural\_net\_policy.py — hill-climbing MLP policy for SC2](#test_sc2_neural_net_policypy--hill-climbing-mlp-policy-for-sc2)
   - [test\_sc2\_neural\_dqn\_policy.py — masked DQN for SC2](#test_sc2_neural_dqn_policypy--masked-dqn-for-sc2)
   - [test\_sc2\_cnn\_policy.py — CNN feature extractor + CMA-ES variant](#test_sc2_cnn_policypy--cnn-feature-extractor--cma-es-variant)
@@ -720,6 +721,16 @@ handful of iterations only).
 - Save: yaml / champion lossless / cfg policy_type=sc2_genetic / from_cfg roundtrip / restores champion / no champion key OK
 - Call: 4-vec after init / raises before init
 - Available-actions masking: no-mask selects highest fn / None by default / masking blocks unavailable fn / selects best available / on_episode_start caches ids / no key clears mask / None info clears mask / update caches ids / no key in update leaves unchanged / mask applied after on_episode_start / mask applied after update / empty set falls back to no_op
+
+### test_sc2_hierarchical_policy.py — `SC2HierarchicalLinearPolicy` + `SC2HierarchicalGeneticPolicy` (issue #388)
+- Categories: all fn_ids covered / no fn_id in multiple categories / names match keys / N_CATEGORIES correct / inverse map complete / inverse map consistent / sentinel members in correct categories
+- Init: meta/fn/spatial/queue weight shapes (minigame + ladder) / default race=random
+- Call: output shape (4,) / dtype float32 / fn_idx in valid range / spatial in unit square / queue is 0 or 1 / positive logit → queue=1 / negative logit → queue=0 / respects availability mask / meta scores route to correct category / empty category falls back / selected fn_idx always in chosen category
+- Serialisation: to_cfg has meta + queue keys / cfg round-trip / save+load round-trip / missing keys default zero
+- Flat: length = (N_CATEGORIES + N_FUNCTION_IDS + N_SPATIAL_ROWS + N_QUEUE_ROWS) × obs_dim / round-trip / mutated differs / same shape after mutation
+- Genetic: policy_type=sc2_hierarchical / compatible with sc2 / incompatible with tmnf / initialize_random + call / save champion + reload / from_cfg round-trip
+
+**Not tested:** actual two-player SC2 binary execution, multi-generation evolution convergence.
 
 ### test_sc2_neural_net_policy.py — hill-climbing MLP policy for SC2
 - Action: shape (4,) / fn_idx range / x+y unit square / queue binary

--- a/tests/test_sc2_hierarchical_policy.py
+++ b/tests/test_sc2_hierarchical_policy.py
@@ -92,6 +92,15 @@ class TestActionCategories(unittest.TestCase):
     def test_morph_lair_in_upgrade(self):
         self.assertIn(111, ACTION_CATEGORIES["upgrade"])
 
+    def test_siege_mode_in_move(self):
+        self.assertIn(46, ACTION_CATEGORIES["move"])
+
+    def test_unsiege_in_move(self):
+        self.assertIn(47, ACTION_CATEGORIES["move"])
+
+    def test_archon_in_train(self):
+        self.assertIn(78, ACTION_CATEGORIES["train"])
+
 
 # ---------------------------------------------------------------------------
 # SC2HierarchicalLinearPolicy — init / shape

--- a/tests/test_sc2_hierarchical_policy.py
+++ b/tests/test_sc2_hierarchical_policy.py
@@ -1,0 +1,362 @@
+"""Tests for SC2HierarchicalLinearPolicy and SC2HierarchicalGeneticPolicy (issue #388)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+from games.sc2.actions import (
+    ACTION_CATEGORIES,
+    CATEGORY_NAMES,
+    FN_IDX_TO_CATEGORY,
+    FUNCTION_IDS,
+    N_CATEGORIES,
+)
+from games.sc2.obs_spec import SC2_LADDER_OBS_SPEC, SC2_MINIGAME_OBS_SPEC
+from games.sc2.sc2_policies import (
+    _ALL_HIERARCHICAL_ROW_NAMES,
+    _META_HEAD_NAMES,
+    _QUEUE_HEAD_NAME,
+    N_FUNCTION_IDS,
+    N_QUEUE_ROWS,
+    N_SPATIAL_ROWS,
+    SC2HierarchicalGeneticPolicy,
+    SC2HierarchicalLinearPolicy,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_policy(obs_spec=None) -> SC2HierarchicalLinearPolicy:
+    spec = obs_spec or SC2_MINIGAME_OBS_SPEC
+    return SC2HierarchicalLinearPolicy(spec)
+
+
+def _make_genetic(pop=6, elite=2, eval_episodes=1, obs_spec=None) -> SC2HierarchicalGeneticPolicy:
+    spec = obs_spec or SC2_MINIGAME_OBS_SPEC
+    return SC2HierarchicalGeneticPolicy(
+        obs_spec=spec,
+        population_size=pop,
+        elite_k=elite,
+        mutation_scale=0.1,
+        mutation_share=0.3,
+        eval_episodes=eval_episodes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ACTION_CATEGORIES invariant tests
+# ---------------------------------------------------------------------------
+
+
+class TestActionCategories(unittest.TestCase):
+    def test_all_fn_ids_covered(self):
+        covered = {fn_idx for fn_ids in ACTION_CATEGORIES.values() for fn_idx in fn_ids}
+        self.assertEqual(covered, set(FUNCTION_IDS.keys()))
+
+    def test_no_fn_id_in_multiple_categories(self):
+        all_ids: list[int] = [fn_idx for fn_ids in ACTION_CATEGORIES.values() for fn_idx in fn_ids]
+        self.assertEqual(len(all_ids), len(set(all_ids)), "fn_idx appears in more than one category")
+
+    def test_category_names_match_keys(self):
+        self.assertEqual(set(CATEGORY_NAMES), set(ACTION_CATEGORIES.keys()))
+
+    def test_n_categories_matches(self):
+        self.assertEqual(N_CATEGORIES, len(CATEGORY_NAMES))
+        self.assertEqual(N_CATEGORIES, len(ACTION_CATEGORIES))
+
+    def test_inverse_map_covers_all(self):
+        self.assertEqual(set(FN_IDX_TO_CATEGORY.keys()), set(FUNCTION_IDS.keys()))
+
+    def test_inverse_map_consistent(self):
+        for fn_idx, cat in FN_IDX_TO_CATEGORY.items():
+            self.assertIn(fn_idx, ACTION_CATEGORIES[cat])
+
+    def test_no_op_in_move(self):
+        self.assertIn(0, ACTION_CATEGORIES["move"])
+
+    def test_attack_screen_in_attack(self):
+        self.assertIn(3, ACTION_CATEGORIES["attack"])
+
+    def test_build_barracks_in_build(self):
+        self.assertIn(8, ACTION_CATEGORIES["build"])
+
+    def test_train_marine_in_train(self):
+        self.assertIn(7, ACTION_CATEGORIES["train"])
+
+    def test_morph_lair_in_upgrade(self):
+        self.assertIn(111, ACTION_CATEGORIES["upgrade"])
+
+
+# ---------------------------------------------------------------------------
+# SC2HierarchicalLinearPolicy — init / shape
+# ---------------------------------------------------------------------------
+
+
+class TestSC2HierarchicalLinearPolicyInit(unittest.TestCase):
+    def test_meta_weights_shape(self):
+        p = _make_policy()
+        self.assertEqual(p._meta_weights.shape, (N_CATEGORIES, SC2_MINIGAME_OBS_SPEC.dim))
+
+    def test_fn_weights_shape(self):
+        p = _make_policy()
+        self.assertEqual(p._fn_weights.shape, (N_FUNCTION_IDS, SC2_MINIGAME_OBS_SPEC.dim))
+
+    def test_spatial_weights_shape(self):
+        p = _make_policy()
+        self.assertEqual(p._sp_weights.shape, (N_SPATIAL_ROWS, SC2_MINIGAME_OBS_SPEC.dim))
+
+    def test_queue_weights_shape(self):
+        p = _make_policy()
+        self.assertEqual(p._q_weights.shape, (N_QUEUE_ROWS, SC2_MINIGAME_OBS_SPEC.dim))
+
+    def test_ladder_obs_spec(self):
+        p = _make_policy(SC2_LADDER_OBS_SPEC)
+        self.assertEqual(p._fn_weights.shape[1], SC2_LADDER_OBS_SPEC.dim)
+        self.assertEqual(p._meta_weights.shape[1], SC2_LADDER_OBS_SPEC.dim)
+
+    def test_default_race_is_random(self):
+        p = _make_policy()
+        self.assertEqual(p._race, "random")
+
+
+# ---------------------------------------------------------------------------
+# SC2HierarchicalLinearPolicy — __call__
+# ---------------------------------------------------------------------------
+
+
+class TestSC2HierarchicalLinearPolicyCall(unittest.TestCase):
+    def _obs(self, spec=None):
+        spec = spec or SC2_MINIGAME_OBS_SPEC
+        return np.ones(spec.dim, dtype=np.float32)
+
+    def test_output_shape(self):
+        p = _make_policy()
+        action = p(self._obs())
+        self.assertEqual(action.shape, (4,))
+
+    def test_output_dtype(self):
+        p = _make_policy()
+        action = p(self._obs())
+        self.assertEqual(action.dtype, np.float32)
+
+    def test_fn_idx_in_valid_range(self):
+        p = _make_policy()
+        action = p(self._obs())
+        fn_idx = int(action[0])
+        self.assertIn(fn_idx, FUNCTION_IDS)
+
+    def test_spatial_in_unit_square(self):
+        p = _make_policy()
+        action = p(self._obs())
+        self.assertGreaterEqual(float(action[1]), 0.0)
+        self.assertLessEqual(float(action[1]), 1.0)
+        self.assertGreaterEqual(float(action[2]), 0.0)
+        self.assertLessEqual(float(action[2]), 1.0)
+
+    def test_queue_is_zero_or_one(self):
+        p = _make_policy()
+        action = p(self._obs())
+        self.assertIn(float(action[3]), {0.0, 1.0})
+
+    def test_queue_positive_logit_gives_one(self):
+        p = _make_policy()
+        p._q_weights[:] = 1.0  # large positive → queue=1
+        action = p(self._obs())
+        self.assertEqual(float(action[3]), 1.0)
+
+    def test_queue_negative_logit_gives_zero(self):
+        p = _make_policy()
+        p._q_weights[:] = -1.0  # negative → queue=0
+        action = p(self._obs())
+        self.assertEqual(float(action[3]), 0.0)
+
+    def test_fn_idx_respects_availability_mask(self):
+        p = _make_policy()
+        # Only allow no_op (fn_idx 0)
+        p._available_fn_ids = {0}
+        action = p(self._obs())
+        self.assertEqual(int(action[0]), 0)
+
+    def test_category_mask_routes_to_attack(self):
+        p = _make_policy()
+        # Force meta weights to strongly prefer "attack" (index 1)
+        p._meta_weights[:] = 0.0
+        p._meta_weights[CATEGORY_NAMES.index("attack")] = 100.0
+        # Force fn_weights so Attack_screen (3) wins within attack category
+        p._fn_weights[:] = 0.0
+        p._fn_weights[3] = 100.0
+        p._available_fn_ids = None
+        action = p(self._obs())
+        self.assertEqual(int(action[0]), 3)
+
+    def test_category_mask_routes_to_build(self):
+        p = _make_policy()
+        p._meta_weights[:] = 0.0
+        p._meta_weights[CATEGORY_NAMES.index("build")] = 100.0
+        p._fn_weights[:] = 0.0
+        p._fn_weights[8] = 100.0  # Build_Barracks_screen
+        p._available_fn_ids = None
+        action = p(self._obs())
+        self.assertIn(int(action[0]), ACTION_CATEGORIES["build"])
+
+    def test_empty_category_falls_back(self):
+        """If the preferred category has no available actions, another is used."""
+        p = _make_policy()
+        # Prefer attack category, but no attack actions are available
+        p._meta_weights[:] = 0.0
+        p._meta_weights[CATEGORY_NAMES.index("attack")] = 100.0
+        # Only allow no_op (fn_idx 0, which is in move)
+        p._available_fn_ids = {0}
+        action = p(self._obs())
+        self.assertEqual(int(action[0]), 0)
+
+    def test_selected_fn_idx_is_in_chosen_category(self):
+        """fn_idx must always belong to the meta-selected category when available."""
+        rng = np.random.default_rng(42)
+        spec = SC2_MINIGAME_OBS_SPEC
+        obs = rng.standard_normal(spec.dim).astype(np.float32)
+        for _ in range(20):
+            p = SC2HierarchicalLinearPolicy(spec)
+            action = p(obs)
+            fn_idx = int(action[0])
+            # Determine which category was chosen: the fn_idx must be in one category
+            cat = FN_IDX_TO_CATEGORY.get(fn_idx)
+            self.assertIsNotNone(cat, f"fn_idx {fn_idx} not in any category")
+
+
+# ---------------------------------------------------------------------------
+# SC2HierarchicalLinearPolicy — serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestSC2HierarchicalLinearPolicySerialization(unittest.TestCase):
+    def test_to_cfg_has_meta_keys(self):
+        p = _make_policy()
+        cfg = p.to_cfg()
+        for name in _META_HEAD_NAMES:
+            self.assertIn(f"{name}_weights", cfg)
+
+    def test_to_cfg_has_queue_key(self):
+        p = _make_policy()
+        cfg = p.to_cfg()
+        self.assertIn(f"{_QUEUE_HEAD_NAME}_weights", cfg)
+
+    def test_round_trip_cfg(self):
+        p = _make_policy()
+        cfg = p.to_cfg()
+        p2 = SC2HierarchicalLinearPolicy.from_cfg(cfg, SC2_MINIGAME_OBS_SPEC)
+        np.testing.assert_allclose(p._meta_weights, p2._meta_weights, atol=1e-6)
+        np.testing.assert_allclose(p._fn_weights, p2._fn_weights, atol=1e-6)
+        np.testing.assert_allclose(p._sp_weights, p2._sp_weights, atol=1e-6)
+        np.testing.assert_allclose(p._q_weights, p2._q_weights, atol=1e-6)
+
+    def test_save_load_round_trip(self):
+        p = _make_policy()
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            path = f.name
+        try:
+            p.save(path)
+            p2 = SC2HierarchicalLinearPolicy.load(path, SC2_MINIGAME_OBS_SPEC)
+            np.testing.assert_allclose(p._meta_weights, p2._meta_weights, atol=1e-6)
+            np.testing.assert_allclose(p._q_weights, p2._q_weights, atol=1e-6)
+        finally:
+            os.unlink(path)
+
+    def test_from_cfg_missing_keys_default_zero(self):
+        p = SC2HierarchicalLinearPolicy.from_cfg({}, SC2_MINIGAME_OBS_SPEC)
+        np.testing.assert_array_equal(p._meta_weights, 0.0)
+        np.testing.assert_array_equal(p._q_weights, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# SC2HierarchicalLinearPolicy — flat-weight interface
+# ---------------------------------------------------------------------------
+
+
+class TestSC2HierarchicalLinearPolicyFlat(unittest.TestCase):
+    def test_flat_length(self):
+        p = _make_policy()
+        obs_dim = SC2_MINIGAME_OBS_SPEC.dim
+        expected = (N_CATEGORIES + N_FUNCTION_IDS + N_SPATIAL_ROWS + N_QUEUE_ROWS) * obs_dim
+        self.assertEqual(len(p.to_flat()), expected)
+
+    def test_with_flat_round_trip(self):
+        p = _make_policy()
+        flat = p.to_flat()
+        p2 = p.with_flat(flat)
+        np.testing.assert_allclose(p._meta_weights, p2._meta_weights, atol=1e-6)
+        np.testing.assert_allclose(p._fn_weights, p2._fn_weights, atol=1e-6)
+        np.testing.assert_allclose(p._q_weights, p2._q_weights, atol=1e-6)
+
+    def test_mutated_different_weights(self):
+        p = _make_policy()
+        p2 = p.mutated(scale=1.0, share=1.0)
+        self.assertFalse(np.allclose(p.to_flat(), p2.to_flat()))
+
+    def test_mutated_same_shape(self):
+        p = _make_policy()
+        p2 = p.mutated(scale=0.1, share=0.3)
+        self.assertEqual(p.to_flat().shape, p2.to_flat().shape)
+
+
+# ---------------------------------------------------------------------------
+# SC2HierarchicalGeneticPolicy
+# ---------------------------------------------------------------------------
+
+
+class TestSC2HierarchicalGeneticPolicy(unittest.TestCase):
+    def test_policy_type(self):
+        self.assertEqual(SC2HierarchicalGeneticPolicy.POLICY_TYPE, "sc2_hierarchical")
+
+    def test_compatible_with_sc2(self):
+        ok, _ = SC2HierarchicalGeneticPolicy.compatible_with("sc2")
+        self.assertTrue(ok)
+
+    def test_not_compatible_with_tmnf(self):
+        ok, _ = SC2HierarchicalGeneticPolicy.compatible_with("tmnf")
+        self.assertFalse(ok)
+
+    def test_initialize_random_and_call(self):
+        g = _make_genetic()
+        g.initialize_random()
+        obs = np.ones(SC2_MINIGAME_OBS_SPEC.dim, dtype=np.float32)
+        # champion is set during initialize_random via the parent class
+        action = g(obs)
+        self.assertEqual(action.shape, (4,))
+
+    def test_head_names_include_meta_and_queue(self):
+        # _ALL_HIERARCHICAL_ROW_NAMES stores base names; _weights suffix is
+        # added by to_cfg() and the GeneticPolicy crossover logic.
+        self.assertIn("meta_0", _ALL_HIERARCHICAL_ROW_NAMES)
+        self.assertIn("queue", _ALL_HIERARCHICAL_ROW_NAMES)
+
+    def test_save_champion(self):
+        g = _make_genetic()
+        g.initialize_random()
+        with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as f:
+            path = f.name
+        try:
+            g.save(path)
+            self.assertTrue(os.path.exists(path))
+            # Reload and verify it's a valid hierarchical policy
+            p = SC2HierarchicalLinearPolicy.load(path, SC2_MINIGAME_OBS_SPEC)
+            self.assertEqual(p._meta_weights.shape[0], N_CATEGORIES)
+        finally:
+            os.unlink(path)
+
+    def test_from_cfg_round_trip(self):
+        g = _make_genetic()
+        cfg = g.to_cfg()
+        self.assertEqual(cfg["policy_type"], "sc2_hierarchical")
+        g2 = SC2HierarchicalGeneticPolicy.from_cfg(cfg)
+        self.assertEqual(g2._pop_size, g._pop_size)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #388

## Summary

- Introduces a hierarchical action space for StarCraft 2 that groups 116 function IDs into five meta-categories (`move`, `attack`, `build`, `train`, `upgrade`), exported from `games.sc2.actions` as `ACTION_CATEGORIES`, `CATEGORY_NAMES`, `N_CATEGORIES`, and `FN_IDX_TO_CATEGORY`.
- Implements `SC2HierarchicalLinearPolicy`: a two-stage linear policy that first selects a meta-category via one weight head, then selects a specific action within that category via a second head, with continuous spatial outputs and a queue flag.
- Adds `SC2HierarchicalGeneticPolicy`: a genetic algorithm trainer for the hierarchical policy, compatible with the existing evolutionary framework.

## Related issues

Refs #388

## Validation

```bash
PYTHONPATH=. poetry run python -m pytest tests/test_sc2_hierarchical_policy.py -v
PYTHONPATH=. poetry run python -m pytest tests/ \
    --ignore=tests/test_env_termination.py \
    --ignore=tests/test_grid_search.py \
    --ignore=tests/integration/
```

## Feature details

**User problem:** SC2 agents benefit from hierarchical action selection — first choosing a logical action category (e.g., "attack" vs. "build"), then selecting a specific action within that category. This reduces the search space and improves sample efficiency.

**Proposed solution:**
1. **Action categories** (`games/sc2/actions.py`): Define `ACTION_CATEGORIES` mapping category names to fn_idx lists, with `CATEGORY_NAMES` as the canonical ordering and `FN_IDX_TO_CATEGORY` as the inverse map. Every fn_idx belongs to exactly one category.
2. **Hierarchical linear policy** (`SC2HierarchicalLinearPolicy`): Four-stage decision process:
   - Stage 1: Meta-category selection via `meta_weights @ obs` → argmax over N_CATEGORIES scores (masked to `-inf` if category has no available actions).
   - Stage 2: fn_idx selection via `fn_weights @ obs` → masked argmax within the selected category's fn_ids.
   - Stage 3: Spatial coordinates via `spatial_weights @ obs` → sigmoid → `(x, y) ∈ [0, 1]²`.
   - Stage 4: Queue flag via `queue_weights @ obs` → sign → `queue ∈ {0, 1}`.
3. **Genetic trainer** (`SC2HierarchicalGeneticPolicy`): Wraps the linear policy in the existing `GeneticPolicy` framework with uniform crossover, Gaussian mutation, and elite selection.
4. **Serialization**: YAML format with one `{head}_{row}_weights` key per matrix row, enabling crossover without modification.

**Trade-offs / follow-ups:**
- The hierarchical structure is fixed (five categories); future work could learn category boundaries or use a learned gating mechanism.
- Availability masking is applied at both stages to ensure the agent never selects an unavailable action.
- The policy is deterministic (argmax); stochastic variants could be added if needed.

## Refactor / docs / chore details

- What changed:
  - Added `ACTION_CATEGORIES`, `CATEGORY_NAMES`, `N_CATEGORIES`, `FN_IDX_TO_CATEGORY` to `games/sc2/actions.py`.
  - Added `SC2HierarchicalLinearPolicy` and `SC2HierarchicalGeneticPolicy` to `games/sc2/sc2_policies.py`.
  - Added comprehensive unit tests in `tests/test_sc2_hierarchical_policy.py` (362 lines, 30+ test cases).
  - Updated `CHANGELOG.md`, `games/sc2/README.md`, and `tests/README.md`.

- Why this is safe:
  - New classes and exports; no changes to existing policies or action encoding.
  - All new code is isolated to the hierarchical policy implementation.
  - Extensive test coverage validates

https://claude.ai/code/session_01X6JzNeDEuHdwvTNDdcRxs9