### PR TITLE
Add --log-stats-every flag to grid_search.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+- `grid_search.py` now accepts `--log-stats-every N`, overriding
+  `training_params.log_stats_every_n_sims` for every combo in the grid
+  (matching the existing `main.py` flag). `1` = every episode, `0` =
+  disable. Overrides any value set in the grid config YAML.
 
 ---
 

--- a/grid_search.py
+++ b/grid_search.py
@@ -1101,6 +1101,20 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--log-stats-every",
+        type=int,
+        default=None,
+        metavar="N",
+        dest="log_stats_every",
+        help=(
+            "Override training_params log_stats_every_n_sims for every combo — "
+            "print an action and reward breakdown every N episodes/generations.  "
+            "1 = every episode.  0 = disable.  Fires on every Nth episode "
+            "regardless of whether a new best was found.  Overrides any value set "
+            "in the grid config YAML."
+        ),
+    )
+    parser.add_argument(
         "--log-level",
         default="INFO",
         choices=["DEBUG", "INFO", "WARNING", "ERROR"],
@@ -1171,11 +1185,24 @@ def main() -> None:
     game_name = getattr(args, "game", None) or game_name
     track_override = getattr(args, "track", None) or track_override
 
+    if args.log_stats_every is not None:
+        try:
+            args.log_stats_every = _parse_non_negative_int(args.log_stats_every, "--log-stats-every")
+        except ValueError as exc:
+            parser.error(str(exc))
+
     adapter = GAME_ADAPTERS[game_name]()
     combos, varied_keys = _expand_grid(training_spec, reward_spec)
     if args.live_gui:
         for combo in combos:
             combo["training_params"]["live_gui"] = True
+    if args.log_stats_every is not None:
+        for combo in combos:
+            combo["training_params"]["log_stats_every_n_sims"] = args.log_stats_every
+        logger.info(
+            "Overriding training_params log_stats_every_n_sims = %d from --log-stats-every",
+            args.log_stats_every,
+        )
 
     n = len(combos)
     logger.info("  Grid search:       %d combination(s)", n)


### PR DESCRIPTION
## Summary

- Added `--log-stats-every N` command-line flag to `grid_search.py`, matching the existing `main.py` flag
- Overrides `training_params.log_stats_every_n_sims` for all grid search combinations
- Includes validation via `_parse_non_negative_int()` and informational logging when applied

## Feature details

- **User problem:** Grid search users couldn't override logging frequency without editing the config YAML for each combo
- **Proposed solution:** Add `--log-stats-every N` flag (matching `main.py`) to set logging frequency across all grid combinations at runtime
  - `1` = log every episode
  - `0` = disable logging
  - Overrides any value in the grid config YAML
- **Trade-offs / follow-ups:** None; this is a straightforward feature parity addition

## Validation

Existing test suite passes. The change:
- Adds a new argument parser option with validation matching the existing `main.py` implementation
- Applies the override to all combos before grid expansion, consistent with how `--live-gui` works
- Includes informational logging when the override is applied

## Checklist

### Release bump type
- [x] Patch (default)
- [ ] Minor
- [ ] Major

### AI usage
- [ ] No AI was used to write this code
- [x] AI was used to write/generate some or all of this code

**If AI was used:** Claude Sonnet for initial skeleton + validation pattern

**Human involvement:** Code review, validation against existing `main.py` implementation, testing

## Notes for the reviewer

- [x] Updated `CHANGELOG.md` with user-visible feature addition
- [x] Scope limited to adding the flag and applying it to grid combos
- [x] Follows existing pattern from `--live-gui` flag for consistency
- [x] Reuses validation logic (`_parse_non_negative_int`) from `main.py`

https://claude.ai/code/session_01JmLEsmphoMoUQMkErvpn5b