### PR TITLE
fix: correct epsilon_decay_steps in SC2 neural DQN grid search templates

### DIFF
--- a/games/sc2/config/gs_neural_dqn_bc_template.yaml
+++ b/games/sc2/config/gs_neural_dqn_bc_template.yaml
@@ -16,8 +16,9 @@
 #   hidden_sizes                                  (capacity axis)
 #
 # At step_mul=1 a 600 s episode yields ~13 440 steps (22.4 ticks/s × 600 s).
-# n_sims=200 gives ~2 688 000 total steps across a run; set epsilon_decay_steps
-# to cover 25–75 % of that budget.
+# n_sims=50 gives ~672 000 total steps; n_sims=200 gives ~2 688 000 total steps.
+# Set epsilon_decay_steps to cover 25–75 % of the budget you actually use
+# (~168 000–504 000 for n_sims=50; ~672 000–2 016 000 for n_sims=200).
 #
 # BC target note
 # --------------
@@ -61,7 +62,7 @@ training_params:
   policy_type: sc2_neural_dqn
   obs_spec_preset: ladder
   enable_belief: true
-  epsilon_decay_steps: 3000
+  epsilon_decay_steps: [168000, 336000]  # 25 % and 50 % of ~672 000 total steps (n_sims=50)
 
   # Search axes — lists trigger a sweep; scalars are fixed across all combos.
   learning_rate: [0.01, 0.05]

--- a/games/sc2/config/gs_neural_dqn_template.yaml
+++ b/games/sc2/config/gs_neural_dqn_template.yaml
@@ -7,8 +7,9 @@
 # after min_replay_size transitions are collected; ε decays linearly from 1.0
 # to epsilon_end over epsilon_decay_steps environment steps.
 #
-# At step_mul=1 a 120 s episode yields ~2 688 steps (22.4 ticks/s × 120 s).
-# n_sims=200 gives ~537 000 total steps; set epsilon_decay_steps accordingly.
+# At step_mul=4 a 600 s episode yields ~3 360 steps (22.4 ticks/s × 600 s ÷ 4).
+# n_sims=50 gives ~168 000 total steps; set epsilon_decay_steps to 25–75 % of
+# that budget (~42 000–126 000).
 #
 # Good first sweep: learning_rate × epsilon_decay_steps.
 # learning_rate is the most sensitive knob; epsilon_decay_steps controls how
@@ -59,12 +60,12 @@ training_params:
   max_apm: 300
   agent_race: terran
   #difficulty: medium
-  n_sims: 50                 # 50 episodes; ~12 000 env steps total
+  n_sims: 50                 # 50 episodes; ~168 000 env steps total
   policy_type: sc2_neural_dqn
   obs_spec_preset: rich
   enable_belief: false      # false: obs only; true: obs+192 belief dims + scout reward
   learning_rate: 0.01
-  epsilon_decay_steps: 3000
+  epsilon_decay_steps: [42000, 126000]  # 25 % and 75 % of ~168 000 total steps
   hidden_sizes: [[64, 256, 256, 64]]
   initial_extreme_random_fraction: [0.0, 0.25]  # fraction of initial runs forced to random valid actions (set 0 to disable)
 


### PR DESCRIPTION
## Summary

- `epsilon_decay_steps: 3000` caused ε to hit its floor before the first episode finished, leaving the agent in near-pure exploitation for >99 % of training budget.
- Fixed both SC2 neural DQN grid search templates with values derived from the actual step budgets, and corrected the stale step-count comments.

## Bug detail

`DQNPolicy.update()` decrements ε by `(epsilon_start − epsilon_end) / epsilon_decay_steps` on **every env step**, with no reset at episode boundaries (`on_episode_end` is a no-op). With the template settings:

| Template | step_mul | episode_s | steps/ep | n_sims | total steps | old decay | floor after |
|---|---|---|---|---|---|---|---|
| `gs_neural_dqn_template.yaml` | 4 | 600 | ~3 360 | 50 | ~168 000 | 3 000 | < 1 episode |
| `gs_neural_dqn_bc_template.yaml` | 1 | 600 | ~13 440 | 50 | ~672 000 | 3 000 | < 1 episode |

## Fix

Set `epsilon_decay_steps` to a sweep that spans the 25–75 % guidance from CLAUDE.md:

- `gs_neural_dqn_template.yaml`: `3000` → `[42000, 126000]` (25 % and 75 % of ~168 000)
- `gs_neural_dqn_bc_template.yaml`: `3000` → `[168000, 336000]` (25 % and 50 % of ~672 000)

Also corrected the step-count comment in `gs_neural_dqn_template.yaml` (was "~12 000 env steps total", now "~168 000"), and updated both file headers to show the step math for their actual `step_mul` / `in_game_episode_s` settings.

## Validation

```bash
# Verify YAML is valid and pre-commit passes
pre-commit run --files games/sc2/config/gs_neural_dqn_template.yaml games/sc2/config/gs_neural_dqn_bc_template.yaml
```

- [x] `check yaml` passed
- [x] `fix end of files` passed
- [x] `trim trailing whitespace` passed
- [x] No code changes — config/template only
- [x] `CHANGELOG.md` — config-only template fix, no behaviour change to shipped code

https://claude.ai/code/session_01F4JSnVLNU48EKXq7YdnqaG

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4JSnVLNU48EKXq7YdnqaG)_