### PR TITLE
fix(live-gui): throttle redraws to every 50 steps, add action bar chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+### Changed
+- Live GUI (`--live_gui`) now updates every 50 steps instead of every env
+  step, eliminating the per-step Tkinter redraw that was blocking the SC2
+  training loop and making the game chug (issue #378). The interval is
+  configurable via `live_gui_update_interval` in `training_params.yaml`
+  (default `50`). Rolling reward statistics are still accumulated every
+  step so the displayed means remain accurate.
+- The "Last 10 actions" list in the live GUI has been replaced with an
+  action-frequency bar chart showing the count and percentage of each
+  distinct action taken in the most recent batch of steps. No-op actions
+  are still hidden.
 
 ---
 

--- a/framework/live_monitor.py
+++ b/framework/live_monitor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 import math
 import re
-from collections import defaultdict, deque
+from collections import Counter, defaultdict, deque
 from dataclasses import dataclass
 from typing import Any
 
@@ -227,15 +227,17 @@ class LiveTelemetryMonitor:
         obs_names: list[str],
         obs_scales: np.ndarray,
         rolling_window: int = 5,
+        update_interval: int = 50,
     ) -> None:
         self._obs_names = list(obs_names)
         self._obs_scales = np.asarray(obs_scales, dtype=np.float32)
         self._rolling_window = max(1, int(rolling_window))
+        self._update_interval = max(1, int(update_interval))
         self._reward_history: dict[str, deque[float]] = {}
         self._prev_episode_components: dict[str, float] = {}
         self._groups = _classify_observation_features(self._obs_names)
         self._step_idx = 0
-        self._last_actions: deque[tuple[int, Any]] = deque(maxlen=10)
+        self._action_buffer: deque[Any] = deque(maxlen=self._update_interval)
 
         self._tk = None
         self._reward_canvas = None
@@ -274,7 +276,12 @@ class LiveTelemetryMonitor:
                 top_frame, text="Rewards (rolling avg)", anchor="w", font=("TkDefaultFont", 8, "bold")
             )
             reward_label.grid(row=0, column=0, sticky="w")
-            action_label = tk.Label(top_frame, text="Last 10 actions", anchor="w", font=("TkDefaultFont", 8, "bold"))
+            action_label = tk.Label(
+                top_frame,
+                text=f"Action frequency (last {self._update_interval} steps)",
+                anchor="w",
+                font=("TkDefaultFont", 8, "bold"),
+            )
             action_label.grid(row=0, column=1, sticky="w", padx=(12, 0))
 
             top_frame.columnconfigure(0, weight=3)
@@ -348,17 +355,20 @@ class LiveTelemetryMonitor:
             return
         self._step_idx += 1
         if action is not None:
-            self._last_actions.append((self._step_idx, action))
+            self._action_buffer.append(action)
         step_components, self._prev_episode_components = _derive_step_components(
             info,
             reward,
             self._prev_episode_components,
         )
+        # Always update rolling stats so the window stays accurate between draws.
         avg_components = _rolling_means(
             self._reward_history,
             step_components,
             self._rolling_window,
         )
+        if self._step_idx % self._update_interval != 0:
+            return
         self._draw_reward_panel(avg_components)
         self._draw_action_panel()
         self._draw_observation_panel(np.asarray(obs, dtype=np.float32))
@@ -431,25 +441,51 @@ class LiveTelemetryMonitor:
             return
         c = self._action_canvas
         c.delete("all")
-        if not self._last_actions:
+        if not self._action_buffer:
             c.create_text(8, 8, anchor="nw", text="(no actions yet)", fill="gray", font=("TkDefaultFont", 8))
             c.configure(scrollregion=(0, 0, 200, 40))
             return
 
-        y = 8
-        row_h = 18
-        actions = list(self._last_actions)
-        shown = 0
-        for step_i, act in reversed(actions):
-            action_text = _fmt_action(act)
-            if not action_text:
-                continue
-            label = f"#{step_i:>5}: {action_text}"
-            c.create_text(8, y, anchor="nw", text=label, font=("TkFixedFont", 8), fill="#222")
-            y += row_h
-            shown += 1
+        counts = Counter(lbl for a in self._action_buffer if (lbl := _fmt_action(a)))
+        if not counts:
+            c.create_text(8, 8, anchor="nw", text="(only no-ops)", fill="gray", font=("TkDefaultFont", 8))
+            c.configure(scrollregion=(0, 0, 200, 40))
+            return
 
-        c.configure(scrollregion=(0, 0, int(c.winfo_width()) or 200, y + 4))
+        total = sum(counts.values())
+        canvas_w = max(220, int(c.winfo_width()) or 220)
+        c.create_text(
+            8,
+            6,
+            anchor="nw",
+            text=f"last {len(self._action_buffer)} steps",
+            fill="#666",
+            font=("TkDefaultFont", 8),
+        )
+
+        y = 26
+        row_h = 18
+        label_w = 110
+        bar_left = 8 + label_w
+        bar_right = canvas_w - 50
+        bar_max = max(20, bar_right - bar_left)
+
+        for label, count in counts.most_common(15):
+            frac = count / total
+            px = max(1, int(bar_max * frac))
+            c.create_rectangle(bar_left, y + 1, bar_left + px, y + row_h - 3, fill="#4c78a8", outline="")
+            c.create_text(bar_left - 4, y + 2, anchor="ne", text=label[:14], font=("TkDefaultFont", 8), fill="#222")
+            c.create_text(
+                bar_left + px + 4,
+                y + 2,
+                anchor="nw",
+                text=f"{count} ({frac * 100:.0f}%)",
+                font=("TkFixedFont", 8),
+                fill="#555",
+            )
+            y += row_h
+
+        c.configure(scrollregion=(0, 0, canvas_w, y + 8))
 
     def _draw_observation_panel(self, obs: np.ndarray) -> None:
         if self._obs_canvas is None:
@@ -589,6 +625,7 @@ def make_live_monitor(training_params: dict, obs_spec: Any) -> LiveTelemetryMoni
     if not names:
         logger.warning("live_gui requested but observation spec is empty; disabling.")
         return None
-    monitor = LiveTelemetryMonitor(names, scales, rolling_window=5)
+    update_interval = max(1, int(training_params.get("live_gui_update_interval", 50)))
+    monitor = LiveTelemetryMonitor(names, scales, rolling_window=5, update_interval=update_interval)
     monitor.start()
     return monitor

--- a/framework/live_monitor.py
+++ b/framework/live_monitor.py
@@ -452,13 +452,16 @@ class LiveTelemetryMonitor:
             c.configure(scrollregion=(0, 0, 200, 40))
             return
 
-        total = sum(counts.values())
+        # total_steps includes no-ops (denominator for honest percentages);
+        # total_shown excludes them (denominator for bar-width so bars fill the chart).
+        total_steps = len(self._action_buffer)
+        total_shown = sum(counts.values())
         canvas_w = max(220, int(c.winfo_width()) or 220)
         c.create_text(
             8,
             6,
             anchor="nw",
-            text=f"last {len(self._action_buffer)} steps",
+            text=f"last {total_steps} steps",
             fill="#666",
             font=("TkDefaultFont", 8),
         )
@@ -471,15 +474,16 @@ class LiveTelemetryMonitor:
         bar_max = max(20, bar_right - bar_left)
 
         for label, count in counts.most_common(15):
-            frac = count / total
-            px = max(1, int(bar_max * frac))
+            bar_frac = count / total_shown
+            pct = count / total_steps * 100
+            px = max(1, int(bar_max * bar_frac))
             c.create_rectangle(bar_left, y + 1, bar_left + px, y + row_h - 3, fill="#4c78a8", outline="")
             c.create_text(bar_left - 4, y + 2, anchor="ne", text=label[:14], font=("TkDefaultFont", 8), fill="#222")
             c.create_text(
                 bar_left + px + 4,
                 y + 2,
                 anchor="nw",
-                text=f"{count} ({frac * 100:.0f}%)",
+                text=f"{count} ({pct:.0f}%)",
                 font=("TkFixedFont", 8),
                 fill="#555",
             )
@@ -625,7 +629,11 @@ def make_live_monitor(training_params: dict, obs_spec: Any) -> LiveTelemetryMoni
     if not names:
         logger.warning("live_gui requested but observation spec is empty; disabling.")
         return None
-    update_interval = max(1, int(training_params.get("live_gui_update_interval", 50)))
+    try:
+        update_interval = max(1, int(training_params.get("live_gui_update_interval", 50) or 50))
+    except (TypeError, ValueError):
+        logger.warning("live_gui_update_interval is invalid; defaulting to 50")
+        update_interval = 50
     monitor = LiveTelemetryMonitor(names, scales, rolling_window=5, update_interval=update_interval)
     monitor.start()
     return monitor

--- a/tests/README.md
+++ b/tests/README.md
@@ -310,6 +310,7 @@ worker mechanics are unit-tested with a dummy env.
 - reward ordering puts `total_reward` first; all other keys (including former TMNF/SC2-specific names) are sorted alphabetically
 - layout helpers split rows into display columns while preserving order and switch observation panel column count from 3 to 4 on wide canvases
 - action formatting renders 3-value TMNF controls with steer direction/percent, treats tiny pedal values (`<= 0.01`) as effectively zero when choosing accel-only vs brake-only display, and still truncates long vectors after six entries
+- action panel (bar chart): all-no-op buffer shows "(only no-ops)" status and draws no bars; real actions produce bar entries with percentage annotations
 
 ### test_obs_memory.py — frame-stacking observation wrapper
 - shape; reset fills initial; step shifts frames; k=1 passthrough; invalid k raises; most-recent zero-padded; clear

--- a/tests/test_live_monitor.py
+++ b/tests/test_live_monitor.py
@@ -137,6 +137,7 @@ class TestDisplayHelpers(unittest.TestCase):
 class _FakeCanvas:
     def __init__(self):
         self.texts = []
+        self.rects = []
         self.scrollregion = None
 
     def delete(self, *_args, **_kwargs):
@@ -146,22 +147,46 @@ class _FakeCanvas:
         self.texts.append(kwargs.get("text", ""))
         return None
 
+    def create_rectangle(self, *args, **_kwargs):
+        self.rects.append(args)
+        return None
+
     def configure(self, **kwargs):
         self.scrollregion = kwargs.get("scrollregion")
 
     def winfo_width(self):
-        return 200
+        return 220
 
 
 class TestActionPanel(unittest.TestCase):
-    def test_draw_action_panel_skips_no_op_lines_entirely(self):
+    def test_draw_action_panel_skips_no_op_actions(self):
+        """All-no-op buffer shows a status message, not an action bar entry."""
         monitor = LiveTelemetryMonitor(["obs"], [1.0], rolling_window=5)
         monitor._action_canvas = _FakeCanvas()
-        monitor._last_actions.append((1, [0.0, 0.0, 0.0, 0.0]))
+        monitor._action_buffer.append([0.0, 0.0, 0.0, 0.0])  # SC2 no-op
 
         monitor._draw_action_panel()
 
-        self.assertEqual(monitor._action_canvas.texts, [])
+        # Only the "(only no-ops)" status text should appear; no bars drawn.
+        self.assertTrue(any("only no-ops" in t for t in monitor._action_canvas.texts))
+        self.assertEqual(monitor._action_canvas.rects, [])
+
+    def test_draw_action_panel_shows_bar_chart_for_real_actions(self):
+        """Non-no-op actions produce bar entries and no list lines."""
+        monitor = LiveTelemetryMonitor(["obs"], [1.0], rolling_window=5)
+        monitor._action_canvas = _FakeCanvas()
+        # Two Move_screen actions (fn_idx=2) and one select_army (fn_idx=1)
+        monitor._action_buffer.append([2.0, 0.5, 0.5, 0.0])
+        monitor._action_buffer.append([2.0, 0.2, 0.3, 0.0])
+        monitor._action_buffer.append([1.0, 0.0, 0.0, 0.0])
+
+        monitor._draw_action_panel()
+
+        # Bars should have been drawn.
+        self.assertTrue(len(monitor._action_canvas.rects) > 0)
+        # Percentage annotations should be present.
+        pct_texts = [t for t in monitor._action_canvas.texts if "%" in t]
+        self.assertTrue(len(pct_texts) > 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_live_monitor.py
+++ b/tests/test_live_monitor.py
@@ -188,6 +188,24 @@ class TestActionPanel(unittest.TestCase):
         pct_texts = [t for t in monitor._action_canvas.texts if "%" in t]
         self.assertTrue(len(pct_texts) > 0)
 
+    def test_draw_action_panel_percentages_use_total_steps(self):
+        """Percentages are computed against total buffer length, not just shown actions.
+
+        1 real action + 49 no-ops → 2%, not 100%.
+        """
+        monitor = LiveTelemetryMonitor(["obs"], [1.0], rolling_window=5, update_interval=50)
+        monitor._action_canvas = _FakeCanvas()
+        # Fill with 49 no-ops then 1 real action
+        for _ in range(49):
+            monitor._action_buffer.append([0.0, 0.0, 0.0, 0.0])
+        monitor._action_buffer.append([1.0, 0.0, 0.0, 0.0])  # select_army
+
+        monitor._draw_action_panel()
+
+        pct_texts = [t for t in monitor._action_canvas.texts if "%" in t]
+        self.assertEqual(len(pct_texts), 1)
+        self.assertIn("2%", pct_texts[0])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Closes #378

## Summary

- `LiveTelemetryMonitor.on_step()` was doing 3 full Tkinter canvas redraws + 2 event-pump calls at every env step, blocking the SC2 training loop at ~22 ticks/s and making the game chug.
- Rolling reward stats still accumulate every step (so rolling means remain accurate); the 3 canvases only repaint every `update_interval` steps (default **50**, tunable via `live_gui_update_interval` in `training_params.yaml`).
- Replaced the "Last 10 actions" timestamped list with an **action-frequency bar chart** showing count + % of each action label in the most recent batch. No unbounded accumulation: the action buffer is a `deque(maxlen=update_interval)`.

### Bug fix detail

Root cause: `framework/live_monitor.py:on_step()` called on every `env.step()` (see `framework/training.py:248`), triggering expensive synchronous Tkinter redraws that blocked the training loop. Fix throttles the redraw cadence by a configurable factor without changing how stats are collected.

## Test plan

- [x] `python -m pytest tests/test_live_monitor.py -v` — all 17 tests pass
- [x] `pre-commit run --all-files` — all hooks pass (check-yaml, ruff, ruff-format)
- [x] `CHANGELOG.md` updated under `## [Unreleased]`
- [x] `tests/README.md` updated with new action-panel tests

https://claude.ai/code/session_01V2VH4Ka4MKgWZWkry6PL8M

---
_Generated by [Claude Code](https://claude.ai/code/session_01V2VH4Ka4MKgWZWkry6PL8M)_