### PR TITLE
Refactor action logging to share category-grouped layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+### Changed
+
+- Training logs: the periodic stats block (`log_stats_every_n_sims`) now pads
+  action labels to a common width so the count / percentage columns line up
+  under each category heading, and the `NEW BEST` action-frequency breakdown
+  now reuses the same category-grouped, column-aligned layout instead of a flat
+  list (`framework/training.py`).
 
 ---
 

--- a/framework/training.py
+++ b/framework/training.py
@@ -359,7 +359,7 @@ def _episode_skipped_frames(info: dict) -> int | None:
         return None
 
 
-def _log_action_breakdown(info: dict, cmp_for_fn) -> None:
+def _log_action_breakdown(info: dict, cmp_for_fn: Callable[[int, float], str]) -> None:
     """Log the per-action frequency breakdown, grouped by category and aligned.
 
     Shared by the NEW BEST and periodic-stats logging paths so both render an

--- a/framework/training.py
+++ b/framework/training.py
@@ -359,6 +359,58 @@ def _episode_skipped_frames(info: dict) -> int | None:
         return None
 
 
+def _log_action_breakdown(info: dict, cmp_for_fn) -> None:
+    """Log the per-action frequency breakdown, grouped by category and aligned.
+
+    Shared by the NEW BEST and periodic-stats logging paths so both render an
+    identical, column-aligned layout (labels padded to a common width so the
+    count / percentage columns line up under each category heading).  When the
+    game supplies ``episode_action_category_map`` the actions are grouped under
+    ``[category]`` headings; otherwise they fall back to a single flat list
+    ordered by frequency.
+
+    *cmp_for_fn(fn_idx, pct)* returns the trailing comparison annotation for an
+    action (e.g. ``" (prev 12.3%)"`` or ``" (+1.2pp vs best)"``); return ``""``
+    for none.
+    """
+    ac = info.get("episode_action_counts")
+    if not ac:
+        return
+    total = sum(ac.values())
+    if total <= 0:
+        return
+
+    name_map: dict = info.get("episode_action_name_map") or {}
+    cat_map: dict = info.get("episode_action_category_map") or {}
+
+    # Pad every label to the widest one so the "= count (pct%)" columns align.
+    label_w = max(len(name_map.get(fn_idx, str(fn_idx))) for fn_idx in ac)
+
+    def _emit(fn_idx: int, count: int, indent: str) -> None:
+        label = name_map.get(fn_idx, str(fn_idx))
+        pct = 100.0 * count / total
+        cmp_s = cmp_for_fn(fn_idx, pct)
+        logger.info("%s%-*s = %4d (%5.1f%%)%s", indent, label_w, label, count, pct, cmp_s)
+
+    if cat_map:
+        _KNOWN_CATS = ["move", "attack", "build", "train", "upgrade"]
+        cat_groups: dict[str, list[int]] = {}
+        for fn_idx in ac:
+            cat = cat_map.get(fn_idx, "other")
+            cat_groups.setdefault(cat, []).append(fn_idx)
+        unknown_cats = sorted(c for c in cat_groups if c not in _KNOWN_CATS)
+        for cat in _KNOWN_CATS + unknown_cats:
+            entries = cat_groups.get(cat)
+            if not entries:
+                continue
+            logger.info("    [%s]", cat)
+            for fn_idx in sorted(entries, key=lambda i: name_map.get(i, str(i))):
+                _emit(fn_idx, ac[fn_idx], "      ")
+    else:
+        for fn_idx, count in sorted(ac.items(), key=lambda x: -x[1]):
+            _emit(fn_idx, count, "    ")
+
+
 def _log_new_best_details(info: dict, prev_best_info: dict | None) -> None:
     """Log expanded breakdown for a newly-achieved best reward.
 
@@ -404,24 +456,18 @@ def _log_new_best_details(info: dict, prev_best_info: dict | None) -> None:
                 logger.info("    loss_penalty=%+.1f", loss_penalty)
 
     # 2. Action-frequency breakdown (any game may populate episode_action_counts)
-    ac = info.get("episode_action_counts")
-    if ac:
-        total = sum(ac.values())
-        if total > 0:
-            prev_ac: dict = prev.get("episode_action_counts") or {}
-            prev_total = sum(prev_ac.values()) if prev_ac else 0
-            name_map: dict = info.get("episode_action_name_map") or {}
-            for fn_idx, count in sorted(ac.items(), key=lambda x: -x[1]):
-                label = name_map.get(fn_idx, str(fn_idx))
-                pct = 100.0 * count / total
-                if prev_total > 0:
-                    # Keys are ints from env.step(); str fallback handles any
-                    # JSON-deserialised prev_best_info where keys became strings.
-                    ppct = 100.0 * prev_ac.get(fn_idx, prev_ac.get(str(fn_idx), 0)) / prev_total
-                    cmp_s = f" (prev {ppct:.1f}%)"
-                else:
-                    cmp_s = ""
-                logger.info("    %s=%.1f%%%s", label, pct, cmp_s)
+    prev_ac: dict = prev.get("episode_action_counts") or {}
+    prev_total = sum(prev_ac.values()) if prev_ac else 0
+
+    def _cmp_vs_prev(fn_idx: int, pct: float) -> str:
+        if prev_total <= 0:
+            return ""
+        # Keys are ints from env.step(); str fallback handles any
+        # JSON-deserialised prev_best_info where keys became strings.
+        ppct = 100.0 * prev_ac.get(fn_idx, prev_ac.get(str(fn_idx), 0)) / prev_total
+        return f" (prev {ppct:.1f}%)"
+
+    _log_action_breakdown(info, _cmp_vs_prev)
 
     # 3. Task metrics — adapters populate info["episode_task_metrics"] as a
     #    dict of {label: formatted_string} so framework stays game-agnostic.
@@ -487,41 +533,19 @@ def _log_periodic_stats(info: dict, sim: int) -> None:
             else:
                 logger.info("    loss_penalty=%+.1f", terminal)
 
-    ac = info.get("episode_action_counts")
-    if ac:
-        total = sum(ac.values())
-        if total > 0:
-            name_map: dict = info.get("episode_action_name_map") or {}
-            cat_map: dict = info.get("episode_action_category_map") or {}
-            best_ac: dict = (_stats_best[0] or {}).get("episode_action_counts") or {}
-            best_total = sum(best_ac.values()) if best_ac else 0
-            if cat_map:
-                _KNOWN_CATS = ["move", "attack", "build", "train", "upgrade"]
-                cat_groups: dict[str, list[tuple[str, int, float, str]]] = {}
-                for fn_idx, count in ac.items():
-                    label = name_map.get(fn_idx, str(fn_idx))
-                    cat = cat_map.get(fn_idx, "other")
-                    pct = 100.0 * count / total
-                    cmp_s = ""
-                    if best_total > 0:
-                        best_pct = 100.0 * best_ac.get(fn_idx, 0) / best_total
-                        delta = pct - best_pct
-                        if abs(delta) >= 0.1:
-                            cmp_s = f" ({delta:+.1f}pp vs best)"
-                    cat_groups.setdefault(cat, []).append((label, count, pct, cmp_s))
-                unknown_cats = sorted(c for c in cat_groups if c not in _KNOWN_CATS)
-                for cat in _KNOWN_CATS + unknown_cats:
-                    entries = cat_groups.get(cat)
-                    if not entries:
-                        continue
-                    logger.info("    [%s]", cat)
-                    for label, count, pct, cmp_s in sorted(entries):
-                        logger.info("      %s=%d (%.1f%%%s)", label, count, pct, cmp_s)
-            else:
-                for fn_idx, count in sorted(ac.items(), key=lambda x: -x[1]):
-                    label = name_map.get(fn_idx, str(fn_idx))
-                    pct = 100.0 * count / total
-                    logger.info("    %s=%d (%.1f%%)", label, count, pct)
+    best_ac: dict = (_stats_best[0] or {}).get("episode_action_counts") or {}
+    best_total = sum(best_ac.values()) if best_ac else 0
+
+    def _cmp_vs_best(fn_idx: int, pct: float) -> str:
+        if best_total <= 0:
+            return ""
+        best_pct = 100.0 * best_ac.get(fn_idx, 0) / best_total
+        delta = pct - best_pct
+        if abs(delta) < 0.1:
+            return ""
+        return f" ({delta:+.1f}pp vs best)"
+
+    _log_action_breakdown(info, _cmp_vs_best)
 
 
 def _print_action_stats(throttle_counts: list[int], turning_steps: int, steps: int) -> None:

--- a/tests/README.md
+++ b/tests/README.md
@@ -344,7 +344,8 @@ worker mechanics are unit-tested with a dummy env.
 - SC2 summary formatting: scalar `outcome` (`win`/`loss`/`draw`) plus scalar `reward=` and `score=` values
 - `_log_new_best_details` — empty info emits nothing
 - reward components: logs all non-zero components, always includes `score` (even when 0); `win_bonus` shown only when terminal > 0, `loss_penalty` only when terminal < 0 (neither shown on non-terminal episodes); prev-best comparison included when available
-- action frequency: one log line per action; uses `episode_action_name_map` when present (e.g. `Attack_screen=70.0%`), falls back to raw key stringified when absent; prev comparison shown
+- action frequency: one log line per action; uses `episode_action_name_map` when present (e.g. `Attack_screen =`), falls back to raw key stringified when absent; count + percentage shown with labels padded to a common width so the `=` columns align; prev comparison shown
+- action frequency grouped: when `episode_action_category_map` is present, actions are grouped under `[category]` headings emitted in the canonical `move`/`attack`/`build`/`train`/`upgrade` order (same layout as the periodic stats log); aligned `=` columns across all groups
 - task metrics: generic `episode_task_metrics` dict (pre-formatted strings); progress, lateral offset, finish time only when present; prev comparison for each key (all on one combined line); adapters are responsible for populating and formatting values
 - SC2 kills: units + structures on one line; prev comparison; absent when key not in info; suppressed when both values zero
 - SC2 game-state averages: one log line per non-zero metric; zero values omitted; prev comparison

--- a/tests/test_new_best_logging.py
+++ b/tests/test_new_best_logging.py
@@ -174,8 +174,10 @@ class TestLogNewBestDetails(unittest.TestCase):
         # one log line per action (sorted by descending count: fn2, fn0, fn1)
         self.assertEqual(len(lines), 3)
         all_text = "\n".join(lines)
-        # Without a name map the key is stringified: "2=60.0%".
-        self.assertIn("2=60.0%", all_text)
+        # Without a name map the key is stringified; count + percentage shown.
+        self.assertIn("2 =", all_text)
+        self.assertIn("60", all_text)
+        self.assertIn("60.0%", all_text)
 
     def test_action_counts_uses_name_map(self):
         info = {
@@ -184,10 +186,12 @@ class TestLogNewBestDetails(unittest.TestCase):
         }
         lines = _capture_training_logs(lambda: _log_new_best_details(info, None))
         all_text = "\n".join(lines)
-        self.assertIn("Attack_screen=70.0%", all_text)
-        self.assertIn("no_op=30.0%", all_text)
+        self.assertIn("Attack_screen =", all_text)
+        self.assertIn("70.0%", all_text)
+        self.assertIn("no_op", all_text)
+        self.assertIn("30.0%", all_text)
         # Raw integer keys must not appear when a name map is present.
-        self.assertNotIn("3=", all_text)
+        self.assertNotIn("3 =", all_text)
 
     def test_action_counts_prev_comparison(self):
         info = {"episode_action_counts": {0: 10, 2: 90}}
@@ -196,6 +200,28 @@ class TestLogNewBestDetails(unittest.TestCase):
         self.assertEqual(len(lines), 2)
         all_text = "\n".join(lines)
         self.assertIn("prev", all_text)
+
+    def test_action_counts_grouped_by_category(self):
+        info = {
+            "episode_action_counts": {0: 20, 3: 50, 5: 30},
+            "episode_action_name_map": {0: "Move_screen", 3: "Attack_screen", 5: "Build_Barracks"},
+            "episode_action_category_map": {0: "move", 3: "attack", 5: "build"},
+        }
+        lines = _capture_training_logs(lambda: _log_new_best_details(info, None))
+        all_text = "\n".join(lines)
+        # Category headings emitted in the canonical order.
+        self.assertIn("[move]", all_text)
+        self.assertIn("[attack]", all_text)
+        self.assertIn("[build]", all_text)
+        move_i = all_text.index("[move]")
+        attack_i = all_text.index("[attack]")
+        build_i = all_text.index("[build]")
+        self.assertLess(move_i, attack_i)
+        self.assertLess(attack_i, build_i)
+        # Labels are padded to a common width so the "=" columns align.
+        action_lines = [ln for ln in lines if "=" in ln]
+        eq_cols = {ln.index("=") for ln in action_lines}
+        self.assertEqual(len(eq_cols), 1)
 
     def test_tmnf_progress_logged(self):
         info = {"episode_task_metrics": {"progress": "75.0%"}}

--- a/tests/test_new_best_logging.py
+++ b/tests/test_new_best_logging.py
@@ -174,10 +174,10 @@ class TestLogNewBestDetails(unittest.TestCase):
         # one log line per action (sorted by descending count: fn2, fn0, fn1)
         self.assertEqual(len(lines), 3)
         all_text = "\n".join(lines)
-        # Without a name map the key is stringified; count + percentage shown.
-        self.assertIn("2 =", all_text)
-        self.assertIn("60", all_text)
-        self.assertIn("60.0%", all_text)
+        # Without a name map the key is stringified, and the line must carry the
+        # raw count *and* the percentage in their own columns (count before the
+        # "(pct%)"), so a regression that drops the count column is caught.
+        self.assertRegex(all_text, r"2\s*=\s*60\s*\(\s*60\.0%\)")
 
     def test_action_counts_uses_name_map(self):
         info = {


### PR DESCRIPTION
## Summary

- Extracted action-frequency logging into a shared `_log_action_breakdown()` function to eliminate duplication between `_log_new_best_details()` and `_log_periodic_stats()`.
- Both logging paths now produce identical, column-aligned output: labels are padded to a common width so count/percentage columns line up under category headings.
- `NEW BEST` action breakdown now uses category-grouped layout (when `episode_action_category_map` is present) instead of a flat frequency-sorted list, matching the periodic stats format.

## Refactor / docs / chore details

- **What changed:**
  - New `_log_action_breakdown(info, cmp_for_fn)` function centralizes action logging logic. It accepts a callback (`cmp_for_fn`) to customize the trailing comparison annotation (e.g., `" (prev 12.3%)"` vs `" (+1.2pp vs best)"`).
  - Removed ~40 lines of duplicated action-logging code from `_log_new_best_details()` and `_log_periodic_stats()`.
  - Both callers now pass a simple comparison function and delegate to the shared implementation.
  - Updated test expectations in `test_new_best_logging.py` to reflect the new column-aligned format (e.g., `"2 ="` instead of `"2=60.0%"`).
  - Added new test `test_action_counts_grouped_by_category()` to verify category grouping and column alignment in the `NEW BEST` path.
  - Updated `tests/README.md` and `CHANGELOG.md` to document the formatting change.

- **Why this is safe:**
  - The refactoring preserves all existing behavior: same data is logged, same filtering logic, same comparison calculations.
  - The only user-visible change is formatting (padding for alignment and category grouping in `NEW BEST` logs), which improves readability.
  - All existing tests pass; new test covers the category-grouping feature.
  - No changes to training loop, policy, or memory management.

## Validation

```bash
PYTHONPATH=. poetry run python -m pytest tests/test_new_best_logging.py -v
```

All tests pass, including the new `test_action_counts_grouped_by_category()` test.

## Checklist

### Release bump type

- [x] Patch (default)
- [ ] Minor
- [ ] Major

### AI usage

- [ ] No AI was used to write this code
- [x] AI was used to write/generate some or all of this code

**If AI was used:** Claude Sonnet for initial skeleton and refactoring structure.

**Human involvement:** Manual review of logic equivalence, test updates, and validation that both logging paths produce identical output.

## Notes for the reviewer

- [x] Updated `tests/README.md` to reflect new action-logging format
- [x] Updated `CHANGELOG.md` with user-visible formatting change
- [x] Tests updated (new test for category grouping, existing tests adjusted for column-aligned format)
- [x] Scope limited to logging refactor; no training loop or policy changes
- [x] No secrets, binaries, or experiment outputs committed

https://claude.ai/code/session_017MKyeU29bvamT5D5jgvGJk