### PR TITLE
BC refactor — Phase 4: docs, polish, and dead-code cleanup (issue #397)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,15 +43,33 @@ formatting, internal refactors with no behaviour change — can be skipped.
   --bc` is the supported way to reproduce the legacy `do_pretrain`
   warm-start.  `.Replay.Gbx` ingest is tracked separately in #396.
 
+### Added
+- BC refactor — Phase 4: docs, polish, and dead-code cleanup (issue #397,
+  parent #392).  New `docs/framework/bc_adapter.md` documents the
+  `BCAdapter` Protocol, `demos.npz` dataset schema, `bc_summary.json`
+  schema, and a worked example of adding BC to a new game.
+  `docs/framework/README.md` updated to list the new page.  `CLAUDE.md`
+  gains a game-agnostic `--bc` section under **Running** (alongside
+  `--play` / `--eval`); the SC2 `--bc` paragraph now cross-links to the
+  framework doc.  `games/tmnf/README.md` updated: `.Replay.Gbx` note
+  changed from "tracked in #396" to "not currently supported".
+  `games/sc2/README.md` BC intro cross-links framework doc.  Stale
+  `#396` / phase-3 references removed from `games/tmnf/bc_adapter.py`
+  and `main.py`.
+
 ### Breaking
-- The `do_pretrain: true` training-params key and its `rl/pretrain.py`
-  landing pad have been removed (issue #395, parent #392).  Replace any
-  remaining `do_pretrain: true` in your `training_params.yaml` with a
-  one-off `python main.py <experiment> --game tmnf --bc` step before
-  the regular training run; the BC output is byte-compatible with what
-  `do_pretrain` produced.  Stale `do_pretrain` keys are silently
-  ignored by `RunConfig.from_training_params`, so legacy configs
-  continue to load.
+- **Migration: `do_pretrain: true` → `--bc`.**  The `do_pretrain: true`
+  training-params key and its `rl/pretrain.py` landing pad were removed
+  in issue #395 (parent #392).  To reproduce the old warm-start
+  behaviour, run a one-off BC step before the regular training run:
+  ```bash
+  python main.py <experiment> --game tmnf --bc   # produces policy_weights.yaml
+  python main.py <experiment> --game tmnf        # fine-tunes from BC weights
+  ```
+  The BC output is byte-compatible with what `do_pretrain` produced.
+  Stale `do_pretrain: true` keys in existing `training_params.yaml`
+  files are silently ignored by `RunConfig.from_training_params`, so
+  legacy configs continue to load without error.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,8 +42,6 @@ formatting, internal refactors with no behaviour change — can be skipped.
   on `TMNFAdapter.bc`, so `python main.py <experiment> --game tmnf
   --bc` is the supported way to reproduce the legacy `do_pretrain`
   warm-start.  `.Replay.Gbx` ingest is tracked separately in #396.
-
-### Added
 - BC refactor — Phase 4: docs, polish, and dead-code cleanup (issue #397,
   parent #392).  New `docs/framework/bc_adapter.md` documents the
   `BCAdapter` Protocol, `demos.npz` dataset schema, `bc_summary.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,10 +27,10 @@ The framework-side protocols a contributor implements to ship a game or a
 policy are documented one file per protocol under
 [`docs/framework/`](docs/framework/README.md): `GameAdapter`, the
 `GameSpec` / `RunConfig` / `ProbeSpec` / `WarmupSpec` / `PolicyExtras`
-config bundles, `BaseGameEnv`, `RewardCalculatorBase`, `BasePolicy`, and
-`ObsSpec`. The sections below describe how these are configured and
-combined; the `docs/framework/` pages give the per-protocol method
-contracts and worked examples.
+config bundles, `BaseGameEnv`, `RewardCalculatorBase`, `BasePolicy`,
+`ObsSpec`, and `BCAdapter`. The sections below describe how these are
+configured and combined; the `docs/framework/` pages give the
+per-protocol method contracts and worked examples.
 
 ---
 
@@ -64,7 +64,7 @@ gamer-ai/
 │   ├── iracing/            # iRacing telemetry via pyirsdk (+ optional vJoy injection)
 │   └── atari/              # Atari 2600 via ale-py (RAM observation, Discrete actions)
 ├── clients/                # Backward-compat shim → games/tmnf/clients
-├── rl/                     # Backward-compat shim + pretrain (behaviour-cloning) experiments
+├── rl/                     # Backward-compat shim (legacy; BC now lives in framework/bc.py)
 ├── distributed/            # Coordinator, worker, protocol for distributed grid search
 ├── infrastructure/         # Terraform: auth, remote_state, environment (Azure VMs)
 ├── experiments/            # Per-experiment results (git-ignored)
@@ -108,6 +108,27 @@ Other useful flags: `--track <name>` overrides the config's track/map
 verbosity (`DEBUG` / `INFO` / `WARNING` / `ERROR`, default `INFO`).
 SC2-only modes `--play` and `--eval` are covered in the StarCraft 2
 section.
+
+**Behaviour cloning (`--bc`).** Any game whose `GameAdapter` exposes a
+`BCAdapter` can pre-train a policy from demonstration data before the RL
+loop:
+
+```bash
+# SC2 — clone from replay files, then fine-tune
+python main.py myrun --game sc2 --bc --replay-dir /path/to/replays --bc-race terran
+python main.py myrun --game sc2
+
+# TMNF — drive SimplePolicy live for 3 laps, then fine-tune
+python main.py myrun --game tmnf --bc
+python main.py myrun --game tmnf
+```
+
+`--bc` writes `policy_weights.yaml` (+ optional `trainer_state.npz`) and
+`bc_summary.json` into the experiment directory; the normal training run
+picks them up automatically.  Mutually exclusive with `--play` and `--eval`.
+See [`docs/framework/bc_adapter.md`](docs/framework/bc_adapter.md) for the
+per-game extension contract, and the per-game READMEs for game-specific
+workflow details.
 
 ---
 
@@ -1029,18 +1050,11 @@ The first run creates `experiments/sc2_<map>/<name>/` and copies both master con
 
 `--eval` (SC2 only) loads the champion and runs it against the AI bot for `--num-episodes` episodes, reporting aggregate statistics. `--bot-difficulty` overrides the opponent difficulty and `--eval-speed` overrides `step_mul` for the eval run.
 
-`--bc` runs offline behaviour cloning into the experiment directory.  It is
-game-agnostic: any game whose `GameAdapter` exposes a `BCAdapter` can use
-it.  SC2 reads `.SC2Replay` files (with `--replay-dir`, `--bc-race`,
-`--bc-player`); TMNF runs the in-game `SimplePolicy` for `bc_n_demo_laps`
-laps and least-squares-fits a `WeightedLinearPolicy` (no `--replay-dir`
-needed) — replacing the legacy `do_pretrain: true` knob.  `.Replay.Gbx`
-ingest for TMNF is tracked in #396.  The mode flag is mutually exclusive
-with `--play` and `--eval`.  Writes `policy_weights.yaml` (+ optional
-`trainer_state.npz`) and `bc_summary.json` into the experiment
-directory.  See `framework/bc.py` for the per-game extension contract,
-and the per-game READMEs (`games/sc2/README.md`, `games/tmnf/README.md`)
-for game-specific workflow details.
+`--bc` runs SC2 offline behaviour cloning into the experiment directory.
+SC2 reads `.SC2Replay` files (with `--replay-dir`, `--bc-race`,
+`--bc-player`).  The framework BC contract and TMNF details are in the
+game-agnostic `--bc` section under **Running** above and in
+[`docs/framework/bc_adapter.md`](docs/framework/bc_adapter.md).
 
 ### Config knobs
 

--- a/docs/framework/README.md
+++ b/docs/framework/README.md
@@ -20,6 +20,7 @@ SC2 action names), but correctness does not depend on them.
 | [`reward.md`](reward.md) | `RewardCalculatorBase` (+ `RewardConfig` convention) | `framework/base_reward.py` | `games/<name>/reward.py` |
 | [`policies.md`](policies.md) | `BasePolicy` | `framework/policies.py` | `framework/policies.py` or `games/<name>/` |
 | [`obs_spec.md`](obs_spec.md) | `ObsSpec`, `ObsDim` | `framework/obs_spec.py` | `games/<name>/obs_spec.py` |
+| [`bc_adapter.md`](bc_adapter.md) | `BCAdapter` | `framework/bc.py`, `framework/bc_io.py` | `games/<name>/bc_adapter.py` |
 
 ## How the pieces fit together
 

--- a/docs/framework/bc_adapter.md
+++ b/docs/framework/bc_adapter.md
@@ -28,7 +28,7 @@ below (duck typing) and be attached to the `GameAdapter.bc` attribute.
 def validate_replay_dir(replay_dir, *, race=None) -> Any
 def build_dataset(replay_dir, save_path, *, obs_spec, training_params,
                   race=None, max_replays=None) -> dict
-def fit_bc(dataset, obs_spec, *, target, training_params) -> (policy, float)
+def fit_bc(dataset, obs_spec, *, target, training_params) -> tuple[Any, float]
 def summary_extras(dataset, meta, *, target, training_params) -> dict   # optional
 ```
 

--- a/docs/framework/bc_adapter.md
+++ b/docs/framework/bc_adapter.md
@@ -1,0 +1,199 @@
+# `BCAdapter`
+
+**Source:** `framework/bc.py`, `framework/bc_io.py` · **You implement:**
+`games/<name>/bc_adapter.py` · **You wire up:** `GameAdapter.bc`
+
+Behaviour cloning (BC) pre-trains a policy from demonstration data before
+the live RL loop starts. The `BCAdapter` Protocol defines the per-game
+seam: your adapter owns the game's replay format, dataset assembly, and
+per-target fit logic. The framework `run()` orchestrator in
+`framework/bc.py` drives the full flow — validate, build, fit, save —
+without knowing anything game-specific.
+
+`BCAdapter` is a `typing.Protocol`: your adapter does **not** need to
+subclass anything. It just needs to expose the attributes and methods
+below (duck typing) and be attached to the `GameAdapter.bc` attribute.
+
+## Attributes
+
+| Attribute | Type | Meaning |
+|---|---|---|
+| `name` | `str` | Game identifier, matching `GameAdapter.name` for the same game (e.g. `"sc2"`, `"tmnf"`). |
+| `supported_targets` | `tuple[str, ...]` | `policy_type` strings this adapter knows how to pre-train. The orchestrator validates the requested target against this tuple before calling `fit_bc`. |
+| `default_target` | `str` | Target used when neither `--bc-target` nor `bc_target` in config is set. Must appear in `supported_targets`. |
+
+## Methods
+
+```python
+def validate_replay_dir(replay_dir, *, race=None) -> Any
+def build_dataset(replay_dir, save_path, *, obs_spec, training_params,
+                  race=None, max_replays=None) -> dict
+def fit_bc(dataset, obs_spec, *, target, training_params) -> (policy, float)
+def summary_extras(dataset, meta, *, target, training_params) -> dict   # optional
+```
+
+| Method | Returns | Notes |
+|---|---|---|
+| `validate_replay_dir` | anything | Fail fast if `replay_dir` cannot be used as a BC source. The return value is ignored by the orchestrator; raise on error. May accept `None` for sources that do not need a replay directory (e.g. TMNF's live-demo source). |
+| `build_dataset` | `dict` with `n_episodes`, `n_steps` | Parse `replay_dir` → `demos.npz` at `save_path`. Must write a file readable by `framework.bc_io.load_dataset`. Read all extra knobs (player id, step_mul, …) from `training_params`. |
+| `fit_bc` | `(policy, final_bc_loss)` | Pre-train `target` on `dataset`. `policy` must have a `save(path)` method; if it is a `BasePolicy`, `save_trainer_state` is also called by the orchestrator. |
+| `summary_extras` | `dict` | *Optional.* Called after `fit_bc` with the fully-loaded dataset in scope. Return game-specific stats to embed under `bc_summary.json["extras"]` (e.g. SC2's `fn_idx_histogram`). Default from the Protocol returns `{}`. |
+
+## `demos.npz` dataset schema
+
+A BC dataset NPZ file contains six required keys:
+
+| Key | dtype | Shape | Description |
+|---|---|---|---|
+| `obs` | `float32` | `[N, D]` | Concatenated observation vectors across all episodes |
+| `actions` | `float32` | `[N, A]` | Corresponding action vectors (game-specific `A`; e.g. SC2 uses `[fn_idx, x, y, queue]`, TMNF uses `[steer, accel, brake]`) |
+| `episode_starts` | `int64` | `[E]` | Start index of each episode in `obs` / `actions` |
+| `episode_lengths` | `int64` | `[E]` | Step count for each episode |
+| `episode_id` | `int64` | `[N]` | Per-sample episode index ∈ `[0, E)` |
+| `meta` | `0-d unicode str` | — | JSON-encoded metadata dict (at minimum `n_episodes` and `n_steps`) |
+
+Call `framework.bc_io.load_dataset(path)` to get a flat dict, or pass
+`as_episodes=True` to get a list of `(obs_seq, act_seq)` tuples in
+episode order (needed by recurrent targets like `sc2_lstm`).
+
+The schema is byte-compatible with the one SC2's `games/sc2/replay_bc.py`
+has written since issue #351, so existing `demos.npz` files load unchanged.
+
+## `bc_summary.json` schema
+
+`framework.bc.run` writes `bc_summary.json` into the experiment directory
+after each BC run:
+
+```json
+{
+  "game": "sc2",
+  "bc_target": "sc2_reinforce",
+  "n_episodes": 12,
+  "n_pairs": 8743,
+  "bc_race": "terran",
+  "final_bc_loss": 0.42,
+  "extras": { "fn_idx_histogram": { "0": 312, "2": 148 } }
+}
+```
+
+| Key | Type | Meaning |
+|---|---|---|
+| `game` | `str` | `BCAdapter.name` |
+| `bc_target` | `str` | Policy type that was pre-trained |
+| `n_episodes` | `int` | Number of episodes in the dataset |
+| `n_pairs` | `int` | Total `(obs, action)` pairs |
+| `bc_race` | `str` | Race filter applied (`"any"` if none) |
+| `final_bc_loss` | `float` | Final training loss (gradient methods) or residual metric (least-squares) |
+| `extras` | `dict` | Game-specific stats from `summary_extras()` |
+
+`grid_search.py` reads `bc_target` from `bc_summary.json` when validating
+warm-start compatibility — keep the key name stable.
+
+## Wiring the adapter
+
+Expose your adapter on the game's `GameAdapter` via the `bc` attribute:
+
+```python
+class MyGameAdapter:
+    name = "my_game"
+    ...
+    bc = MyGameBCAdapter()   # or a property if construction is deferred
+```
+
+Games that do not support BC simply omit the `bc` attribute (or set it to
+`None`). The `--bc` CLI flag checks for a wired adapter and exits with a
+clear error if none is present.
+
+## Worked example: adding BC to a new game
+
+Here is a minimal adapter skeleton for a hypothetical game `"mygame"` whose
+BC source is a directory of binary replay files and whose only supported
+target is `hill_climbing`:
+
+```python
+# games/mygame/bc_adapter.py
+from __future__ import annotations
+import pathlib
+import numpy as np
+from framework.obs_spec import ObsSpec
+from framework.bc_io import load_dataset
+
+class MyGameBCAdapter:
+    name = "mygame"
+    supported_targets = ("hill_climbing",)
+    default_target = "hill_climbing"
+
+    def validate_replay_dir(self, replay_dir, *, race=None):
+        path = pathlib.Path(replay_dir or "")
+        replays = sorted(path.glob("*.myreplay"))
+        if not replays:
+            raise ValueError(f"No .myreplay files found in {replay_dir!r}")
+        return replays
+
+    def build_dataset(self, replay_dir, save_path, *,
+                      obs_spec, training_params, race=None, max_replays=None):
+        import json
+        replays = sorted(pathlib.Path(replay_dir).glob("*.myreplay"))
+        if max_replays:
+            replays = replays[:max_replays]
+
+        obs_list, act_list, episode_lengths = [], [], []
+        for rpath in replays:
+            obs_ep, act_ep = _parse_replay(rpath, obs_spec)
+            obs_list.append(obs_ep)
+            act_list.append(act_ep)
+            episode_lengths.append(len(obs_ep))
+
+        obs = np.concatenate(obs_list).astype(np.float32)
+        actions = np.concatenate(act_list).astype(np.float32)
+        ep_lengths = np.array(episode_lengths, dtype=np.int64)
+        ep_starts = np.concatenate(([0], np.cumsum(ep_lengths[:-1]))).astype(np.int64)
+        ep_id = np.repeat(np.arange(len(ep_lengths), dtype=np.int64), ep_lengths)
+        meta = {"n_episodes": len(replays), "n_steps": int(obs.shape[0])}
+        np.savez_compressed(str(save_path),
+                            obs=obs, actions=actions,
+                            episode_starts=ep_starts, episode_lengths=ep_lengths,
+                            episode_id=ep_id, meta=np.array(json.dumps(meta)))
+        return meta
+
+    def fit_bc(self, dataset, obs_spec, *, target, training_params):
+        from games.mygame.policies import WeightedLinearPolicy
+        obs = dataset["obs"]
+        actions = dataset["actions"]
+        # Simple least-squares fit
+        scales = obs_spec.scales.astype(float)
+        norm_obs = obs / scales[np.newaxis, :]
+        w, *_ = np.linalg.lstsq(norm_obs, actions[:, 0], rcond=None)
+        policy = WeightedLinearPolicy(w)
+        loss = float(np.mean((norm_obs @ w - actions[:, 0]) ** 2))
+        return policy, loss
+
+
+def make_bc_adapter() -> MyGameBCAdapter:
+    return MyGameBCAdapter()
+```
+
+Then wire it up in `games/mygame/adapter.py`:
+
+```python
+class MyGameAdapter:
+    name = "mygame"
+    config_dir = "games/mygame/config"
+    bc = MyGameBCAdapter()
+    ...
+```
+
+That is the entire contract. The framework `run()` orchestrator handles the
+rest: it calls `validate_replay_dir`, `build_dataset`, `fit_bc`, saves
+`policy_weights.yaml` and `bc_summary.json`, and returns the summary dict
+to the caller.
+
+## Existing implementations
+
+| Game | Module | Sources | Targets |
+|---|---|---|---|
+| SC2 | `games/sc2/bc_adapter.py` | `.SC2Replay` files (requires `--replay-dir`) | `sc2_reinforce`, `sc2_genetic`, `sc2_cmaes`, `sc2_neural_net`, `sc2_neural_dqn`, `sc2_lstm`, `sc2_cnn`, `epsilon_greedy`, `ucb_q` |
+| TMNF | `games/tmnf/bc_adapter.py` | In-game `SimplePolicy` live demos (no `--replay-dir` needed) | `hill_climbing` |
+
+See the per-game READMEs (`games/sc2/README.md`, `games/tmnf/README.md`)
+for game-specific workflow details and CLI examples.

--- a/games/sc2/README.md
+++ b/games/sc2/README.md
@@ -672,16 +672,17 @@ python main.py myrun --game sc2 --bc --replay-dir /path/to/replays --bc-race ter
 python main.py myrun --game sc2
 ```
 
-`--bc` is now game-agnostic — any game whose `GameAdapter` exposes a
-`BCAdapter` can use it (currently SC2; TMNF lands in issue #395).  The
-mode flag is still mutually exclusive with `--play` / `--eval`.  The
-resulting `policy_weights.yaml` (and optional `trainer_state.npz`) are
-written to the standard experiment directory; the normal SC2 training
-loop auto-loads them on the next run, so step 2 is just a regular
-training run.  The orchestration lives in `framework/bc.py` and the
-SC2-specific implementation in `games/sc2/bc_adapter.py` —
-`games/sc2/replay_bc.py` still owns the replay parser and per-target
-fitters.
+`--bc` is game-agnostic — any game whose `GameAdapter` exposes a
+`BCAdapter` can use it.  The mode flag is mutually exclusive with
+`--play` / `--eval`.  The resulting `policy_weights.yaml` (and optional
+`trainer_state.npz`) are written to the standard experiment directory;
+the normal SC2 training loop auto-loads them on the next run, so step 2
+is just a regular training run.  The orchestration lives in
+`framework/bc.py` (see
+[`docs/framework/bc_adapter.md`](../../docs/framework/bc_adapter.md)
+for the full contract) and the SC2-specific implementation in
+`games/sc2/bc_adapter.py` — `games/sc2/replay_bc.py` still owns the
+replay parser and per-target fitters.
 
 ### Getting replay data
 

--- a/games/tmnf/README.md
+++ b/games/tmnf/README.md
@@ -106,10 +106,12 @@ python main.py my_experiment --game tmnf
 ```
 
 This replaces the legacy `do_pretrain: true` config knob (removed in
-issue #395).  `.Replay.Gbx` replay-file ingest is tracked in #396.
+issue #395).  `.Replay.Gbx` replay-file ingest is not currently
+supported — running without `--replay-dir` (SimplePolicy source) is
+the only BC mode available for TMNF today.
 
 Tune via `bc_n_demo_laps: <N>` in `training_params.yaml`; only
-`bc_target: hill_climbing` is supported today.
+`bc_target: hill_climbing` is supported.
 
 ### Grid search
 

--- a/games/tmnf/bc_adapter.py
+++ b/games/tmnf/bc_adapter.py
@@ -8,7 +8,7 @@ on the demos.  This is the same logic that the now-removed
 ``rl/pretrain.py`` ran under ``do_pretrain: true``; here it is exposed
 through the framework BC pipeline instead.
 
-Replay-file ingest (``*.Replay.Gbx``) is tracked separately as #396.
+Replay-file ingest (``*.Replay.Gbx``) is not currently supported.
 """
 
 from __future__ import annotations
@@ -41,7 +41,7 @@ class TMNFBCAdapter:
       be reachable — i.e. running the BC mode binds to the live game
       just like a normal training run does.
     * ``replay_dir`` set to a directory of ``*.Replay.Gbx`` files —
-      not yet supported (#396).  Raises with a clear pointer.
+      not currently supported.  Raises with a clear error message.
     """
 
     name = "tmnf"
@@ -59,14 +59,14 @@ class TMNFBCAdapter:
             # synthetic marker so logs read sensibly.
             return "<simple-policy-live-demos>"
 
-        # .Gbx ingest is in scope for #396, not this phase.
+        # .Replay.Gbx replay-file ingest is not currently implemented.
         path = pathlib.Path(replay_dir)
         gbx = sorted(path.glob("*.Replay.Gbx")) if path.is_dir() else []
         raise ValueError(
-            f".Replay.Gbx ingest is not yet implemented for TMNF BC (tracked in "
-            f"#396).  Found {len(gbx)} .Replay.Gbx file(s) in {replay_dir!r}.  "
-            f"For now, run without --replay-dir to use the SimplePolicy live "
-            f"demonstration source."
+            f".Replay.Gbx ingest is not currently supported for TMNF BC.  "
+            f"Found {len(gbx)} .Replay.Gbx file(s) in {replay_dir!r}.  "
+            f"Run without --replay-dir to use the SimplePolicy live "
+            f"demonstration source instead."
         )
 
     def build_dataset(
@@ -83,7 +83,7 @@ class TMNFBCAdapter:
             # Caller skipped validate_replay_dir or framework re-entered with
             # a replay path — defend the same boundary.
             raise ValueError(
-                ".Replay.Gbx ingest is not yet implemented for TMNF BC (#396); "
+                ".Replay.Gbx ingest is not currently supported for TMNF BC; "
                 "run without --replay-dir to use SimplePolicy demonstrations."
             )
 

--- a/main.py
+++ b/main.py
@@ -463,9 +463,8 @@ def _run_bc(adapter, args: argparse.Namespace) -> None:
 def _build_bc_obs_spec(game: str, training_params: dict):
     """Build the active observation spec for a BC run.
 
-    Each game decides its own obs_spec wiring.  The CLI doesn't try to be
-    clever — it asks the game module directly.  When phase 3 (#395) lands,
-    TMNF and other games will plug into this same dispatch.
+    Each game decides its own obs_spec wiring.  The CLI asks the game
+    module directly; new games add a branch here when they wire a BCAdapter.
     """
     if game == "sc2":
         from games.sc2.adapter import _get_obs_spec

--- a/tests/README.md
+++ b/tests/README.md
@@ -926,7 +926,10 @@ handful of iterations only); reading real `.SC2Replay` files end-to-end
 ## Framework BC seam
 
 `framework/bc.py` and `framework/bc_io.py` — game-agnostic BC orchestrator
-introduced in issue #393.
+(issue #393, parent #392).  Two game-specific implementations are wired
+on top: `games/sc2/bc_adapter.py` (issue #394) and
+`games/tmnf/bc_adapter.py` (issue #395).  See
+`docs/framework/bc_adapter.md` for the full protocol contract.
 
 **Tested.** `BCAdapter` Protocol conformance via a fake adapter, the
 generic `run()` orchestrator's validate → build → fit → save flow, NPZ
@@ -960,7 +963,7 @@ shape.  These tests do not touch any game.
 
 `games/tmnf/bc_adapter.py` — TMNF implementation of the framework BC seam
 introduced in issue #395.  Uses the in-game `SimplePolicy` as the
-demonstration source (replay-file ingest tracked in #396).
+demonstration source (`.Replay.Gbx` replay-file ingest not currently supported).
 
 **Tested.** Protocol surface, lstsq fit recovers a synthetic target
 policy, full pipeline through `framework.bc.run` with a stubbed env, and
@@ -975,8 +978,8 @@ episodes.
 - `validate_replay_dir(None)` returns a synthetic
   `"<simple-policy-live-demos>"` marker
 - `validate_replay_dir(<dir with .Replay.Gbx>)` raises `ValueError`
-  pointing to #396; `build_dataset` with a non-None `replay_dir` raises
-  the same way
+  with "not currently supported"; `build_dataset` with a non-None
+  `replay_dir` raises the same way
 - `fit_weighted_linear` recovers a synthetic target weight vector via
   lstsq (tolerance `1e-4`) when the training signal is noiseless
 - `fit_bc` returns `(policy, loss)` where `loss` matches

--- a/tests/test_tmnf_bc.py
+++ b/tests/test_tmnf_bc.py
@@ -7,8 +7,8 @@ path.  This suite covers:
 - Protocol surface (``name``, ``supported_targets``, ``default_target``,
   required methods).
 - ``validate_replay_dir`` synthetic-marker behaviour for the SimplePolicy
-  source, and the explicit ``#396`` defer when a ``.Replay.Gbx``
-  directory is passed.
+  source, and the explicit "not currently supported" error when a
+  ``.Replay.Gbx`` directory is passed.
 - ``fit_bc`` lstsq round-trip on synthetic demos — verifies parity with
   the historical ``rl/pretrain.fit_weighted_linear`` (which produced
   exactly the same numerical fit).
@@ -118,17 +118,17 @@ def test_validate_replay_dir_none_returns_marker():
     assert "simple-policy" in result
 
 
-def test_validate_replay_dir_with_gbx_defers_to_396(tmp_path):
+def test_validate_replay_dir_with_gbx_raises(tmp_path):
     (tmp_path / "a.Replay.Gbx").touch()
     (tmp_path / "b.Replay.Gbx").touch()
     a = TMNFBCAdapter()
-    with pytest.raises(ValueError, match="#396"):
+    with pytest.raises(ValueError, match="not currently supported"):
         a.validate_replay_dir(tmp_path)
 
 
-def test_build_dataset_with_replay_dir_defers_to_396(tmp_path):
+def test_build_dataset_with_replay_dir_raises(tmp_path):
     a = TMNFBCAdapter()
-    with pytest.raises(ValueError, match="#396"):
+    with pytest.raises(ValueError, match="not currently supported"):
         a.build_dataset(
             tmp_path,
             tmp_path / "demos.npz",


### PR DESCRIPTION
$(cat <<'EOF'
Closes #397
Refs #392

## Summary

- **New:** `docs/framework/bc_adapter.md` — full `BCAdapter` protocol reference: attributes, methods, `demos.npz` schema, `bc_summary.json` schema, wiring guide, and a worked example of adding BC to a new game.
- **Docs updates:** `docs/framework/README.md`, `CLAUDE.md` (game-agnostic `--bc` section under Running; SC2 paragraph cross-links framework doc), `games/sc2/README.md`, `games/tmnf/README.md` (replace "#396 tracked" with "not currently supported"), `tests/README.md`.
- **Dead-code cleanup:** All `#396` forward references removed from `games/tmnf/bc_adapter.py`, stale phase-3 comment removed from `main.py`, test names / match strings in `test_tmnf_bc.py` updated to match new error text.
- **CHANGELOG:** Phase 4 Added entry + expanded `do_pretrain` → `--bc` migration note as a self-contained Breaking entry with CLI example.

## Validation

```bash
python -m pytest tests/test_framework_bc.py tests/test_tmnf_bc.py -q
# 30 passed

pre-commit run --all-files
# all checks passed
```

## Checklist

- [x] `docs/framework/bc_adapter.md` created and listed in `docs/framework/README.md`
- [x] `CLAUDE.md` updated (game-agnostic `--bc` section; `rl/` description; framework docs list)
- [x] `games/sc2/README.md` and `games/tmnf/README.md` updated
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] `tests/README.md` updated
- [x] Dead-code sweep clean (`grep -rn "#396"` returns nothing outside CHANGELOG)
- [x] Pre-commit clean
- [x] All BC tests pass

https://claude.ai/code/session_01VrV8VDZG5c7JgDfZerHe8g
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrV8VDZG5c7JgDfZerHe8g)_