### PR TITLE
feat(minerl): add games/minerl/ package scaffold (issue #215, sub-issue #437)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
+### Added
+
+- **MineRL game integration scaffold** (`games/minerl/`) — Phase 1 of issue #215.
+  Adds the `MineRLAdapter`, `MineRLEnv`, obs spec (3-dim vector: compass angle +
+  dirt/log inventory), 9 discrete actions, reward config, and analytics.  Registers
+  `minerl` in `GAME_ADAPTERS`.  Requires `pip install minerl` (Java 8 also needed);
+  all other game integrations are unaffected.  New config keys:
+  `native_reward_scale`, `step_penalty`, `finish_bonus` in
+  `games/minerl/config/reward_config.yaml`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ set (`framework/`) drive per-game integrations (`games/<game>/`) through a
 common adapter interface (`framework/game_adapter.py`), training autonomous
 agents via hill-climbing / evolutionary / CMA-ES / Q-learning /
 policy-gradient methods. The project began as a Trackmania Nations Forever
-(TMNF) agent and now spans nine games.
+(TMNF) agent and now spans ten games.
 
 **Runtime per game** (select with `--game`; default `tmnf`):
 - TMNF: Windows-only (`pywin32`, `mss` window grab, `tminterface` bind to live game process).
@@ -74,6 +74,7 @@ policy-gradient methods. The project began as a Trackmania Nations Forever
 - Rocket League: Rocket League (commercial, Windows) via the `rlgym` API + Bakkesmod (`--game rocket_league`).
 - iRacing: iRacing (commercial, Windows) telemetry via `pyirsdk`, with optional vJoy live action injection (`--game iracing`).
 - Atari: cross-platform, headless; Atari 2600 via `ale-py` (MIT-licensed ROMs bundled). 128-byte RAM observation, `Discrete(N)` action space. `poetry install --with atari` (`--game atari`).
+- MineRL: cross-platform; Minecraft via `minerl` (requires Java 8 + `pip install minerl`). Phase 1 uses 3-dim vector obs (compass + inventory); no pixel obs yet (`--game minerl`).
 
 Each game ships a `games/<game>/README.md` documenting its install,
 config, observation/action space, reward, and supported policies. This file
@@ -132,7 +133,8 @@ gamer-ai/
 │   ├── assetto_corsa/      # Assetto Corsa via assetto-corsa-rl shared memory
 │   ├── rocket_league/      # Rocket League via rlgym + Bakkesmod
 │   ├── iracing/            # iRacing telemetry via pyirsdk (+ optional vJoy injection)
-│   └── atari/              # Atari 2600 via ale-py (RAM observation, Discrete actions)
+│   ├── atari/              # Atari 2600 via ale-py (RAM observation, Discrete actions)
+│   └── minerl/             # Minecraft via MineRL (Phase 1: vector obs, pip install minerl)
 ├── clients/                # Backward-compat shim → games/tmnf/clients
 ├── rl/                     # Backward-compat shim (legacy; BC now lives in framework/bc.py)
 ├── distributed/            # Coordinator, worker, protocol for distributed grid search
@@ -155,7 +157,7 @@ Master configs and grid-search templates live **per game** under
 # Single experiment (TMNF — default)
 python main.py <experiment_name> [--no-interrupt] [--re-initialize]
 
-# Run on a different game (--game: tmnf | torcs | sc2 | car_racing | beamng | assetto)
+# Run on a different game (--game: tmnf | torcs | sc2 | car_racing | beamng | assetto | minerl)
 python main.py <experiment_name> --game torcs
 python main.py <experiment_name> --game sc2
 python main.py <experiment_name> --game car_racing
@@ -988,7 +990,7 @@ Ready-made templates ship per game (e.g.
 `games/sc2/config/grid_search_template.yaml`,
 `games/torcs/config/gs_genetic.yaml`). Pick the target game with `--game`
 (choices: `tmnf`, `beamng`, `car_racing`, `torcs`, `sc2`, `rocket_league`,
-`iracing`).
+`iracing`, `minerl`).
 
 Set any param to list to sweep it:
 

--- a/framework/game_adapter.py
+++ b/framework/game_adapter.py
@@ -100,4 +100,5 @@ GAME_ADAPTERS: dict[str, Callable[[], GameAdapter]] = {
     "rocket_league": lambda: __import__("games.rocket_league.adapter", fromlist=["make_adapter"]).make_adapter(),
     "iracing": lambda: __import__("games.iracing.adapter", fromlist=["make_adapter"]).make_adapter(),
     "atari": lambda: __import__("games.atari.adapter", fromlist=["make_adapter"]).make_adapter(),
+    "minerl": lambda: __import__("games.minerl.adapter", fromlist=["make_adapter"]).make_adapter(),
 }

--- a/games/minerl/actions.py
+++ b/games/minerl/actions.py
@@ -1,0 +1,44 @@
+"""MineRL discrete action definitions.
+
+Nine discrete actions cover the primary navigation and gathering behaviours.
+The environment decodes an integer index (0–8) into a MineRL action dict;
+see ``games.minerl.env.MineRLEnv._decode_action`` for the mapping.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+#: Total number of discrete actions.
+N_ACTIONS: int = 9
+
+#: Discrete action set — integer indices in a (N_ACTIONS, 1) float32 array,
+#: matching the Atari convention used by the framework's tabular policies.
+DISCRETE_ACTIONS: np.ndarray = np.arange(N_ACTIONS, dtype=np.float32).reshape(-1, 1)
+
+#: Human-readable labels for each action index (for debugging / analytics).
+ACTION_LABELS: list[str] = [
+    "noop",
+    "forward",
+    "forward+jump",
+    "forward+attack",
+    "attack",
+    "left+forward",
+    "right+forward",
+    "back",
+    "forward+sprint",
+]
+
+#: Per-action overrides applied on top of a no-op base dict.
+#: Keys follow the MineRL action-space naming convention.
+_ACTION_OVERRIDES: list[dict] = [
+    {},                                          # 0: noop
+    {"forward": 1},                              # 1: forward
+    {"forward": 1, "jump": 1},                   # 2: forward+jump
+    {"forward": 1, "attack": 1},                 # 3: forward+attack
+    {"attack": 1},                               # 4: attack
+    {"left": 1, "forward": 1},                   # 5: left+forward
+    {"right": 1, "forward": 1},                  # 6: right+forward
+    {"back": 1},                                 # 7: back
+    {"forward": 1, "sprint": 1},                 # 8: forward+sprint
+]

--- a/games/minerl/actions.py
+++ b/games/minerl/actions.py
@@ -32,13 +32,13 @@ ACTION_LABELS: list[str] = [
 #: Per-action overrides applied on top of a no-op base dict.
 #: Keys follow the MineRL action-space naming convention.
 _ACTION_OVERRIDES: list[dict] = [
-    {},                                          # 0: noop
-    {"forward": 1},                              # 1: forward
-    {"forward": 1, "jump": 1},                   # 2: forward+jump
-    {"forward": 1, "attack": 1},                 # 3: forward+attack
-    {"attack": 1},                               # 4: attack
-    {"left": 1, "forward": 1},                   # 5: left+forward
-    {"right": 1, "forward": 1},                  # 6: right+forward
-    {"back": 1},                                 # 7: back
-    {"forward": 1, "sprint": 1},                 # 8: forward+sprint
+    {},  # 0: noop
+    {"forward": 1},  # 1: forward
+    {"forward": 1, "jump": 1},  # 2: forward+jump
+    {"forward": 1, "attack": 1},  # 3: forward+attack
+    {"attack": 1},  # 4: attack
+    {"left": 1, "forward": 1},  # 5: left+forward
+    {"right": 1, "forward": 1},  # 6: right+forward
+    {"back": 1},  # 7: back
+    {"forward": 1, "sprint": 1},  # 8: forward+sprint
 ]

--- a/games/minerl/adapter.py
+++ b/games/minerl/adapter.py
@@ -1,0 +1,97 @@
+"""MineRL game adapter — builds config bundles for train_rl."""
+
+from __future__ import annotations
+
+from framework.run_config import GameSpec, ProbeSpec, WarmupSpec
+
+
+def _sanitize(name: str) -> str:
+    """Make *name* safe for use as a directory component."""
+    return name.replace("/", "_").replace(" ", "_")
+
+
+class MineRLAdapter:
+    name = "minerl"
+    config_dir = "games/minerl/config"
+
+    def experiment_dir(
+        self,
+        experiment_name: str,
+        training_params: dict,
+        track_override: str | None,
+    ) -> str:
+        policy = training_params.get("policy_type", "genetic")
+        track = self.track_label(training_params, track_override)
+        return f"experiments/minerl/{policy}/{track}/{experiment_name}"
+
+    def experiment_dir_root(
+        self,
+        training_params: dict,
+        track_override: str | None,
+    ) -> str:
+        policy = training_params.get("policy_type", "genetic")
+        track = self.track_label(training_params, track_override)
+        return f"experiments/minerl/{policy}/{track}"
+
+    def track_label(
+        self,
+        training_params: dict,
+        track_override: str | None,
+    ) -> str:
+        raw = track_override or training_params.get("map_name", "MineRLNavigateDense-v0")
+        return _sanitize(raw)
+
+    def decorate_reward_cfg(
+        self,
+        reward_cfg: dict,
+        training_params: dict,
+        track_override: str | None,
+    ) -> None:
+        pass
+
+    def build_game_spec(
+        self,
+        experiment_name: str,
+        experiment_dir: str,
+        weights_file: str,
+        reward_cfg_file: str,
+        training_params: dict,
+        track_override: str | None,
+    ) -> GameSpec:
+        from games.minerl.actions import DISCRETE_ACTIONS
+        from games.minerl.analytics import save_experiment_results
+        from games.minerl.obs_spec import MINERL_OBS_SPEC
+
+        map_name = track_override or training_params.get("map_name", "MineRLNavigateDense-v0")
+
+        def _make_env():
+            from games.minerl.env import make_env
+
+            return make_env(
+                experiment_dir=experiment_dir,
+                map_name=map_name,
+                max_episode_time_s=training_params["in_game_episode_s"],
+            )
+
+        return GameSpec(
+            experiment_name=experiment_name,
+            track=self.track_label(training_params, track_override),
+            make_env_fn=_make_env,
+            obs_spec=MINERL_OBS_SPEC,
+            head_names=["action"],
+            discrete_actions=DISCRETE_ACTIONS,
+            weights_file=weights_file,
+            reward_config_file=reward_cfg_file,
+            save_results_fn=save_experiment_results,
+            game_name=self.name,
+        )
+
+    def build_probe(self, training_params: dict) -> ProbeSpec | None:
+        return None
+
+    def build_warmup(self, training_params: dict) -> WarmupSpec | None:
+        return None
+
+
+def make_adapter() -> MineRLAdapter:
+    return MineRLAdapter()

--- a/games/minerl/analytics.py
+++ b/games/minerl/analytics.py
@@ -1,0 +1,62 @@
+"""MineRL-specific analytics.
+
+Entry point called by main.py:
+    save_experiment_results(data: ExperimentData, results_dir: str) -> None
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from framework.analytics import (
+    ExperimentData,
+    _cold_start_table_md,
+    _greedy_table_md,
+    _probe_table_md,
+    _summary_md,
+    _timings_md,
+    plot_cold_start_rewards,
+    plot_greedy_rewards,
+    plot_probe_rewards,
+    plot_reward_trajectory,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def save_experiment_results(data: ExperimentData, results_dir: str) -> None:
+    """Generate all plots and write a results.md report to *results_dir*."""
+    os.makedirs(results_dir, exist_ok=True)
+
+    sections = [
+        f"# Experiment: {data.experiment_name}\n\n**Game:** MineRL\n\n",
+        _timings_md(data),
+        _summary_md(data),
+    ]
+
+    if data.probe_results:
+        plot_probe_rewards(data, results_dir)
+        sections.append(_probe_table_md(data))
+        sections.append("\n![Probe rewards](probe_rewards.png)\n\n")
+
+    if data.cold_start_restarts:
+        plot_cold_start_rewards(data, results_dir)
+        sections.append(_cold_start_table_md(data))
+        sections.append("\n![Cold-start best rewards](cold_start_best_rewards.png)\n\n")
+
+    if data.greedy_sims:
+        plot_greedy_rewards(data, results_dir)
+        sections.append(_greedy_table_md(data))
+        sections.append("\n![Greedy rewards](greedy_rewards.png)\n\n")
+
+    plot_reward_trajectory(data, results_dir)
+    sections.append("## Additional Plots\n\n")
+    sections.append("![Reward trajectory](reward_trajectory.png)\n\n")
+
+    report_path = os.path.join(results_dir, "results.md")
+    with open(report_path, "w", encoding="utf-8") as f:
+        f.write("".join(sections).rstrip("\n") + "\n")
+
+    n = len(os.listdir(results_dir))
+    logger.info("Saved %d file(s) to %s/ (report: results.md)", n, results_dir)

--- a/games/minerl/config/reward_config.yaml
+++ b/games/minerl/config/reward_config.yaml
@@ -1,0 +1,10 @@
+# Reward configuration for MineRL. See games/minerl/README.md for full documentation.
+
+# native signal
+native_reward_scale: 1.0
+
+# time
+step_penalty: -0.001
+
+# finish
+finish_bonus: 100.0

--- a/games/minerl/config/training_params.yaml
+++ b/games/minerl/config/training_params.yaml
@@ -1,0 +1,15 @@
+# MineRL training parameters. See games/minerl/README.md for full documentation.
+
+map_name: MineRLNavigateDense-v0
+in_game_episode_s: 120.0
+n_sims: 100
+mutation_scale: 0.05
+mutation_share: 1.0
+adaptive_mutation: true
+patience: 0
+
+policy_type: genetic
+
+policy_params:
+  population_size: 10
+  elite_k: 3

--- a/games/minerl/env.py
+++ b/games/minerl/env.py
@@ -24,8 +24,8 @@ import numpy as np
 
 # Optional dependency — raises ImportError if minerl is not installed.
 try:
-    import minerl  # noqa: F401
     import gymnasium as gym
+    import minerl  # noqa: F401
 except ImportError as _exc:
     raise ImportError(
         "MineRL requires the 'minerl' package and Java 8+.  Install with:\n"
@@ -36,7 +36,7 @@ except ImportError as _exc:
 from gymnasium import spaces
 
 from framework.base_env import BaseGameEnv
-from games.minerl.actions import N_ACTIONS, _ACTION_OVERRIDES
+from games.minerl.actions import _ACTION_OVERRIDES, N_ACTIONS
 from games.minerl.obs_spec import BASE_OBS_DIM
 from games.minerl.reward import MineRLRewardCalculator, MineRLRewardConfig
 

--- a/games/minerl/env.py
+++ b/games/minerl/env.py
@@ -1,0 +1,218 @@
+"""MineRL environment wrapper (Phase 1: vector observations).
+
+Wraps a MineRL Gymnasium-compatible environment and converts the obs dict
+into a compact feature vector compatible with the framework's policy zoo.
+
+Requires the ``minerl`` package and Java 8+::
+
+    pip install minerl
+
+See ``games/minerl/README.md`` for full setup instructions.
+
+If ``minerl`` is not installed, importing this module raises ``ImportError``.
+The entry point in ``main.py`` converts that to a ``ValueError`` with a
+helpful message.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+# Optional dependency — raises ImportError if minerl is not installed.
+try:
+    import minerl  # noqa: F401
+    import gymnasium as gym
+except ImportError as _exc:
+    raise ImportError(
+        "MineRL requires the 'minerl' package and Java 8+.  Install with:\n"
+        "    pip install minerl\n"
+        "See games/minerl/README.md for full setup instructions."
+    ) from _exc
+
+from gymnasium import spaces
+
+from framework.base_env import BaseGameEnv
+from games.minerl.actions import N_ACTIONS, _ACTION_OVERRIDES
+from games.minerl.obs_spec import BASE_OBS_DIM
+from games.minerl.reward import MineRLRewardCalculator, MineRLRewardConfig
+
+logger = logging.getLogger(__name__)
+
+#: Default frames per second for MineRL envs (used for time limit conversion).
+_MINERL_FPS: float = 20.0
+
+
+class MineRLEnv(BaseGameEnv):
+    """Gymnasium wrapper around a MineRL environment.
+
+    Converts the MineRL obs dict into a compact feature vector (compass angle
+    + inventory counts) compatible with the ``WeightedLinearPolicy`` framework.
+
+    Parameters
+    ----------
+    map_name :
+        MineRL environment ID (e.g. ``"MineRLNavigateDense-v0"``).
+    reward_config :
+        ``MineRLRewardConfig`` instance.  If None, uses Python defaults.
+    max_episode_steps :
+        Maximum steps per episode.
+    """
+
+    metadata = {"render_modes": ["human", "rgb_array"]}
+
+    def __init__(
+        self,
+        map_name: str = "MineRLNavigateDense-v0",
+        reward_config: MineRLRewardConfig | None = None,
+        max_episode_steps: int = 2400,
+    ) -> None:
+        super().__init__()
+
+        self._map_name = map_name
+        self._reward_config = reward_config or MineRLRewardConfig()
+        self._reward_calc = MineRLRewardCalculator(self._reward_config)
+        self._max_episode_steps = max_episode_steps
+
+        self._env = gym.make(map_name, max_episode_steps=max_episode_steps)
+        self._noop_action: dict = self._build_noop()
+
+        self.observation_space = spaces.Box(
+            low=-np.inf,
+            high=np.inf,
+            shape=(BASE_OBS_DIM,),
+            dtype=np.float32,
+        )
+        self.action_space = spaces.Discrete(N_ACTIONS)
+
+        self._step_count: int = 0
+
+    # ------------------------------------------------------------------
+    # BaseGameEnv contract
+    # ------------------------------------------------------------------
+
+    def reset(
+        self,
+        *,
+        seed: int | None = None,
+        options: dict[str, Any] | None = None,
+    ) -> tuple[np.ndarray, dict]:
+        super().reset(seed=seed)
+        obs_dict, info = self._env.reset(seed=seed, options=options)
+        self._step_count = 0
+        self._reward_calc.reset()
+        return self._flatten_obs(obs_dict), info
+
+    def step(self, action: np.ndarray) -> tuple[np.ndarray, float, bool, bool, dict]:
+        action_idx = int(round(float(action[0]) if hasattr(action, "__len__") else float(action)))
+        action_idx = max(0, min(action_idx, N_ACTIONS - 1))
+        minerl_action = self._decode_action(action_idx)
+
+        result = self._env.step(minerl_action)
+        # Handle both gymnasium 5-tuple and legacy MineRL 4-tuple returns.
+        if len(result) == 5:
+            obs_dict, native_reward, terminated, truncated, info = result
+        else:
+            obs_dict, native_reward, done, info = result
+            terminated, truncated = done, False
+
+        self._step_count += 1
+        if self._step_count >= self._max_episode_steps:
+            truncated = True
+
+        info["native_reward"] = float(native_reward)
+        info.setdefault("termination_reason", None)
+        if terminated:
+            info["termination_reason"] = "finish"
+        elif truncated:
+            info["termination_reason"] = "timeout"
+
+        reward = self._reward_calc.compute(
+            prev_state=None,
+            curr_state=None,
+            finished=terminated,
+            elapsed_s=self._step_count / _MINERL_FPS,
+            info=info,
+        )
+
+        return self._flatten_obs(obs_dict), reward, terminated, truncated, info
+
+    def close(self) -> None:
+        self._env.close()
+
+    def _build_obs(self, step: Any) -> np.ndarray:
+        return np.zeros(BASE_OBS_DIM, dtype=np.float32)
+
+    def get_episode_time_limit(self) -> float:
+        return float(self._max_episode_steps) / _MINERL_FPS
+
+    def set_episode_time_limit(self, seconds: float) -> None:
+        self._max_episode_steps = max(1, int(seconds * _MINERL_FPS))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _build_noop(self) -> dict:
+        """Return a no-op action dict from the env's action space."""
+        if hasattr(self._env.action_space, "noop"):
+            return self._env.action_space.noop()
+        return {
+            "forward": 0,
+            "back": 0,
+            "left": 0,
+            "right": 0,
+            "jump": 0,
+            "sprint": 0,
+            "sneak": 0,
+            "attack": 0,
+            "camera": [0.0, 0.0],
+            "place": "none",
+            "craft": "none",
+            "equip": "none",
+            "nearbyCraft": "none",
+            "nearbySmelt": "none",
+        }
+
+    def _decode_action(self, action_idx: int) -> dict:
+        """Convert a discrete action index to a MineRL action dict."""
+        act = dict(self._noop_action)
+        act.update(_ACTION_OVERRIDES[action_idx])
+        # Only pass keys present in the env's action space to avoid KeyErrors.
+        if hasattr(self._env.action_space, "spaces"):
+            act = {k: v for k, v in act.items() if k in self._env.action_space.spaces}
+        return act
+
+    def _flatten_obs(self, obs_dict: dict) -> np.ndarray:
+        """Flatten MineRL obs dict into a float32 array matching MINERL_OBS_SPEC."""
+        compass = float(obs_dict.get("compassAngle", 0.0))
+        inv = obs_dict.get("inventory", {})
+        inv_dirt = float(inv.get("dirt", 0))
+        inv_log = float(inv.get("log", 0))
+        return np.array(
+            [compass / 180.0, inv_dirt / 64.0, inv_log / 64.0],
+            dtype=np.float32,
+        )
+
+
+def make_env(
+    experiment_dir: str | Path,
+    map_name: str = "MineRLNavigateDense-v0",
+    max_episode_time_s: float = 120.0,
+) -> MineRLEnv:
+    """Factory that wires up a MineRLEnv from an experiment directory."""
+    experiment_dir = Path(experiment_dir)
+    reward_cfg_path = experiment_dir / "reward_config.yaml"
+    if reward_cfg_path.exists():
+        reward_config = MineRLRewardConfig.from_yaml(str(reward_cfg_path))
+    else:
+        reward_config = MineRLRewardConfig()
+    max_steps = max(1, int(max_episode_time_s * _MINERL_FPS))
+    return MineRLEnv(
+        map_name=map_name,
+        reward_config=reward_config,
+        max_episode_steps=max_steps,
+    )

--- a/games/minerl/obs_spec.py
+++ b/games/minerl/obs_spec.py
@@ -1,0 +1,37 @@
+"""MineRL observation space definition (Phase 1: vector obs only).
+
+Phase 1 uses a compact feature vector derived from the MineRL obs dict.
+Pixel observations (``pov``) are not included; that is deferred to Phase 2
+once a CNN policy is available for non-SC2 games.
+
+Supported environments:
+  - MineRLNavigateDense-v0  (compass angle + dirt inventory)
+  - MineRLTreechop-v0       (log inventory)
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from framework.obs_spec import ObsDim, ObsSpec
+
+_MINERL_DIMS: list[ObsDim] = [
+    ObsDim("compass_angle", 180.0, "Compass bearing to goal in degrees [-180, 180]"),
+    ObsDim("inventory_dirt", 64.0, "Dirt blocks in inventory [0, 64]"),
+    ObsDim("inventory_log", 64.0, "Log blocks in inventory [0, 64]"),
+]
+
+#: The canonical MineRL observation spec.
+MINERL_OBS_SPEC: ObsSpec = ObsSpec(_MINERL_DIMS)
+
+#: Number of base observation features.
+BASE_OBS_DIM: int = MINERL_OBS_SPEC.dim
+
+#: Ordered list of feature names.
+OBS_NAMES: list[str] = MINERL_OBS_SPEC.names
+
+#: Float32 scale array, shape (BASE_OBS_DIM,).
+OBS_SCALES: np.ndarray = MINERL_OBS_SPEC.scales
+
+#: Plain OBS_SPEC list for callers that iterate over ObsDim entries.
+OBS_SPEC: list[ObsDim] = _MINERL_DIMS

--- a/games/minerl/reward.py
+++ b/games/minerl/reward.py
@@ -1,0 +1,55 @@
+"""MineRL reward configuration and calculator."""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Any
+
+import yaml
+
+
+@dataclasses.dataclass
+class MineRLRewardConfig:
+    """Reward hyperparameters for MineRL training.
+
+    MineRL environments provide a native dense or sparse reward signal.
+    This config scales the native signal and adds optional shaping terms.
+    """
+
+    native_reward_scale: float = 1.0
+    step_penalty: float = -0.001
+    finish_bonus: float = 100.0
+
+    @classmethod
+    def from_yaml(cls, path: str) -> "MineRLRewardConfig":
+        with open(path) as f:
+            d = yaml.safe_load(f) or {}
+        return cls(**{k: v for k, v in d.items() if k in cls.__dataclass_fields__})
+
+
+class MineRLRewardCalculator:
+    """Stateful reward calculator for MineRL episodes."""
+
+    def __init__(self, config: MineRLRewardConfig) -> None:
+        self._cfg = config
+        self._total_native_reward: float = 0.0
+
+    def reset(self) -> None:
+        self._total_native_reward = 0.0
+
+    def compute(
+        self,
+        prev_state: Any,
+        curr_state: Any,
+        finished: bool,
+        elapsed_s: float,
+        info: dict,
+    ) -> float:
+        native = float(info.get("native_reward", 0.0))
+        self._total_native_reward += native
+
+        reward = self._cfg.native_reward_scale * native
+        reward += self._cfg.step_penalty
+        if finished:
+            reward += self._cfg.finish_bonus
+        return float(reward)

--- a/tests/README.md
+++ b/tests/README.md
@@ -79,6 +79,10 @@
   - [test\_framework\_bc.py — `BCAdapter` Protocol + `framework.bc.run` orchestrator (issue #393)](#test_framework_bcpy--bcadapter-protocol--frameworkbcrun-orchestrator-issue-393)
 - [TMNF BC](#tmnf-bc)
   - [test\_tmnf\_bc.py — TMNF BC adapter (SimplePolicy source) + `do_pretrain` removal (issue #395)](#test_tmnf_bcpy--tmnf-bc-adapter-simplepolicy-source--do_pretrain-removal-issue-395)
+- [MineRL](#minerl)
+  - [test\_minerl\_obs\_spec.py — MineRL observation spec (3-dim vector)](#test_minerl_obs_specpy--minerl-observation-spec-3-dim-vector)
+  - [test\_minerl\_adapter.py — MineRL game adapter](#test_minerl_adapterpy--minerl-game-adapter)
+  - [test\_minerl\_reward.py — MineRL reward config and calculator](#test_minerl_rewardpy--minerl-reward-config-and-calculator)
 - [Rocket League](#rocket-league)
   - [test\_rocket\_league\_obs\_spec.py — Rocket League observation spec (142-dim)](#test_rocket_league_obs_specpy--rocket-league-observation-spec-142-dim)
   - [test\_rocket\_league\_reward.py — Rocket League reward calc](#test_rocket_league_rewardpy--rocket-league-reward-calc)
@@ -1012,6 +1016,31 @@ episodes.
   `rl/pretrain.py` deleted; legacy `do_pretrain: true` in
   `training_params.yaml` is silently dropped by
   `RunConfig.from_training_params` rather than raising
+
+## MineRL
+
+`games/minerl/` — Phase 1 scaffold for Minecraft RL via MineRL (issue #215).
+
+**Tested.** The 3-dim vector observation spec (compass angle, dirt inventory,
+log inventory); the reward calculator (native reward scaling, step penalty,
+finish bonus, reset clears episode accumulator); and the game adapter
+(registered in `GAME_ADAPTERS`, experiment dir layout, track label with slash
+sanitisation, build_game_spec wires the correct obs_spec / head_names /
+discrete_actions).
+
+**Not tested.** The actual `MineRLEnv` wrapper (requires `minerl` + Java 8
+to be installed); real episode rollouts; MineRL-specific obs dict parsing
+against a live environment.  Full env tests are deferred to the env
+implementation sub-issue (#438).
+
+### test_minerl_obs_spec.py — MineRL observation spec (3-dim vector)
+- dim=3; names length=3; names unique; `compass_angle`, `inventory_dirt`, `inventory_log` present; compass scale=180.0; inventory scales=64.0; all dims carry descriptions
+
+### test_minerl_adapter.py — MineRL game adapter
+- registered under `minerl` key; `name`/`config_dir` correct; `experiment_dir` embeds game/policy/map/run; track override replaces map_name; `track_label` defaults to `MineRLNavigateDense-v0`; sanitises slashes; `build_probe`/`build_warmup` return None; `decorate_reward_cfg` is a no-op; `build_game_spec` returns correct `game_name`/`head_names`/`obs_spec`/`discrete_actions` shape (9,1)
+
+### test_minerl_reward.py — MineRL reward config and calculator
+- config defaults; `from_yaml` loads fields and ignores unknown keys; `compute` scales native reward, applies step penalty, adds finish bonus on termination only; missing `native_reward` defaults to 0.0; `reset()` clears `_total_native_reward` accumulator
 
 ## Rocket League
 

--- a/tests/test_game_adapter.py
+++ b/tests/test_game_adapter.py
@@ -32,6 +32,7 @@ class TestGameAdapterRegistry:
             "rocket_league",
             "iracing",
             "atari",
+            "minerl",
         }
 
 

--- a/tests/test_minerl_adapter.py
+++ b/tests/test_minerl_adapter.py
@@ -1,0 +1,109 @@
+"""Tests for the MineRL game adapter."""
+
+from __future__ import annotations
+
+import unittest
+
+from framework.game_adapter import GAME_ADAPTERS
+
+
+class TestMineRLAdapter(unittest.TestCase):
+    def _adapter(self):
+        return GAME_ADAPTERS["minerl"]()
+
+    def test_adapter_registered(self):
+        self.assertIn("minerl", GAME_ADAPTERS)
+
+    def test_adapter_name_and_config_dir(self):
+        a = self._adapter()
+        self.assertEqual(a.name, "minerl")
+        self.assertEqual(a.config_dir, "games/minerl/config")
+
+    def test_experiment_dir_embeds_game_policy_and_map(self):
+        a = self._adapter()
+        d = a.experiment_dir(
+            "myrun",
+            {"map_name": "MineRLNavigateDense-v0", "policy_type": "genetic"},
+            None,
+        )
+        self.assertIn("minerl", d)
+        self.assertIn("genetic", d)
+        self.assertIn("MineRLNavigateDense-v0", d)
+        self.assertIn("myrun", d)
+
+    def test_track_override_replaces_map_name(self):
+        a = self._adapter()
+        d = a.experiment_dir(
+            "myrun",
+            {"map_name": "MineRLNavigateDense-v0", "policy_type": "genetic"},
+            "MineRLTreechop-v0",
+        )
+        self.assertIn("MineRLTreechop-v0", d)
+        self.assertNotIn("MineRLNavigateDense-v0", d)
+
+    def test_track_label_default(self):
+        a = self._adapter()
+        self.assertEqual(
+            a.track_label({"map_name": "MineRLNavigateDense-v0"}, None),
+            "MineRLNavigateDense-v0",
+        )
+
+    def test_track_label_falls_back_when_no_map_name(self):
+        a = self._adapter()
+        self.assertEqual(a.track_label({}, None), "MineRLNavigateDense-v0")
+
+    def test_track_label_sanitizes_slash(self):
+        a = self._adapter()
+        label = a.track_label({"map_name": "MineRL/Navigate-v0"}, None)
+        self.assertNotIn("/", label)
+        self.assertEqual(label, "MineRL_Navigate-v0")
+
+    def test_build_probe_returns_none(self):
+        a = self._adapter()
+        self.assertIsNone(a.build_probe({}))
+
+    def test_build_warmup_returns_none(self):
+        a = self._adapter()
+        self.assertIsNone(a.build_warmup({}))
+
+    def test_decorate_reward_cfg_is_noop(self):
+        a = self._adapter()
+        cfg = {"native_reward_scale": 1.0}
+        a.decorate_reward_cfg(cfg, {"map_name": "MineRLNavigateDense-v0"}, None)
+        self.assertEqual(cfg, {"native_reward_scale": 1.0})
+
+    def test_experiment_dir_root(self):
+        a = self._adapter()
+        root = a.experiment_dir_root(
+            {"map_name": "MineRLNavigateDense-v0", "policy_type": "genetic"},
+            None,
+        )
+        self.assertIn("minerl", root)
+        self.assertIn("MineRLNavigateDense-v0", root)
+
+    def test_build_game_spec_structure(self):
+        from games.minerl.obs_spec import MINERL_OBS_SPEC
+
+        a = self._adapter()
+        spec = a.build_game_spec(
+            experiment_name="myrun",
+            experiment_dir="experiments/minerl/genetic/MineRLNavigateDense-v0/myrun",
+            weights_file="experiments/minerl/genetic/MineRLNavigateDense-v0/myrun/policy_weights.yaml",
+            reward_cfg_file="experiments/minerl/genetic/MineRLNavigateDense-v0/myrun/reward_config.yaml",
+            training_params={
+                "map_name": "MineRLNavigateDense-v0",
+                "in_game_episode_s": 120.0,
+                "policy_type": "genetic",
+            },
+            track_override=None,
+        )
+        self.assertEqual(spec.game_name, "minerl")
+        self.assertEqual(spec.head_names, ["action"])
+        self.assertIs(spec.obs_spec, MINERL_OBS_SPEC)
+        self.assertEqual(spec.discrete_actions.shape, (9, 1))
+        self.assertTrue(callable(spec.make_env_fn))
+        self.assertTrue(callable(spec.save_results_fn))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minerl_obs_spec.py
+++ b/tests/test_minerl_obs_spec.py
@@ -1,0 +1,56 @@
+"""Tests for the MineRL observation spec (vector obs, Phase 1)."""
+
+from __future__ import annotations
+
+import unittest
+
+import numpy as np
+
+from games.minerl.obs_spec import (
+    BASE_OBS_DIM,
+    MINERL_OBS_SPEC,
+    OBS_NAMES,
+    OBS_SCALES,
+    OBS_SPEC,
+)
+
+
+class TestMineRLObsSpec(unittest.TestCase):
+    def test_dim_is_3(self):
+        self.assertEqual(BASE_OBS_DIM, 3)
+        self.assertEqual(MINERL_OBS_SPEC.dim, 3)
+
+    def test_obs_names_match_dim(self):
+        self.assertEqual(len(OBS_NAMES), BASE_OBS_DIM)
+
+    def test_obs_names_are_unique(self):
+        self.assertEqual(len(set(OBS_NAMES)), len(OBS_NAMES))
+
+    def test_obs_names_expected(self):
+        self.assertIn("compass_angle", OBS_NAMES)
+        self.assertIn("inventory_dirt", OBS_NAMES)
+        self.assertIn("inventory_log", OBS_NAMES)
+
+    def test_scales_shape_and_dtype(self):
+        self.assertEqual(OBS_SCALES.shape, (BASE_OBS_DIM,))
+        self.assertEqual(OBS_SCALES.dtype, np.float32)
+
+    def test_compass_scale_is_180(self):
+        compass_idx = OBS_NAMES.index("compass_angle")
+        self.assertEqual(OBS_SCALES[compass_idx], 180.0)
+
+    def test_inventory_scales_are_64(self):
+        for name in ("inventory_dirt", "inventory_log"):
+            idx = OBS_NAMES.index(name)
+            self.assertEqual(OBS_SCALES[idx], 64.0)
+
+    def test_dims_carry_descriptions(self):
+        for dim in OBS_SPEC:
+            self.assertTrue(dim.description)
+
+    def test_obs_spec_list_length(self):
+        self.assertEqual(len(OBS_SPEC), BASE_OBS_DIM)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minerl_reward.py
+++ b/tests/test_minerl_reward.py
@@ -1,0 +1,89 @@
+"""Tests for the MineRL reward configuration and calculator."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+
+import yaml
+
+from games.minerl.reward import MineRLRewardCalculator, MineRLRewardConfig
+
+
+class TestMineRLRewardConfig(unittest.TestCase):
+    def test_defaults(self):
+        cfg = MineRLRewardConfig()
+        self.assertEqual(cfg.native_reward_scale, 1.0)
+        self.assertEqual(cfg.step_penalty, -0.001)
+        self.assertEqual(cfg.finish_bonus, 100.0)
+
+    def test_from_yaml(self):
+        data = {
+            "native_reward_scale": 2.0,
+            "step_penalty": -0.01,
+            "finish_bonus": 200.0,
+        }
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump(data, f)
+            path = f.name
+
+        cfg = MineRLRewardConfig.from_yaml(path)
+        self.assertEqual(cfg.native_reward_scale, 2.0)
+        self.assertEqual(cfg.step_penalty, -0.01)
+        self.assertEqual(cfg.finish_bonus, 200.0)
+
+    def test_from_yaml_ignores_unknown_keys(self):
+        data = {"native_reward_scale": 0.5, "unknown_key": 99}
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as f:
+            yaml.dump(data, f)
+            path = f.name
+
+        cfg = MineRLRewardConfig.from_yaml(path)
+        self.assertEqual(cfg.native_reward_scale, 0.5)
+        # Defaults preserved for keys not in the file.
+        self.assertEqual(cfg.step_penalty, -0.001)
+
+
+class TestMineRLRewardCalculator(unittest.TestCase):
+    def _calc(self, **kwargs) -> MineRLRewardCalculator:
+        return MineRLRewardCalculator(MineRLRewardConfig(**kwargs))
+
+    def test_native_reward_scaled(self):
+        calc = self._calc(native_reward_scale=2.0, step_penalty=0.0, finish_bonus=0.0)
+        reward = calc.compute(None, None, False, 0.0, {"native_reward": 3.0})
+        self.assertAlmostEqual(reward, 6.0)
+
+    def test_step_penalty_applied_every_step(self):
+        calc = self._calc(native_reward_scale=0.0, step_penalty=-0.5, finish_bonus=0.0)
+        reward = calc.compute(None, None, False, 0.0, {"native_reward": 0.0})
+        self.assertAlmostEqual(reward, -0.5)
+
+    def test_finish_bonus_added_on_termination(self):
+        calc = self._calc(native_reward_scale=0.0, step_penalty=0.0, finish_bonus=50.0)
+        reward = calc.compute(None, None, True, 1.0, {"native_reward": 0.0})
+        self.assertAlmostEqual(reward, 50.0)
+
+    def test_no_finish_bonus_when_not_terminated(self):
+        calc = self._calc(native_reward_scale=0.0, step_penalty=0.0, finish_bonus=50.0)
+        reward = calc.compute(None, None, False, 1.0, {"native_reward": 0.0})
+        self.assertAlmostEqual(reward, 0.0)
+
+    def test_missing_native_reward_defaults_to_zero(self):
+        calc = self._calc(native_reward_scale=1.0, step_penalty=0.0, finish_bonus=0.0)
+        reward = calc.compute(None, None, False, 0.0, {})
+        self.assertAlmostEqual(reward, 0.0)
+
+    def test_reset_clears_episode_state(self):
+        calc = self._calc(native_reward_scale=1.0, step_penalty=0.0, finish_bonus=0.0)
+        calc.compute(None, None, False, 0.0, {"native_reward": 10.0})
+        self.assertAlmostEqual(calc._total_native_reward, 10.0)
+        calc.reset()
+        self.assertAlmostEqual(calc._total_native_reward, 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_minerl_reward.py
+++ b/tests/test_minerl_reward.py
@@ -23,9 +23,7 @@ class TestMineRLRewardConfig(unittest.TestCase):
             "step_penalty": -0.01,
             "finish_bonus": 200.0,
         }
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump(data, f)
             path = f.name
 
@@ -36,9 +34,7 @@ class TestMineRLRewardConfig(unittest.TestCase):
 
     def test_from_yaml_ignores_unknown_keys(self):
         data = {"native_reward_scale": 0.5, "unknown_key": 99}
-        with tempfile.NamedTemporaryFile(
-            mode="w", suffix=".yaml", delete=False
-        ) as f:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
             yaml.dump(data, f)
             path = f.name
 


### PR DESCRIPTION
Closes #437
Refs #215

## Summary

- Adds the `games/minerl/` package scaffold: adapter, env, obs_spec, actions, reward, analytics, and default config files — following the same pattern as `games/car_racing/` and `games/atari/`
- Registers `"minerl"` in `GAME_ADAPTERS` (lazy import, so no `minerl` install required at framework load time)
- Phase 1 uses a 3-dim vector observation (compass angle + dirt/log inventory) so existing linear/genetic/CMA-ES policies work without a CNN

## Feature details

- **User problem:** No Minecraft RL integration exists in the framework; issue #215 calls for one modelled after the car_racing adapter.
- **Proposed solution:** Phase 1 scaffold with vector obs (no pixels). The `MineRLEnv` raises a helpful `ImportError` if `minerl` + Java 8 are not installed; the adapter, obs_spec, reward, and analytics are importable without `minerl`. Phase 2 (full env implementation, #438) follows.
- **Trade-offs / follow-ups:** Pixel obs deferred to Phase 2 (#438); CI smoke test deferred to #441; README docs deferred to #440.

## Validation

```bash
python -m pytest tests/test_minerl_obs_spec.py tests/test_minerl_adapter.py tests/test_minerl_reward.py -v
# 30 passed in 0.26s

python -c "from framework.game_adapter import GAME_ADAPTERS; assert 'minerl' in GAME_ADAPTERS; print('OK')"
# OK

pre-commit run --all-files
# all checks passed
```

## Checklist
### Release bump type

- [x] Minor

### AI usage

- [x] AI was used to write/generate some or all of this code

**If AI was used:** Claude Sonnet 4.6 for the initial implementation

**Human involvement:** Automated session via Claude Code; all tests pass and pre-commit is clean.

## Notes for the reviewer

- [x] Updated `tests/README.md` — added MineRL section with tested/not-tested breakdown
- [x] Added an entry under `## [Unreleased]` in `CHANGELOG.md`
- [x] New config keys appear in `games/minerl/config/reward_config.yaml` with sensible defaults
- [x] Scope is limited to this sub-issue (#437); full env implementation is #438
- [x] No secrets, large binaries, or experiment outputs committed

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCu3Ef44WdM6C8mttebDTg)_