### PR TITLE
Lift BC pipeline to framework; add game-agnostic orchestrator (#393)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,15 @@ formatting, internal refactors with no behaviour change — can be skipped.
   `demos.npz` schema is byte-compatible with what `games/sc2/replay_bc.py`
   has been writing since #351, so existing datasets load unchanged. The
   `GameAdapter` Protocol gains an optional `bc: BCAdapter | None`
-  attribute. No game wires this seam yet — SC2 BC still runs through its
-  existing path. Phase 2 (#394) ports SC2 onto the new seam; phase 3
-  (#395) adds TMNF.
+  attribute.
+- SC2 BC ported onto the framework seam (issue #394, parent #392). New
+  `games/sc2/bc_adapter.py` implements `BCAdapter` for SC2 and is wired
+  on `SC2Adapter.bc`. `--bc` is now game-agnostic at the CLI level
+  (`_run_bc(adapter, args)` in `main.py`); games without a wired
+  `BCAdapter` exit with a clear error. `games/sc2/replay_bc.py` still
+  owns the replay parser and per-target fitters, and its `run()` remains
+  as a backward-compat shim with the legacy summary shape — external
+  scripts and `tests/test_sc2_replay_bc.py` keep working unchanged.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+### Added
+- Framework-level behaviour-cloning seam (issue #393, parent #392). New
+  modules `framework/bc.py` (`BCAdapter` Protocol + `run()` orchestrator)
+  and `framework/bc_io.py` (`load_dataset`, `save_summary`) lift the
+  game-agnostic parts of the SC2 BC pipeline into the framework. The
+  `demos.npz` schema is byte-compatible with what `games/sc2/replay_bc.py`
+  has been writing since #351, so existing datasets load unchanged. The
+  `GameAdapter` Protocol gains an optional `bc: BCAdapter | None`
+  attribute. No game wires this seam yet — SC2 BC still runs through its
+  existing path. Phase 2 (#394) ports SC2 onto the new seam; phase 3
+  (#395) adds TMNF.
 
 ---
 

--- a/framework/bc.py
+++ b/framework/bc.py
@@ -56,8 +56,9 @@ class BCAdapter(Protocol):
     name :
         Game identifier, matching the ``GameAdapter.name`` of the same game.
     supported_targets :
-        ``policy_type`` strings this adapter knows how to BC into.  The CLI
-        ``--bc-target`` choices list is derived from this.
+        ``policy_type`` strings this adapter knows how to BC into.  The
+        framework :func:`run` orchestrator validates ``target`` against this
+        tuple before dispatching to :meth:`fit_bc`.
     default_target :
         Default value when neither CLI nor config specifies ``bc_target``.
         Must appear in :attr:`supported_targets`.
@@ -265,7 +266,7 @@ def run(
         "bc_target": target,
         "n_episodes": int(meta.get("n_episodes", 0)),
         "n_pairs": int(meta.get("n_steps", 0)),
-        "bc_race": race if race else "any",
+        "bc_race": race_filter or "any",
         "final_bc_loss": float(bc_loss),
         "extras": extras,
     }

--- a/framework/bc.py
+++ b/framework/bc.py
@@ -127,6 +127,23 @@ class BCAdapter(Protocol):
         """
         ...
 
+    def summary_extras(
+        self,
+        dataset: dict,
+        meta: dict,
+        *,
+        target: str,
+        training_params: dict,
+    ) -> dict:
+        """Optional: per-game stats merged into ``bc_summary.json["extras"]``.
+
+        Called by the orchestrator after :meth:`fit_bc` has returned, with
+        the full loaded dataset still in scope.  Default implementation
+        returns an empty dict — implement when your game wants to record
+        game-specific stats (e.g. SC2's ``fn_idx_histogram``).
+        """
+        return {}
+
 
 def run(
     bc_adapter: BCAdapter,
@@ -235,6 +252,14 @@ def run(
         policy.save_trainer_state(ts_path)
         logger.info("BC: saved trainer state → %s", ts_path)
 
+    extras: dict = dict(meta.get("summary_extras", {}))
+    # Optional post-fit hook: lets the adapter compute stats that need the
+    # loaded dataset (e.g. SC2's fn_idx_histogram).  Adapters that don't
+    # implement it inherit the no-op default from the Protocol.
+    extras_hook = getattr(bc_adapter, "summary_extras", None)
+    if callable(extras_hook):
+        extras.update(extras_hook(dataset, meta, target=target, training_params=training_params))
+
     summary = {
         "game": bc_adapter.name,
         "bc_target": target,
@@ -242,7 +267,7 @@ def run(
         "n_pairs": int(meta.get("n_steps", 0)),
         "bc_race": race if race else "any",
         "final_bc_loss": float(bc_loss),
-        "extras": meta.get("summary_extras", {}),
+        "extras": extras,
     }
 
     save_summary(experiment_dir, summary)

--- a/framework/bc.py
+++ b/framework/bc.py
@@ -1,0 +1,249 @@
+"""Game-agnostic behaviour-cloning protocol and orchestrator.
+
+Behaviour cloning (BC) pre-trains a policy from demonstration trajectories
+before the live RL loop starts.  StarCraft 2 has shipped its own end-to-end
+BC pipeline (``games/sc2/replay_bc.py``) since #353; this module lifts the
+generic parts of that pipeline — workflow shape, summary schema, NPZ I/O,
+weight + trainer-state saving — into the framework so other games can plug
+in their own replay parsers and per-target fitters.
+
+Phase 1 (#393) introduces the seam.  No game wires its ``BCAdapter`` yet;
+phase 2 (#394) ports SC2 onto it, phase 3 (#395) adds TMNF.
+
+Per-game extension point
+========================
+
+Implement :class:`BCAdapter` for your game (one module per game, conventionally
+``games/<game>/bc.py``).  Expose the instance via the game's ``GameAdapter.bc``
+attribute.  The :func:`run` orchestrator drives the whole flow:
+
+#. ``bc_adapter.validate_replay_dir(replay_dir, race=...)`` — fail fast on a
+   bad source directory.
+#. ``bc_adapter.build_dataset(replay_dir, save_path, ...)`` — replays →
+   ``demos.npz`` (schema in :mod:`framework.bc_io`).
+#. ``bc_adapter.fit_bc(dataset, obs_spec, target=...)`` — return a trained
+   policy + final BC loss.
+#. Save ``policy_weights.yaml`` (+ ``trainer_state.npz`` when the policy
+   carries one) and ``bc_summary.json`` into the experiment directory.
+
+The orchestrator never reads game-specific config; everything game-specific
+is owned by the ``BCAdapter`` implementation, which is free to inspect the
+``training_params`` dict it receives.
+"""
+
+from __future__ import annotations
+
+import logging
+import pathlib
+import tempfile
+from typing import Any, Protocol
+
+from framework.bc_io import load_dataset, save_summary
+from framework.obs_spec import ObsSpec
+
+logger = logging.getLogger(__name__)
+
+
+class BCAdapter(Protocol):
+    """Per-game behaviour-cloning extension.
+
+    A concrete adapter owns its game's replay format, dataset assembly, and
+    per-target fit logic.  The framework :func:`run` orchestrator calls into
+    this interface to drive the BC flow.
+
+    Attributes
+    ----------
+    name :
+        Game identifier, matching the ``GameAdapter.name`` of the same game.
+    supported_targets :
+        ``policy_type`` strings this adapter knows how to BC into.  The CLI
+        ``--bc-target`` choices list is derived from this.
+    default_target :
+        Default value when neither CLI nor config specifies ``bc_target``.
+        Must appear in :attr:`supported_targets`.
+    """
+
+    name: str
+    supported_targets: tuple[str, ...]
+    default_target: str
+
+    def validate_replay_dir(
+        self,
+        replay_dir: str | pathlib.Path | None,
+        *,
+        race: str | None = None,
+    ) -> Any:
+        """Fail fast if *replay_dir* cannot be used as a BC source.
+
+        Implementations may return any metadata that helps logging (e.g. the
+        list of replay paths found).  The orchestrator does not inspect the
+        return value — it only cares whether this call raises.
+        """
+        ...
+
+    def build_dataset(
+        self,
+        replay_dir: str | pathlib.Path | None,
+        save_path: str | pathlib.Path,
+        *,
+        obs_spec: ObsSpec,
+        training_params: dict,
+        race: str | None = None,
+        max_replays: int | None = None,
+    ) -> dict:
+        """Parse *replay_dir* → ``demos.npz`` at *save_path*.
+
+        The saved file must be readable by :func:`framework.bc_io.load_dataset`
+        (schema: ``obs``, ``actions``, ``episode_starts``, ``episode_lengths``,
+        ``episode_id``, ``meta``).
+
+        Implementations read any extra knobs they need (player id, step_mul,
+        screen size, …) from *training_params*.
+
+        Returns
+        -------
+        dict
+            Metadata dict; at minimum ``n_episodes`` and ``n_steps``.  Also
+            embedded in the ``.npz`` under the ``meta`` key.
+        """
+        ...
+
+    def fit_bc(
+        self,
+        dataset: dict,
+        obs_spec: ObsSpec,
+        *,
+        target: str,
+        training_params: dict,
+    ) -> tuple[Any, float]:
+        """Pre-train a *target* policy on *dataset*.
+
+        Returns
+        -------
+        (policy, final_bc_loss)
+            ``policy`` must have a ``save(path)`` method.  When it is a
+            :class:`framework.policies.BasePolicy`, the orchestrator also
+            calls ``save_trainer_state``.
+        """
+        ...
+
+
+def run(
+    bc_adapter: BCAdapter,
+    replay_dir: str | pathlib.Path | None,
+    experiment_dir: str | pathlib.Path,
+    *,
+    obs_spec: ObsSpec,
+    target: str,
+    training_params: dict,
+    race: str | None = None,
+    max_replays: int | None = None,
+) -> dict:
+    """Drive a full BC run end to end via *bc_adapter*.
+
+    Workflow
+    --------
+    #. :meth:`BCAdapter.validate_replay_dir`.
+    #. :meth:`BCAdapter.build_dataset` into a temp ``demos.npz``, then load
+       it back via :func:`framework.bc_io.load_dataset`.
+    #. :meth:`BCAdapter.fit_bc`.
+    #. Save ``policy_weights.yaml`` and (when the policy has one)
+       ``trainer_state.npz`` into *experiment_dir*.  Save ``bc_summary.json``
+       via :func:`framework.bc_io.save_summary`.
+
+    Parameters
+    ----------
+    bc_adapter :
+        The game-specific BC implementation.
+    replay_dir :
+        Directory the *bc_adapter* knows how to read.  May be ``None`` for
+        adapters whose source is live demonstrations rather than replay files.
+    experiment_dir :
+        Where ``policy_weights.yaml``, ``trainer_state.npz``, and
+        ``bc_summary.json`` are written.
+    obs_spec :
+        Active observation spec for the experiment.
+    target :
+        Policy type to BC into.  Must be in
+        :attr:`BCAdapter.supported_targets`.
+    training_params :
+        The full ``training_params.yaml`` dict.  Forwarded to *bc_adapter*
+        unchanged so it can read game-specific knobs.
+    race :
+        Optional race filter forwarded to *bc_adapter*.
+    max_replays :
+        Optional cap on replays processed.
+
+    Returns
+    -------
+    dict
+        BC summary (same content written to ``bc_summary.json``).
+    """
+    from framework.policies import BasePolicy, trainer_state_path
+
+    if target not in bc_adapter.supported_targets:
+        raise ValueError(
+            f"BC target {target!r} not supported by {bc_adapter.name!r} "
+            f"BCAdapter; supported: {bc_adapter.supported_targets}"
+        )
+
+    experiment_dir = pathlib.Path(experiment_dir)
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+
+    # Normalise race: "any"/empty → None
+    race_filter: str | None = None
+    if race and race.lower() not in ("", "any"):
+        race_filter = race.lower()
+
+    bc_adapter.validate_replay_dir(replay_dir, race=race_filter)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        demos_path = pathlib.Path(tmp) / "demos.npz"
+        meta = bc_adapter.build_dataset(
+            replay_dir,
+            demos_path,
+            obs_spec=obs_spec,
+            training_params=training_params,
+            race=race_filter,
+            max_replays=max_replays,
+        )
+        dataset = load_dataset(demos_path)
+
+    policy, bc_loss = bc_adapter.fit_bc(
+        dataset,
+        obs_spec,
+        target=target,
+        training_params=training_params,
+    )
+
+    # Save weights.  Champion-based policies whose save() writes metadata
+    # only (e.g. SC2CMAESPolicy) expose ``._champion`` — save that directly
+    # so a subsequent fine-tune can reload it.
+    weights_path = str(experiment_dir / "policy_weights.yaml")
+    champion = getattr(policy, "_champion", None)
+    if champion is not None and hasattr(champion, "save") and callable(champion.save):
+        champion.save(weights_path)
+    else:
+        policy.save(weights_path)
+    # CNN-style policies may redirect .yaml → .npz inside save(); log whichever exists.
+    _npz = weights_path.replace(".yaml", ".npz")
+    _logged = _npz if not pathlib.Path(weights_path).exists() and pathlib.Path(_npz).exists() else weights_path
+    logger.info("BC: saved weights → %s", _logged)
+
+    if isinstance(policy, BasePolicy):
+        ts_path = trainer_state_path(weights_path)
+        policy.save_trainer_state(ts_path)
+        logger.info("BC: saved trainer state → %s", ts_path)
+
+    summary = {
+        "game": bc_adapter.name,
+        "bc_target": target,
+        "n_episodes": int(meta.get("n_episodes", 0)),
+        "n_pairs": int(meta.get("n_steps", 0)),
+        "bc_race": race if race else "any",
+        "final_bc_loss": float(bc_loss),
+        "extras": meta.get("summary_extras", {}),
+    }
+
+    save_summary(experiment_dir, summary)
+    return summary

--- a/framework/bc_io.py
+++ b/framework/bc_io.py
@@ -1,0 +1,105 @@
+"""I/O helpers for behaviour-cloning datasets and summaries.
+
+The NPZ format here is byte-compatible with the one SC2 has been writing
+since #351 (``games/sc2/replay_bc.build_dataset``), so existing ``demos.npz``
+files load unchanged.
+
+Dataset schema
+==============
+
+A BC dataset NPZ contains six keys::
+
+    obs              float32[N, D]     — concatenated observations
+    actions          float32[N, A]     — concatenated actions
+    episode_starts   int64[E]          — start index of each episode in obs/actions
+    episode_lengths  int64[E]          — length of each episode
+    episode_id       int64[N]          — per-sample episode index ∈ [0, E)
+    meta             0-d bytes         — JSON-encoded metadata dict
+
+The exact shape of ``actions`` is game-specific (SC2 uses
+``[fn_idx, x, y, queue]``; TMNF uses ``[steer, accel, brake]``).  The
+framework loader is shape-agnostic.
+
+Summary schema
+==============
+
+``bc_summary.json`` is written by :func:`save_summary` with at minimum::
+
+    {
+      "game": "sc2",
+      "bc_target": "sc2_reinforce",
+      "n_episodes": 12,
+      "n_pairs": 8743,
+      "bc_race": "terran",
+      "final_bc_loss": 0.42,
+      "extras": { ... game-specific stats ... }
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import numpy as np
+
+
+def load_dataset(
+    path: str | pathlib.Path,
+    *,
+    as_episodes: bool = False,
+) -> dict | list[tuple[np.ndarray, np.ndarray]]:
+    """Load a ``demos.npz`` dataset.
+
+    Parameters
+    ----------
+    path :
+        Path to the ``.npz`` file.
+    as_episodes :
+        ``False`` (default) — return a dict with keys ``obs``, ``actions``,
+        ``episode_starts``, ``episode_lengths``, ``episode_id``, ``meta``.
+        Suitable for memoryless policies that sample individual (obs, action)
+        pairs.
+
+        ``True`` — return a list of ``(obs_seq, act_seq)`` tuples, one per
+        episode, preserving temporal order within each episode.  Suitable for
+        recurrent policies that consume whole ordered sequences with
+        hidden-state carry-over.
+    """
+    data = np.load(str(path), allow_pickle=False)
+    obs = data["obs"]
+    actions = data["actions"]
+    episode_starts = data["episode_starts"]
+    episode_lengths = data["episode_lengths"]
+    episode_id = data["episode_id"]
+    meta = json.loads(str(data["meta"]))
+
+    if not as_episodes:
+        return {
+            "obs": obs,
+            "actions": actions,
+            "episode_starts": episode_starts,
+            "episode_lengths": episode_lengths,
+            "episode_id": episode_id,
+            "meta": meta,
+        }
+
+    episodes: list[tuple[np.ndarray, np.ndarray]] = []
+    for start, length in zip(episode_starts.tolist(), episode_lengths.tolist()):
+        ep_obs = obs[start : start + length]
+        ep_act = actions[start : start + length]
+        episodes.append((ep_obs, ep_act))
+    return episodes
+
+
+def save_summary(experiment_dir: str | pathlib.Path, summary: dict) -> pathlib.Path:
+    """Write *summary* to ``<experiment_dir>/bc_summary.json``.
+
+    Returns the path written, for caller convenience.
+    """
+    experiment_dir = pathlib.Path(experiment_dir)
+    experiment_dir.mkdir(parents=True, exist_ok=True)
+    out = experiment_dir / "bc_summary.json"
+    with open(out, "w") as f:
+        json.dump(summary, f, indent=2, sort_keys=False)
+    return out

--- a/framework/bc_io.py
+++ b/framework/bc_io.py
@@ -14,7 +14,9 @@ A BC dataset NPZ contains six keys::
     episode_starts   int64[E]          — start index of each episode in obs/actions
     episode_lengths  int64[E]          — length of each episode
     episode_id       int64[N]          — per-sample episode index ∈ [0, E)
-    meta             0-d bytes         — JSON-encoded metadata dict
+    meta             0-d unicode str   — JSON-encoded metadata dict (numpy
+                                          stores as `<U…`; ``np.load`` yields
+                                          a 0-d ``str_``)
 
 The exact shape of ``actions`` is game-specific (SC2 uses
 ``[fn_idx, x, y, queue]``; TMNF uses ``[steer, accel, brake]``).  The

--- a/framework/game_adapter.py
+++ b/framework/game_adapter.py
@@ -9,7 +9,10 @@ pysc2).
 
 from __future__ import annotations
 
-from typing import Any, Callable, Protocol
+from typing import TYPE_CHECKING, Any, Callable, Protocol
+
+if TYPE_CHECKING:
+    from framework.bc import BCAdapter
 
 # ---------------------------------------------------------------------------
 # Protocol
@@ -21,6 +24,12 @@ class GameAdapter(Protocol):
 
     name: str
     config_dir: str  # e.g. "games/tmnf/config"
+
+    #: Optional behaviour-cloning extension.  When set, ``python main.py
+    #: <experiment> --game <name> --bc`` drives the framework BC orchestrator
+    #: via this object.  ``None`` means BC isn't supported for the game yet.
+    #: See :mod:`framework.bc`.
+    bc: "BCAdapter | None"
 
     def experiment_dir(
         self,

--- a/games/sc2/README.md
+++ b/games/sc2/README.md
@@ -672,11 +672,16 @@ python main.py myrun --game sc2 --bc --replay-dir /path/to/replays --bc-race ter
 python main.py myrun --game sc2
 ```
 
-`--bc` is SC2-only (rejected with an error for other games, and mutually
-exclusive with `--play` / `--eval`).  The resulting `policy_weights.yaml`
-(and optional `trainer_state.npz`) are written to the standard experiment
-directory; the normal SC2 training loop auto-loads them on the next run, so
-step 2 is just a regular training run.
+`--bc` is now game-agnostic — any game whose `GameAdapter` exposes a
+`BCAdapter` can use it (currently SC2; TMNF lands in issue #395).  The
+mode flag is still mutually exclusive with `--play` / `--eval`.  The
+resulting `policy_weights.yaml` (and optional `trainer_state.npz`) are
+written to the standard experiment directory; the normal SC2 training
+loop auto-loads them on the next run, so step 2 is just a regular
+training run.  The orchestration lives in `framework/bc.py` and the
+SC2-specific implementation in `games/sc2/bc_adapter.py` —
+`games/sc2/replay_bc.py` still owns the replay parser and per-target
+fitters.
 
 ### Getting replay data
 

--- a/games/sc2/adapter.py
+++ b/games/sc2/adapter.py
@@ -74,6 +74,11 @@ class SC2Adapter:
     name = "sc2"
     config_dir = "games/sc2/config"
 
+    def __init__(self) -> None:
+        from games.sc2.bc_adapter import SC2BCAdapter
+
+        self.bc = SC2BCAdapter()
+
     def _map_name(self, training_params: dict, track_override: str | None) -> str:
         if track_override:
             return track_override

--- a/games/sc2/bc_adapter.py
+++ b/games/sc2/bc_adapter.py
@@ -1,0 +1,137 @@
+"""StarCraft 2 BC adapter — wires :mod:`games.sc2.replay_bc` into the
+framework BC orchestrator (:mod:`framework.bc`).
+
+This is the SC2 implementation of :class:`framework.bc.BCAdapter`.  The
+heavy lifting (replay parsing, dataset assembly, per-target fitting)
+still lives in :mod:`games.sc2.replay_bc` — this module just owns the
+SC2-specific config-key reading and forwards to it.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from typing import Any
+
+from framework.obs_spec import ObsSpec
+
+SUPPORTED_TARGETS: tuple[str, ...] = (
+    "sc2_reinforce",
+    "sc2_genetic",
+    "sc2_cmaes",
+    "sc2_neural_net",
+    "sc2_neural_dqn",
+    "sc2_lstm",
+    "sc2_cnn",
+    "epsilon_greedy",
+    "ucb_q",
+)
+
+
+class SC2BCAdapter:
+    """SC2 implementation of the framework :class:`BCAdapter` Protocol."""
+
+    name = "sc2"
+    supported_targets: tuple[str, ...] = SUPPORTED_TARGETS
+    default_target = "sc2_reinforce"
+
+    def validate_replay_dir(
+        self,
+        replay_dir: str | pathlib.Path | None,
+        *,
+        race: str | None = None,
+    ) -> Any:
+        from games.sc2.replay_bc import validate_replay_dir as _validate
+
+        if replay_dir is None:
+            raise ValueError(
+                "SC2 BC needs a directory of .SC2Replay files; "
+                "pass --replay-dir or set bc_replay_dir in training_params.yaml."
+            )
+        return _validate(replay_dir, race=race)
+
+    def build_dataset(
+        self,
+        replay_dir: str | pathlib.Path | None,
+        save_path: str | pathlib.Path,
+        *,
+        obs_spec: ObsSpec,
+        training_params: dict,
+        race: str | None = None,
+        max_replays: int | None = None,
+    ) -> dict:
+        from games.sc2.replay_bc import build_dataset as _build
+
+        if replay_dir is None:
+            raise ValueError("SC2 BC requires a non-None replay directory.")
+
+        player_id = _resolve_player_id(training_params)
+        return _build(
+            replay_dir,
+            save_path,
+            obs_spec=obs_spec,
+            player_id=player_id,
+            race=race,
+            step_mul=training_params.get("bc_step_mul", training_params.get("step_mul", 1)),
+            screen_size=training_params.get("screen_size", 64),
+            minimap_size=training_params.get("minimap_size", 64),
+            max_replays=max_replays,
+        )
+
+    def summary_extras(
+        self,
+        dataset: dict,
+        meta: dict,
+        *,
+        target: str,
+        training_params: dict,
+    ) -> dict:
+        """Per-game summary stats: fn_idx histogram + replay-counting fields."""
+        import numpy as np
+
+        fn_idx_all = dataset["actions"][:, 0].astype(int)
+        unique_fns, counts = np.unique(fn_idx_all, return_counts=True)
+        fn_histogram = {int(k): int(v) for k, v in zip(unique_fns, counts)}
+
+        return {
+            "n_replays_kept": int(meta.get("n_episodes", 0)),
+            "n_replays_skipped_race": int(meta.get("n_replays_skipped_race", 0)),
+            "fn_idx_histogram": fn_histogram,
+            "bc_player_id": str(_resolve_player_id(training_params)),
+        }
+
+    def fit_bc(
+        self,
+        dataset: dict,
+        obs_spec: ObsSpec,
+        *,
+        target: str,
+        training_params: dict,
+    ) -> tuple[Any, float]:
+        from games.sc2.replay_bc import fit_bc as _fit
+
+        return _fit(
+            dataset,
+            obs_spec,
+            target=target,
+            hidden_sizes=training_params.get("hidden_sizes"),
+            bc_epochs=training_params.get("bc_epochs", 10),
+            bc_learning_rate=training_params.get("bc_learning_rate", 1e-3),
+            bc_batch_size=training_params.get("bc_batch_size", 256),
+            bc_ignore_noop=training_params.get("bc_ignore_noop", True),
+            seed=training_params.get("seed"),
+            n_channels=training_params.get("_n_channels", 1),
+            n_bins=training_params.get("n_bins", 3),
+            bc_lstm_hidden_size=training_params.get("bc_lstm_hidden_size", 64),
+        )
+
+
+def _resolve_player_id(training_params: dict) -> int | str:
+    """Read ``bc_player_id`` from *training_params*, accepting "winner"/"1"/"2"."""
+    raw = training_params.get("bc_player_id", "winner")
+    if raw in ("1", "2"):
+        return int(raw)
+    return raw
+
+
+def make_bc_adapter() -> SC2BCAdapter:
+    return SC2BCAdapter()

--- a/games/sc2/bc_adapter.py
+++ b/games/sc2/bc_adapter.py
@@ -96,7 +96,9 @@ class SC2BCAdapter:
             "n_replays_kept": int(meta.get("n_episodes", 0)),
             "n_replays_skipped_race": int(meta.get("n_replays_skipped_race", 0)),
             "fn_idx_histogram": fn_histogram,
-            "bc_player_id": str(_resolve_player_id(training_params)),
+            # Preserve the resolved type ("winner" / 1 / 2) so consumers that
+            # distinguish "1" from 1 see the same value as the legacy summary.
+            "bc_player_id": _resolve_player_id(training_params),
         }
 
     def fit_bc(

--- a/games/sc2/replay_bc.py
+++ b/games/sc2/replay_bc.py
@@ -58,9 +58,15 @@ from typing import Any, Iterator
 
 import numpy as np
 
+from framework.bc_io import load_dataset  # re-exported for backward-compat
 from framework.obs_spec import ObsSpec
 
 logger = logging.getLogger(__name__)
+
+# Silence "imported but unused" — load_dataset is re-exported from this module
+# so existing callers (notebooks, third-party imports) keep working after the
+# canonical definition moved to framework.bc_io (issue #393).
+_ = load_dataset
 
 _WINNER_SENTINEL = "winner"
 
@@ -646,58 +652,6 @@ def build_dataset(
 # ---------------------------------------------------------------------------
 # Dataset loader
 # ---------------------------------------------------------------------------
-
-
-def load_dataset(
-    path: str | pathlib.Path,
-    *,
-    as_episodes: bool = False,
-) -> dict | list[tuple[np.ndarray, np.ndarray]]:
-    """Load a ``demos.npz`` dataset saved by :func:`build_dataset`.
-
-    Parameters
-    ----------
-    path:
-        Path to the ``.npz`` file.
-    as_episodes:
-        ``False`` (default) — return a dict with keys ``obs``, ``actions``,
-        ``episode_starts``, ``episode_lengths``, ``episode_id``, and ``meta``
-        (parsed JSON).  Suitable for memoryless policies that sample
-        individual (obs, action) pairs.
-
-        ``True`` — return a list of ``(obs_seq, act_seq)`` tuples, one per
-        episode, preserving temporal order within each episode.  Suitable for
-        recurrent policies that consume whole ordered sequences with
-        hidden-state carry-over.
-
-    Returns
-    -------
-    dict or list of (obs_seq, act_seq)
-    """
-    data = np.load(str(path), allow_pickle=False)
-    obs = data["obs"]
-    actions = data["actions"]
-    episode_starts = data["episode_starts"]
-    episode_lengths = data["episode_lengths"]
-    episode_id = data["episode_id"]
-    meta = json.loads(str(data["meta"]))
-
-    if not as_episodes:
-        return {
-            "obs": obs,
-            "actions": actions,
-            "episode_starts": episode_starts,
-            "episode_lengths": episode_lengths,
-            "episode_id": episode_id,
-            "meta": meta,
-        }
-
-    episodes: list[tuple[np.ndarray, np.ndarray]] = []
-    for start, length in zip(episode_starts.tolist(), episode_lengths.tolist()):
-        ep_obs = obs[start : start + length]
-        ep_act = actions[start : start + length]
-        episodes.append((ep_obs, ep_act))
-    return episodes
 
 
 # ---------------------------------------------------------------------------
@@ -1552,7 +1506,11 @@ def fit_bc(
 
 
 # ---------------------------------------------------------------------------
-# run — full pipeline: replays → dataset → fit → save
+# run — backward-compat shim
+#
+# The canonical orchestrator is now :func:`framework.bc.run`, driven by an
+# :class:`games.sc2.bc_adapter.SC2BCAdapter`.  This shim preserves the old
+# call signature for external scripts and the SC2 test suite.
 # ---------------------------------------------------------------------------
 
 
@@ -1578,57 +1536,28 @@ def run(
     n_bins: int = 3,
     bc_lstm_hidden_size: int = 64,
 ) -> dict:
-    """Orchestrate replay reading, BC fitting, and saving of weights + summary.
+    """Drive an SC2 BC run end to end.
 
-    Workflow:
-
-    1. :func:`validate_replay_dir` and optionally cap at *max_replays*.
-    2. :func:`build_dataset` — parse replays → NPZ demonstration dataset.
-    3. :func:`fit_bc` — pre-train the policy on the dataset.
-    4. Save ``policy_weights.yaml`` (+ ``trainer_state.npz`` for MLP targets)
-       and ``bc_summary.json`` into *experiment_dir*.
-
-    Parameters
-    ----------
-    replay_dir :
-        Directory containing ``.SC2Replay`` files.
-    experiment_dir :
-        Destination directory for ``policy_weights.yaml``,
-        ``trainer_state.npz``, and ``bc_summary.json``.
-    obs_spec :
-        Observation spec — built from ``training_params.yaml`` by the caller.
-    target, player_id, race, max_replays, step_mul, screen_size,
-    minimap_size, hidden_sizes, bc_epochs, bc_learning_rate,
-    bc_batch_size, bc_ignore_noop, seed, n_channels, n_bins,
-    bc_lstm_hidden_size :
-        Forwarded to :func:`build_dataset` and/or :func:`fit_bc`.
-
-    Returns
-    -------
-    dict
-        BC summary dict (same content written to ``bc_summary.json``).
-
-    Raises
-    ------
-    ValueError
-        If the replay directory is empty, race filter drops all replays, or
-        the filtered dataset has no steps.
+    Implementation mirrors :func:`framework.bc.run`, but resolves
+    ``validate_replay_dir``, ``build_dataset``, and ``load_dataset`` through
+    this module's namespace so tests that ``patch.multiple("games.sc2.replay_bc",
+    ...)`` continue to work after the canonical names moved to
+    :mod:`framework`.
     """
     import tempfile
 
+    from framework.bc_io import save_summary
     from framework.policies import BasePolicy, trainer_state_path
 
     experiment_dir = pathlib.Path(experiment_dir)
     experiment_dir.mkdir(parents=True, exist_ok=True)
 
-    # Normalise race: "any"/empty → None (no filter in build_dataset)
     race_filter: str | None = None
     if race and race.lower() not in ("", "any"):
         race_filter = race.lower()
 
     validate_replay_dir(replay_dir, race=race_filter)
 
-    # Build dataset in a temporary file
     with tempfile.TemporaryDirectory() as tmp:
         demos_path = pathlib.Path(tmp) / "demos.npz"
         meta = build_dataset(
@@ -1644,7 +1573,6 @@ def run(
         )
         dataset = load_dataset(demos_path)
 
-    # Fit BC
     policy, bc_loss = fit_bc(
         dataset,
         obs_spec,
@@ -1660,30 +1588,22 @@ def run(
         bc_lstm_hidden_size=bc_lstm_hidden_size,
     )
 
-    # Save policy weights.
-    # For champion-based policies whose save() writes metadata only (e.g.
-    # SC2CMAESPolicy), save the champion directly in the linear YAML format so
-    # _construct_or_resume can reload it on the next run.
     weights_path = str(experiment_dir / "policy_weights.yaml")
     champion = getattr(policy, "_champion", None)
     if champion is not None and hasattr(champion, "save") and callable(champion.save):
         champion.save(weights_path)
     else:
         policy.save(weights_path)
-    # SC2CNNEvolutionPolicy.save() redirects .yaml → .npz; log whichever exists.
     _npz = weights_path.replace(".yaml", ".npz")
     _logged = _npz if not pathlib.Path(weights_path).exists() and pathlib.Path(_npz).exists() else weights_path
     logger.info("BC: saved weights → %s", _logged)
 
-    # Save trainer state for policies that carry one (e.g. SC2REINFORCEPolicy)
     if isinstance(policy, BasePolicy):
         ts_path = trainer_state_path(weights_path)
         policy.save_trainer_state(ts_path)
         logger.info("BC: saved trainer state → %s", ts_path)
 
-    # Build fn_idx histogram from the raw (unfiltered) dataset
-    act_arr_all = dataset["actions"]
-    fn_idx_all = act_arr_all[:, 0].astype(int)
+    fn_idx_all = dataset["actions"][:, 0].astype(int)
     unique_fns, counts = np.unique(fn_idx_all, return_counts=True)
     fn_histogram = {int(k): int(v) for k, v in zip(unique_fns, counts)}
 
@@ -1698,10 +1618,6 @@ def run(
         "bc_target": target,
         "final_bc_loss": float(bc_loss),
     }
-
-    summary_path = experiment_dir / "bc_summary.json"
-    with open(summary_path, "w") as f:
-        json.dump(summary, f, indent=2)
-    logger.info("BC summary written → %s", summary_path)
-
+    save_summary(experiment_dir, summary)
+    logger.info("BC summary written → %s", experiment_dir / "bc_summary.json")
     return summary

--- a/games/sc2/replay_bc.py
+++ b/games/sc2/replay_bc.py
@@ -58,15 +58,10 @@ from typing import Any, Iterator
 
 import numpy as np
 
-from framework.bc_io import load_dataset  # re-exported for backward-compat
+from framework.bc_io import load_dataset  # noqa: F401  (re-exported)
 from framework.obs_spec import ObsSpec
 
 logger = logging.getLogger(__name__)
-
-# Silence "imported but unused" — load_dataset is re-exported from this module
-# so existing callers (notebooks, third-party imports) keep working after the
-# canonical definition moved to framework.bc_io (issue #393).
-_ = load_dataset
 
 _WINNER_SENTINEL = "winner"
 

--- a/main.py
+++ b/main.py
@@ -416,16 +416,23 @@ def _run_bc(adapter, args: argparse.Namespace) -> None:
     if getattr(args, "bc_player", None):
         p = dict(p, bc_player_id=args.bc_player)
 
-    bc_run(
-        bc_adapter,
-        replay_dir,
-        experiment_dir,
-        obs_spec=obs_spec,
-        target=target,
-        training_params=p,
-        race=race,
-        max_replays=p.get("bc_max_replays"),
-    )
+    try:
+        bc_run(
+            bc_adapter,
+            replay_dir,
+            experiment_dir,
+            obs_spec=obs_spec,
+            target=target,
+            training_params=p,
+            race=race,
+            max_replays=p.get("bc_max_replays"),
+        )
+    except ValueError as exc:
+        # Adapter/orchestrator validation errors (missing --replay-dir,
+        # unsupported target, empty replay directory, race filter dropped
+        # all replays, ...) should exit cleanly with the message rather
+        # than dump a traceback at the user.
+        raise SystemExit(str(exc)) from exc
     logger.info(
         "BC complete — run 'python main.py %s --game %s' to fine-tune from pre-trained weights.",
         args.experiment,

--- a/main.py
+++ b/main.py
@@ -88,8 +88,8 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         ),
     )
 
-    sc2_mode = parser.add_mutually_exclusive_group()
-    sc2_mode.add_argument(
+    mode_group = parser.add_mutually_exclusive_group()
+    mode_group.add_argument(
         "--play",
         action="store_true",
         help=(
@@ -99,7 +99,7 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "the trained agent.  No weight updates occur."
         ),
     )
-    sc2_mode.add_argument(
+    mode_group.add_argument(
         "--eval",
         action="store_true",
         help=(
@@ -110,16 +110,16 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "No weight updates occur."
         ),
     )
-    sc2_mode.add_argument(
+    mode_group.add_argument(
         "--bc",
         action="store_true",
         help=(
-            "Behaviour-cloning pre-training mode (SC2 only).  "
-            "Reads .SC2Replay files from --replay-dir, fits a policy to the "
-            "demonstration data, and writes policy_weights.yaml into the "
-            "experiment directory.  Run without --bc afterwards to fine-tune "
-            "from the pre-trained weights.  Defaults: --bc-player winner, "
-            "--bc-race any, --bc-target sc2_reinforce."
+            "Behaviour-cloning pre-training mode.  Available for any game whose "
+            "adapter exposes a BCAdapter (currently SC2; TMNF lands in #395).  "
+            "Reads replay files from --replay-dir (or from a per-game live "
+            "demonstration source when None), fits a policy to the data, and "
+            "writes policy_weights.yaml into the experiment directory.  Run "
+            "without --bc afterwards to fine-tune from the pre-trained weights."
         ),
     )
 
@@ -128,37 +128,32 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         default=None,
         metavar="DIR",
         help=(
-            "Directory containing .SC2Replay files for --bc mode.  "
-            "May also be set via bc_replay_dir in training_params.yaml."
+            "Directory of replay files for --bc mode (e.g. .SC2Replay for SC2).  "
+            "May also be set via bc_replay_dir in training_params.yaml.  Some "
+            "games (e.g. TMNF live-demo source) accept no replay-dir."
         ),
     )
     parser.add_argument(
         "--bc-player",
         default=None,
         choices=["winner", "1", "2"],
-        help="Which player to clone: 'winner' (default), '1', or '2'.  Overrides bc_player_id in config.",
+        help=("Which player to clone (SC2 only): 'winner' (default), '1', or '2'.  Overrides bc_player_id in config."),
     )
     parser.add_argument(
         "--bc-race",
         default=None,
         choices=["terran", "protoss", "zerg", "any"],
-        help="Race filter for --bc mode (default: any).  Overrides bc_race in config.",
+        help=("Race filter for --bc mode (SC2 only, default: any).  Overrides bc_race in config."),
     )
     parser.add_argument(
         "--bc-target",
         default=None,
-        choices=[
-            "sc2_reinforce",
-            "sc2_genetic",
-            "sc2_cmaes",
-            "sc2_neural_net",
-            "sc2_neural_dqn",
-            "sc2_lstm",
-            "sc2_cnn",
-            "epsilon_greedy",
-            "ucb_q",
-        ],
-        help="Policy type to pre-train (default: sc2_reinforce).  Overrides bc_target in config.",
+        metavar="POLICY_TYPE",
+        help=(
+            "Policy type to pre-train.  Overrides bc_target in config.  "
+            "Validated against the active game's BCAdapter.supported_targets "
+            "at runtime."
+        ),
     )
 
     def _positive_int(name: str):
@@ -254,9 +249,6 @@ def main() -> None:
     if args.eval and args.game != "sc2":
         raise SystemExit("--eval is only supported with --game sc2")
 
-    if args.bc and args.game != "sc2":
-        raise SystemExit("--bc is only supported with --game sc2")
-
     if args.play:
         _run_play_sc2(args)
         return
@@ -265,11 +257,12 @@ def main() -> None:
         _run_eval_sc2(args)
         return
 
+    adapter = GAME_ADAPTERS[args.game]()
+
     if args.bc:
-        _run_bc_sc2(args)
+        _run_bc(adapter, args)
         return
 
-    adapter = GAME_ADAPTERS[args.game]()
     _run_one(adapter, args)
 
 
@@ -380,16 +373,22 @@ def _run_play_sc2(args: argparse.Namespace) -> None:
 # ======================================================================
 
 
-def _run_bc_sc2(args: argparse.Namespace) -> None:
-    try:
-        from games.sc2.adapter import SC2Adapter
-        from games.sc2.replay_bc import run as bc_run
-    except ImportError as exc:
-        raise SystemExit(
-            f"Cannot import SC2 BC dependencies: {exc}\nInstall pysc2 with:  poetry install --with sc2"
-        ) from exc
+def _run_bc(adapter, args: argparse.Namespace) -> None:
+    """Game-agnostic behaviour-cloning entry point.
 
-    adapter = SC2Adapter()
+    Drives the framework BC orchestrator (:func:`framework.bc.run`) via the
+    game's :class:`framework.bc.BCAdapter`.  Games without a BC adapter wired
+    on their :class:`GameAdapter` raise a clean error here.
+    """
+    bc_adapter = getattr(adapter, "bc", None)
+    if bc_adapter is None:
+        raise SystemExit(
+            f"--bc is not supported for --game {args.game}: no BCAdapter wired on "
+            f"the game adapter.  See framework/bc.py for the integration contract."
+        )
+
+    from framework.bc import run as bc_run
+
     master_cfg = os.path.join(adapter.config_dir, "training_params.yaml")
     with open(master_cfg) as f:
         master_p = yaml.safe_load(f)
@@ -405,45 +404,52 @@ def _run_bc_sc2(args: argparse.Namespace) -> None:
     with open(training_params_file) as f:
         p = yaml.safe_load(f)
 
-    # Resolve obs_spec from training params
-    from games.sc2.adapter import _get_obs_spec  # noqa: PLC0415
+    obs_spec = _build_bc_obs_spec(args.game, p)
 
-    map_name = p.get("map_name", "MoveToBeacon")
-    obs_spec_preset = p.get("obs_spec_preset")
-    enable_belief = p.get("enable_belief", False)
-    obs_spec = _get_obs_spec(map_name, obs_spec_preset, enable_belief)
-
-    # CLI flags override config; config overrides hard-wired defaults.
+    # CLI flags override config; config overrides BCAdapter default.
     replay_dir = getattr(args, "replay_dir", None) or p.get("bc_replay_dir")
-    if not replay_dir:
-        raise SystemExit("--replay-dir must be specified for --bc mode (or set bc_replay_dir in training_params.yaml)")
-
-    player_id: str | int = getattr(args, "bc_player", None) or p.get("bc_player_id", "winner")
-    # Coerce "1"/"2" string choices to int so _resolve_player_id works
-    if player_id in ("1", "2"):
-        player_id = int(player_id)
-
     race = getattr(args, "bc_race", None) or p.get("bc_race", "any")
-    target = getattr(args, "bc_target", None) or p.get("bc_target", "sc2_reinforce")
+    target = getattr(args, "bc_target", None) or p.get("bc_target", bc_adapter.default_target)
 
-    bc_opts: dict = dict(
+    # SC2-specific: --bc-player overrides bc_player_id in the training params
+    # the BCAdapter will read.  Other games can ignore the key.
+    if getattr(args, "bc_player", None):
+        p = dict(p, bc_player_id=args.bc_player)
+
+    bc_run(
+        bc_adapter,
+        replay_dir,
+        experiment_dir,
+        obs_spec=obs_spec,
         target=target,
-        player_id=player_id,
+        training_params=p,
         race=race,
         max_replays=p.get("bc_max_replays"),
-        step_mul=p.get("bc_step_mul", p.get("step_mul", 1)),
-        screen_size=p.get("screen_size", 64),
-        minimap_size=p.get("minimap_size", 64),
-        bc_epochs=p.get("bc_epochs", 10),
-        bc_learning_rate=p.get("bc_learning_rate", 1e-3),
-        bc_batch_size=p.get("bc_batch_size", 256),
-        bc_ignore_noop=p.get("bc_ignore_noop", True),
+    )
+    logger.info(
+        "BC complete — run 'python main.py %s --game %s' to fine-tune from pre-trained weights.",
+        args.experiment,
+        args.game,
     )
 
-    bc_run(replay_dir, experiment_dir, obs_spec, **bc_opts)
-    logger.info(
-        "BC complete — run 'python main.py %s --game sc2' to fine-tune from pre-trained weights.",
-        args.experiment,
+
+def _build_bc_obs_spec(game: str, training_params: dict):
+    """Build the active observation spec for a BC run.
+
+    Each game decides its own obs_spec wiring.  The CLI doesn't try to be
+    clever — it asks the game module directly.  When phase 3 (#395) lands,
+    TMNF and other games will plug into this same dispatch.
+    """
+    if game == "sc2":
+        from games.sc2.adapter import _get_obs_spec
+
+        map_name = training_params.get("map_name", "MoveToBeacon")
+        preset = training_params.get("obs_spec_preset")
+        enable_belief = training_params.get("enable_belief", False)
+        return _get_obs_spec(map_name, preset, enable_belief)
+
+    raise SystemExit(
+        f"BC obs_spec for --game {game} is not wired into main.py yet.  See _build_bc_obs_spec in main.py."
     )
 
 

--- a/tests/test_framework_bc.py
+++ b/tests/test_framework_bc.py
@@ -1,0 +1,321 @@
+"""Tests for the game-agnostic BC framework (issue #393).
+
+Phase 1 of the BC refactor introduces `framework/bc.py` and
+`framework/bc_io.py`.  This suite covers:
+
+- `framework.bc_io.load_dataset` flat-vs-episode round-trip, and the
+  NPZ schema staying byte-compatible with SC2's existing format.
+- `framework.bc_io.save_summary` JSON shape.
+- `framework.bc.BCAdapter` Protocol conformance with a fake adapter.
+- `framework.bc.run` end-to-end against a fake adapter — exercises the
+  validate → build → fit → save flow without any game-specific code.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+
+import numpy as np
+import pytest
+import yaml
+
+from framework.bc import run
+from framework.bc_io import load_dataset, save_summary
+from framework.obs_spec import ObsDim, ObsSpec
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_demo_npz(
+    path: pathlib.Path, n_episodes: int = 2, ep_len: int = 4, obs_dim: int = 3, act_dim: int = 2
+) -> dict:
+    """Write a demos.npz at *path* with deterministic contents.  Returns its meta dict."""
+    n = n_episodes * ep_len
+    obs = np.arange(n * obs_dim, dtype=np.float32).reshape(n, obs_dim)
+    actions = np.arange(n * act_dim, dtype=np.float32).reshape(n, act_dim)
+    episode_starts = np.arange(0, n, ep_len, dtype=np.int64)
+    episode_lengths = np.full(n_episodes, ep_len, dtype=np.int64)
+    episode_id = np.repeat(np.arange(n_episodes, dtype=np.int64), ep_len)
+    meta = {"n_episodes": n_episodes, "n_steps": n}
+    np.savez(
+        path,
+        obs=obs,
+        actions=actions,
+        episode_starts=episode_starts,
+        episode_lengths=episode_lengths,
+        episode_id=episode_id,
+        meta=json.dumps(meta),
+    )
+    return meta
+
+
+class _FakePolicy:
+    """Minimal stand-in for a BC-trained policy.  Has `save()` only."""
+
+    def __init__(self) -> None:
+        self.weights = {"w": [1.0, 2.0, 3.0]}
+        self.saved_to: str | None = None
+
+    def save(self, path: str) -> None:
+        self.saved_to = path
+        with open(path, "w") as f:
+            yaml.dump(self.weights, f)
+
+
+class _FakeBCAdapter:
+    """Fake game-side BC adapter used by the framework orchestrator tests."""
+
+    name = "fake"
+    supported_targets: tuple[str, ...] = ("dummy",)
+    default_target = "dummy"
+
+    def __init__(self) -> None:
+        self.validate_calls: list[tuple] = []
+        self.build_calls: list[tuple] = []
+        self.fit_calls: list[tuple] = []
+        self.last_policy: _FakePolicy | None = None
+
+    def validate_replay_dir(self, replay_dir, *, race=None):
+        self.validate_calls.append((replay_dir, race))
+        return [pathlib.Path("fake/replay")]
+
+    def build_dataset(
+        self,
+        replay_dir,
+        save_path,
+        *,
+        obs_spec,
+        training_params,
+        race=None,
+        max_replays=None,
+    ):
+        self.build_calls.append((replay_dir, save_path, race, max_replays))
+        meta = _write_demo_npz(pathlib.Path(save_path))
+        meta["summary_extras"] = {"fake_stat": 42}
+        return meta
+
+    def fit_bc(self, dataset, obs_spec, *, target, training_params):
+        self.fit_calls.append((target, dict(training_params)))
+        self.last_policy = _FakePolicy()
+        return self.last_policy, 0.123
+
+
+# ---------------------------------------------------------------------------
+# bc_io.load_dataset
+# ---------------------------------------------------------------------------
+
+
+def test_load_dataset_flat_round_trip(tmp_path):
+    path = tmp_path / "demos.npz"
+    _write_demo_npz(path, n_episodes=3, ep_len=5, obs_dim=4, act_dim=2)
+
+    data = load_dataset(path)
+
+    assert set(data.keys()) == {"obs", "actions", "episode_starts", "episode_lengths", "episode_id", "meta"}
+    assert data["obs"].shape == (15, 4)
+    assert data["actions"].shape == (15, 2)
+    assert data["episode_starts"].tolist() == [0, 5, 10]
+    assert data["episode_lengths"].tolist() == [5, 5, 5]
+    assert data["episode_id"].tolist() == [0] * 5 + [1] * 5 + [2] * 5
+    assert data["meta"] == {"n_episodes": 3, "n_steps": 15}
+
+
+def test_load_dataset_as_episodes_preserves_order(tmp_path):
+    path = tmp_path / "demos.npz"
+    _write_demo_npz(path, n_episodes=2, ep_len=3, obs_dim=2, act_dim=1)
+
+    episodes = load_dataset(path, as_episodes=True)
+
+    assert len(episodes) == 2
+    ep0_obs, ep0_act = episodes[0]
+    ep1_obs, ep1_act = episodes[1]
+    assert ep0_obs.shape == (3, 2)
+    assert ep1_obs.shape == (3, 2)
+    # Episode 1 starts where episode 0 ended (concatenated obs).
+    assert ep1_obs[0, 0] == ep0_obs[-1, 0] + 2  # next row, 2 obs dims
+
+
+def test_load_dataset_rejects_missing_keys(tmp_path):
+    path = tmp_path / "broken.npz"
+    np.savez(path, obs=np.zeros((3, 2), dtype=np.float32))
+    with pytest.raises(KeyError):
+        load_dataset(path)
+
+
+# ---------------------------------------------------------------------------
+# bc_io.save_summary
+# ---------------------------------------------------------------------------
+
+
+def test_save_summary_writes_indented_json(tmp_path):
+    summary = {"game": "fake", "bc_target": "dummy", "extras": {"x": 1}}
+    out = save_summary(tmp_path, summary)
+
+    assert out == tmp_path / "bc_summary.json"
+    text = out.read_text()
+    # Indented (multi-line) output.
+    assert "\n" in text
+    assert json.loads(text) == summary
+
+
+def test_save_summary_creates_missing_experiment_dir(tmp_path):
+    nested = tmp_path / "does" / "not" / "exist"
+    save_summary(nested, {"game": "fake"})
+    assert (nested / "bc_summary.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# bc.run orchestrator
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def obs_spec() -> ObsSpec:
+    return ObsSpec([ObsDim("a", 1.0, "a"), ObsDim("b", 2.0, "b"), ObsDim("c", 1.0, "c")])
+
+
+def test_run_drives_adapter_in_order(tmp_path, obs_spec):
+    adapter = _FakeBCAdapter()
+    training_params = {"foo": "bar"}
+
+    summary = run(
+        adapter,
+        replay_dir="some/dir",
+        experiment_dir=tmp_path,
+        obs_spec=obs_spec,
+        target="dummy",
+        training_params=training_params,
+        race="any",
+        max_replays=None,
+    )
+
+    assert len(adapter.validate_calls) == 1
+    assert len(adapter.build_calls) == 1
+    assert len(adapter.fit_calls) == 1
+    # validate runs before build runs before fit
+    # (call list ordering already implies this via the single-counter increments,
+    # but assert the fit was passed the requested target)
+    assert adapter.fit_calls[0][0] == "dummy"
+    assert adapter.fit_calls[0][1] == training_params
+
+    # Summary on disk matches return value.
+    summary_on_disk = json.loads((tmp_path / "bc_summary.json").read_text())
+    assert summary_on_disk == summary
+    assert summary["game"] == "fake"
+    assert summary["bc_target"] == "dummy"
+    assert summary["n_episodes"] == 2
+    assert summary["n_pairs"] == 8  # 2 episodes × 4 steps from _write_demo_npz default
+    assert summary["bc_race"] == "any"
+    assert summary["final_bc_loss"] == pytest.approx(0.123)
+    assert summary["extras"] == {"fake_stat": 42}
+
+
+def test_run_saves_policy_weights(tmp_path, obs_spec):
+    adapter = _FakeBCAdapter()
+    run(
+        adapter,
+        replay_dir=None,
+        experiment_dir=tmp_path,
+        obs_spec=obs_spec,
+        target="dummy",
+        training_params={},
+    )
+    weights = tmp_path / "policy_weights.yaml"
+    assert weights.exists()
+    loaded = yaml.safe_load(weights.read_text())
+    assert loaded == {"w": [1.0, 2.0, 3.0]}
+    assert adapter.last_policy is not None
+    assert adapter.last_policy.saved_to == str(weights)
+
+
+def test_run_normalises_race_any_to_none(tmp_path, obs_spec):
+    adapter = _FakeBCAdapter()
+    run(
+        adapter,
+        replay_dir=None,
+        experiment_dir=tmp_path,
+        obs_spec=obs_spec,
+        target="dummy",
+        training_params={},
+        race="ANY",
+    )
+    # build_dataset was called with race=None (the orchestrator normalised it).
+    assert adapter.build_calls[0][2] is None
+    # The validate call was also passed the normalised value.
+    assert adapter.validate_calls[0][1] is None
+
+
+def test_run_passes_through_real_race_filter(tmp_path, obs_spec):
+    adapter = _FakeBCAdapter()
+    run(
+        adapter,
+        replay_dir=None,
+        experiment_dir=tmp_path,
+        obs_spec=obs_spec,
+        target="dummy",
+        training_params={},
+        race="Terran",
+    )
+    assert adapter.build_calls[0][2] == "terran"  # lower-cased
+
+
+def test_run_rejects_unsupported_target(tmp_path, obs_spec):
+    adapter = _FakeBCAdapter()
+    with pytest.raises(ValueError, match="not supported"):
+        run(
+            adapter,
+            replay_dir=None,
+            experiment_dir=tmp_path,
+            obs_spec=obs_spec,
+            target="not_a_real_target",
+            training_params={},
+        )
+    # Nothing was attempted because the target check is the first guard.
+    assert adapter.validate_calls == []
+
+
+def test_run_creates_experiment_dir(tmp_path, obs_spec):
+    adapter = _FakeBCAdapter()
+    target_dir = tmp_path / "fresh" / "experiment"
+    run(
+        adapter,
+        replay_dir=None,
+        experiment_dir=target_dir,
+        obs_spec=obs_spec,
+        target="dummy",
+        training_params={},
+    )
+    assert (target_dir / "policy_weights.yaml").exists()
+    assert (target_dir / "bc_summary.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# BCAdapter protocol conformance
+# ---------------------------------------------------------------------------
+
+
+def test_fake_adapter_satisfies_protocol():
+    """_FakeBCAdapter is structurally a BCAdapter — assignment to a
+    typed slot would type-check at runtime via isinstance with @runtime_checkable.
+    We don't decorate BCAdapter with @runtime_checkable (Protocols are
+    structural; isinstance support is optional), so this test asserts the
+    attribute surface area instead."""
+    a = _FakeBCAdapter()
+    assert isinstance(a.name, str)
+    assert isinstance(a.supported_targets, tuple)
+    assert a.default_target in a.supported_targets
+    for attr in ("validate_replay_dir", "build_dataset", "fit_bc"):
+        assert callable(getattr(a, attr))
+
+
+def test_game_adapter_protocol_documents_bc_attribute():
+    """The GameAdapter Protocol declares a ``bc`` attribute for the BC seam.
+
+    Concrete adapters use structural typing rather than inheritance, so we
+    verify the declaration is present on the Protocol class itself."""
+    from framework.game_adapter import GameAdapter
+
+    assert "bc" in GameAdapter.__annotations__

--- a/tests/test_sc2_bc_adapter.py
+++ b/tests/test_sc2_bc_adapter.py
@@ -1,0 +1,187 @@
+"""Tests for the SC2 ↔ framework BC seam introduced in phase 2 (#394).
+
+Covers the integration shape — that ``SC2BCAdapter`` plugs into
+``framework.bc.run`` end-to-end and produces the canonical framework
+summary shape (with SC2 stats under ``extras``).  The detailed SC2 BC
+test suite lives in ``tests/test_sc2_replay_bc.py`` and exercises the
+backward-compat shim plus the per-target fitters; it remains the
+behavioural baseline.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+# Inject minimal fake PySC2 + s2protocol modules so games.sc2.replay_bc imports
+# cleanly without the real SC2 binary.  Mirrors the setup in
+# tests/test_sc2_replay_bc.py — kept private here to keep this test file
+# standalone.
+
+
+def _inject_pysc2_stubs() -> None:
+    if "pysc2" in sys.modules:
+        return
+    pysc2 = types.ModuleType("pysc2")
+    run_configs = types.ModuleType("pysc2.run_configs")
+    run_configs.get = lambda *a, **kw: types.SimpleNamespace()
+    pysc2.run_configs = run_configs
+    features = types.ModuleType("pysc2.lib.features")
+    features.AgentInterfaceFormat = object
+    features.Dimensions = object
+    features.features_from_game_info = lambda *a, **kw: None
+    pysc2.lib = types.ModuleType("pysc2.lib")
+    pysc2.lib.features = features
+    sys.modules["pysc2"] = pysc2
+    sys.modules["pysc2.run_configs"] = run_configs
+    sys.modules["pysc2.lib"] = pysc2.lib
+    sys.modules["pysc2.lib.features"] = features
+
+    s2 = types.ModuleType("s2protocol")
+    versions = types.ModuleType("s2protocol.versions")
+
+    def _build_decoders(_ver):
+        return None
+
+    versions.build = _build_decoders
+    s2.versions = versions
+    sys.modules["s2protocol"] = s2
+    sys.modules["s2protocol.versions"] = versions
+
+
+_inject_pysc2_stubs()
+
+from framework.bc import run as fw_run  # noqa: E402
+from games.sc2.bc_adapter import SC2BCAdapter  # noqa: E402
+from games.sc2.obs_spec import SC2_MINIGAME_OBS_SPEC  # noqa: E402
+
+_OBS_DIM = len(SC2_MINIGAME_OBS_SPEC.names)
+
+
+def _synthetic_dataset(n: int = 30) -> dict:
+    actions = np.column_stack(
+        [
+            np.full(n, 2, np.float32),
+            np.full(n, 0.5, np.float32),
+            np.full(n, 0.5, np.float32),
+            np.zeros(n, np.float32),
+        ]
+    )
+    return {
+        "obs": np.zeros((n, _OBS_DIM), dtype=np.float32),
+        "actions": actions,
+        "episode_starts": np.array([0], dtype=np.int64),
+        "episode_lengths": np.array([n], dtype=np.int64),
+        "episode_id": np.zeros(n, dtype=np.int64),
+        "meta": {"n_episodes": 1, "n_steps": n},
+    }
+
+
+def _patch_sc2_pipeline(dataset: dict):
+    """Context manager patching the parts of games.sc2.replay_bc that touch
+    real replays / PySC2.  Lets the orchestrator drive SC2BCAdapter end to
+    end without an SC2 binary."""
+    meta = {
+        "n_episodes": 1,
+        "n_steps": int(dataset["obs"].shape[0]),
+        "obs_dim": _OBS_DIM,
+        "n_replays_skipped_race": 0,
+        "player_id": "winner",
+        "race_filter": None,
+    }
+    return patch.multiple(
+        "games.sc2.replay_bc",
+        validate_replay_dir=lambda d, race=None, version=None: [Path(d) / "fake.SC2Replay"],
+        build_dataset=lambda *a, **kw: meta,
+    ), meta
+
+
+def test_sc2_adapter_satisfies_framework_protocol_surface():
+    a = SC2BCAdapter()
+    assert a.name == "sc2"
+    assert "sc2_reinforce" in a.supported_targets
+    assert a.default_target == "sc2_reinforce"
+    for method in ("validate_replay_dir", "build_dataset", "fit_bc", "summary_extras"):
+        assert callable(getattr(a, method))
+
+
+def test_run_through_framework_writes_canonical_summary(tmp_path):
+    dataset = _synthetic_dataset(n=20)
+    patch_ctx, _meta = _patch_sc2_pipeline(dataset)
+
+    # Patch framework.bc_io.load_dataset too — the framework orchestrator
+    # imports it directly, so the SC2 module's patch doesn't bite.
+    with patch_ctx, patch("framework.bc.load_dataset", lambda p: dataset):
+        replay_dir = tmp_path / "replays"
+        replay_dir.mkdir()
+        (replay_dir / "g.SC2Replay").touch()
+        experiment_dir = tmp_path / "exp"
+
+        summary = fw_run(
+            SC2BCAdapter(),
+            replay_dir,
+            experiment_dir,
+            obs_spec=SC2_MINIGAME_OBS_SPEC,
+            target="sc2_reinforce",
+            training_params={
+                "bc_player_id": "winner",
+                "bc_epochs": 1,
+                "bc_batch_size": 5,
+                "bc_ignore_noop": False,
+                "seed": 0,
+            },
+            race="any",
+        )
+
+    # Canonical framework summary shape: SC2-specific stats nested under "extras".
+    assert summary["game"] == "sc2"
+    assert summary["bc_target"] == "sc2_reinforce"
+    assert summary["n_pairs"] == 20
+    assert summary["bc_race"] == "any"
+    assert "extras" in summary
+    extras = summary["extras"]
+    assert "fn_idx_histogram" in extras
+    assert extras["fn_idx_histogram"] == {2: 20}
+    assert extras["bc_player_id"] == "winner"
+
+    # bc_summary.json matches the returned dict (modulo JSON key-stringification
+    # of the int-keyed fn_idx_histogram).
+    on_disk = json.loads((experiment_dir / "bc_summary.json").read_text())
+    assert on_disk["extras"]["fn_idx_histogram"] == {"2": 20}
+    on_disk_extras = dict(on_disk["extras"])
+    on_disk_extras["fn_idx_histogram"] = {int(k): v for k, v in on_disk_extras["fn_idx_histogram"].items()}
+    assert {**on_disk, "extras": on_disk_extras} == summary
+
+    # policy_weights.yaml exists.
+    assert (experiment_dir / "policy_weights.yaml").exists()
+
+
+def test_validate_replay_dir_rejects_none():
+    a = SC2BCAdapter()
+    with pytest.raises(ValueError, match="non-None|--replay-dir|bc_replay_dir"):
+        a.validate_replay_dir(None)
+
+
+def test_supported_targets_covers_all_per_target_fitters():
+    """If a per-target fitter is added in games.sc2.replay_bc.fit_bc but not
+    declared in SC2BCAdapter.supported_targets, the framework orchestrator
+    will refuse to dispatch to it.  Sanity check the union stays in sync."""
+    a = SC2BCAdapter()
+    expected = {
+        "sc2_reinforce",
+        "sc2_genetic",
+        "sc2_cmaes",
+        "sc2_neural_net",
+        "sc2_neural_dqn",
+        "sc2_lstm",
+        "sc2_cnn",
+        "epsilon_greedy",
+        "ucb_q",
+    }
+    assert set(a.supported_targets) == expected


### PR DESCRIPTION
Closes #393
Closes #394

## Summary

- Introduces `framework/bc.py` with `BCAdapter` Protocol and `run()` orchestrator to lift the game-agnostic parts of the SC2 BC pipeline into the framework
- Adds `framework/bc_io.py` with `load_dataset()` and `save_summary()` helpers; NPZ schema is byte-compatible with existing SC2 datasets
- Implements `games/sc2/bc_adapter.py` wrapping `games/sc2/replay_bc.py` to plug SC2 into the framework seam
- Updates `main.py` to drive BC via the game adapter's `bc` attribute, making `--bc` game-agnostic (currently SC2 only; TMNF lands in #395)
- Moves `load_dataset()` from `games/sc2/replay_bc.py` to `framework/bc_io.py` with backward-compat re-export

## Related issues

Refs #392 (parent — refactor SC2 BC into framework). This PR bundles phase 1 (#393) and phase 2 (#394) since the phase-2 branch was built on top of phase 1's branch and PR #398 (phase 1 alone) was closed in favour of merging both together. Phase 3 lands in #395.

This PR **targets `feature/bc-refactor-392`**, not `main` — the BC refactor merges to its feature branch first; the feature branch will merge to `main` once phase 3 / 3b / 4 (#395, #396, #397) also land on it.

## Validation

```bash
PYTHONPATH=. poetry run python -m pytest tests/test_framework_bc.py tests/test_sc2_bc_adapter.py tests/test_sc2_replay_bc.py -v
PYTHONPATH=. poetry run python -m pytest tests/ \
    --ignore=tests/test_env_termination.py \
    --ignore=tests/test_grid_search.py \
    --ignore=tests/integration/
```

145 BC tests green (13 framework + 4 sc2_bc_adapter + 128 sc2_replay_bc). Pre-existing `tests/test_sc2_analytics.py` failures (matplotlib stub mismatch) are unrelated to this PR and reproduce on `main`.

## Feature details

- **User problem:** BC pipeline was SC2-specific; other games cannot pre-train policies from demonstrations without duplicating the orchestration logic.
- **Proposed solution:** Extract the workflow shape (validate → build → fit → save) and I/O schema into the framework as a Protocol-based extension point. Games implement `BCAdapter` (one per game, e.g. `games/sc2/bc_adapter.py`) and expose it via `GameAdapter.bc`. The framework `run()` orchestrator drives the flow without game-specific knowledge.
- **Trade-offs / follow-ups:**
  - Phase 1 introduces the seam; phase 2 ports SC2 onto it (backward-compat shim preserves the old `games/sc2/replay_bc.run()` signature so the existing 128-test SC2 BC suite is unchanged).
  - Phase 3 (#395) adds TMNF.
  - The `BCAdapter.summary_extras()` hook is optional (default no-op) so adapters can inject game-specific stats into `bc_summary.json` (e.g. SC2's `fn_idx_histogram`) without polluting the generic shape.

## Refactor / docs / chore details

- **What changed:**
  - New modules: `framework/bc.py` (Protocol + orchestrator), `framework/bc_io.py` (I/O helpers)
  - New module: `games/sc2/bc_adapter.py` (SC2 implementation of BCAdapter)
  - Moved `load_dataset()` from `games/sc2/replay_bc.py` → `framework/bc_io.py` (re-exported for backward-compat)
  - Updated `main.py`: `_run_bc_sc2()` → `_run_bc(adapter, args)` (game-agnostic); removed SC2-only check on `--bc`
  - Updated `framework/game_adapter.py`: added `bc: BCAdapter` attribute to Protocol (TYPE_CHECKING import)
  - Updated `games/sc2/adapter.py`: wired `SC2BCAdapter()` instance to `self.bc`
  - Updated `games/sc2/replay_bc.py`: converted `run()` to a self-contained backward-compat shim (keeps legacy flat-summary shape and the existing test patches); removed `load_dataset()` definition
  - Added comprehensive test suites: `tests/test_framework_bc.py` (framework seam + fake adapter), `tests/test_sc2_bc_adapter.py` (SC2 integration)
  - Updated `CHANGELOG.md` and `games/sc2/README.md` to reflect game-agnostic BC

- **Why this is safe:**
  - `load_dataset()` moved to framework but re-exported from `games/sc2/replay_bc.py` — existing imports and notebooks continue to work
  - `games/sc2/replay_bc.run()` kept as a shim with the legacy flat-summary shape; external scripts and the existing SC2 BC test suite are unchanged
  - `GameAdapter.bc` defaults to `None` for games that don't implement BC; CLI exits with a clear error rather than crashing

https://claude.ai/code/session_017YYNh7Zfp7RQSAhLKYu9Qx