### PR TITLE
feat: add --log-file flag to tee logs to a file

### DIFF
--- a/main.py
+++ b/main.py
@@ -212,6 +212,17 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Logging verbosity (default: INFO)",
     )
     parser.add_argument(
+        "--log-file",
+        default=None,
+        metavar="PATH",
+        help=(
+            "Write logs to PATH in addition to the terminal (tee).  "
+            "The file is opened fresh on each run (overwrites).  "
+            "Combine with --log-level DEBUG to capture SC2 state snapshots "
+            "(available actions, units, buildings) every ~10 s."
+        ),
+    )
+    parser.add_argument(
         "--workers",
         type=_positive_int("--workers"),
         default=None,
@@ -236,11 +247,16 @@ def main() -> None:
     parser = _build_arg_parser()
     args = parser.parse_args()
 
-    logging.basicConfig(
-        level=getattr(logging, args.log_level),
-        format="%(asctime)s %(levelname)-8s %(name)s: %(message)s",
-        datefmt="%H:%M:%S",
-    )
+    _log_level = getattr(logging, args.log_level)
+    _log_fmt = "%(asctime)s %(levelname)-8s %(name)s: %(message)s"
+    _log_datefmt = "%H:%M:%S"
+    logging.basicConfig(level=_log_level, format=_log_fmt, datefmt=_log_datefmt)
+    if args.log_file:
+        _fh = logging.FileHandler(args.log_file, mode="w", encoding="utf-8", delay=False)
+        _fh.setLevel(_log_level)
+        _fh.setFormatter(logging.Formatter(_log_fmt, datefmt=_log_datefmt))
+        logging.getLogger().addHandler(_fh)
+        logger.info("Logging to file: %s", args.log_file)
     logger.info("gamer-ai code version: %s", code_version())
 
     if args.play and args.game != "sc2":


### PR DESCRIPTION
Adds --log-file PATH to main.py and grid_search.py. When set, a FileHandler is attached to the root logger alongside the existing StreamHandler so all log output is written to both the terminal and the file. The file is opened fresh on each run (mode="w") and delay=False so it is created immediately. StreamHandler flushes after every emit(), meaning records are visible in the file even if the run is aborted mid-way.

Combine with --log-level DEBUG to capture SC2 state snapshots (available actions, units, buildings) every ~10 s from SC2Client._maybe_log_state_dump().

<!--
One template for all PRs.
Keep only the section(s) that apply to this PR and delete the rest.
Replace <issue> in the "Closes" line below with the issue number this PR resolves.
-->

Closes #<issue>

## Summary

<!-- 1–3 bullets on what changed and why -->

-
-

## Related issues

<!-- The issue this PR closes goes in the "Closes #<issue>" line at the top.
     Add any *additional* related issues here, e.g. "Refs #456". -->

## Validation

<!-- Commands or manual checks you ran -->

```bash
PYTHONPATH=. poetry run python -m pytest tests/ \
    --ignore=tests/test_env_termination.py \
    --ignore=tests/test_grid_search.py \
    --ignore=tests/integration/
```

## Bug fix details (delete this section if not a bug fix)

- Problem:
- Root cause:
- Fix:

## Feature details (delete this section if not a feature)

- User problem:
- Proposed solution:
- Trade-offs / follow-ups:

## Refactor / docs / chore details (delete this section if not applicable)

- What changed:
- Why this is safe:

## Checklist
### Release bump type

- [x] Patch (default)
- [ ] Minor
- [ ] Major

### AI usage

- [ ] No AI was used to write this code
- [ ] AI was used to write/generate some or all of this code

**If AI was used:** Please describe which AI tool(s) and model(s) were used (e.g., Claude Opus, ChatGPT, etc.):
<!-- e.g. "Claude Sonnet 4.6 for initial skeleton + types" -->

**Human involvement:**

<!-- Describe what human review/changes happened: validation of AI output, manual edits, testing, etc. -->

## Screenshots / plots (optional)

<!-- For training-loop, reward, or analytics changes: drop in the
     before/after plots from experiments/<...>/results/. -->

## Notes for the reviewer

- [ ] Updated `README.md` if user-visible behaviour, install steps, or CLI flags changed
- [ ] Updated `CLAUDE.md` if architecture, config knobs, or training-loop semantics changed
- [ ] Updated the relevant `games/<name>/README.md` for per-game changes
- [ ] Updated `tests/README.md` if tests were added, removed, or substantially changed (required by the repo's test-suite contract)
- [ ] Added an entry under `## [Unreleased]` in `CHANGELOG.md` for any user- or developer-visible change (new feature, new config key, breaking change, bug fix, dependency change). Trivial commits — experiment dumps, formatting, no-op refactors — can be skipped.
- [ ] New config keys appear in the relevant `config/*.yaml` master file with a sensible default
- [ ] Scope is limited to this issue/PR
- [ ] Tests updated where needed
- [ ] Docs updated where needed
- [ ] No secrets, large binaries, or experiment outputs committed
