### PR TITLE
feat(atari): add return analytics plots

### DIFF
--- a/games/atari/analytics.py
+++ b/games/atari/analytics.py
@@ -4,14 +4,29 @@ Entry point called by main.py::
 
     save_experiment_results(data: ExperimentData, results_dir: str) -> None
 
-Atari games don't expose centreline-style spatial geometry, so the report is
-intentionally minimal: framework-wide reward plots + a results.md summary.
+Atari games expose 128-byte RAM observations and a small discrete action set,
+so the report focuses on return, episode length, and action-choice behaviour
+rather than centreline-style spatial geometry.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+
+try:
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
+    import matplotlib.cm as cm
+    import matplotlib.pyplot as plt
+    from matplotlib.figure import Figure
+
+    _HAS_MPL = True
+except ImportError:
+    _HAS_MPL = False
+
+import numpy as np
 
 from framework.analytics import (
     ExperimentData,
@@ -27,6 +42,124 @@ from framework.analytics import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _save(fig: "Figure", path: str) -> None:
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def plot_episode_returns(data: ExperimentData, results_dir: str) -> bool:
+    """Plot un-clipped native-score returns with a best-so-far curve."""
+    if not _HAS_MPL or not data.greedy_sims:
+        return False
+
+    sims = [s.sim for s in data.greedy_sims]
+    returns = [s.reward for s in data.greedy_sims]
+    best_so_far: list[float] = []
+    running_best = float("-inf")
+    for score in returns:
+        running_best = max(running_best, score)
+        best_so_far.append(running_best)
+
+    fig, ax = plt.subplots(figsize=(max(8, len(sims) * 0.15), 5))
+    ax.plot(sims, returns, color="#3498db", linewidth=1.2, marker="o", markersize=3, label="episode return")
+    ax.step(sims, best_so_far, where="post", color="#e67e22", linewidth=2.0, label="best so far")
+    improved_xs = [s.sim for s in data.greedy_sims if s.improved]
+    improved_ys = [s.reward for s in data.greedy_sims if s.improved]
+    if improved_xs:
+        ax.scatter(improved_xs, improved_ys, color="#27ae60", s=50, marker="^", zorder=4, label="improved")
+    ax.set_title(f"{data.experiment_name} — Atari Episode Return")
+    ax.set_xlabel("Simulation")
+    ax.set_ylabel("Episode return")
+    ax.legend(fontsize=9)
+    fig.tight_layout()
+    _save(fig, os.path.join(results_dir, "atari_episode_returns.png"))
+    return True
+
+
+def plot_episode_lengths(data: ExperimentData, results_dir: str) -> bool:
+    """Plot episode length in environment steps for each greedy sim."""
+    if not _HAS_MPL or not data.greedy_sims:
+        return False
+
+    sims = [s.sim for s in data.greedy_sims]
+    lengths = [s.total_steps for s in data.greedy_sims]
+    fig, ax = plt.subplots(figsize=(max(8, len(sims) * 0.15), 4))
+    ax.plot(sims, lengths, color="#8e44ad", linewidth=1.2, marker="o", markersize=3)
+    improved_xs = [s.sim for s in data.greedy_sims if s.improved]
+    improved_ys = [s.total_steps for s in data.greedy_sims if s.improved]
+    if improved_xs:
+        ax.scatter(improved_xs, improved_ys, color="#27ae60", s=50, marker="^", zorder=4, label="improved")
+        ax.legend(fontsize=9)
+    ax.set_title(f"{data.experiment_name} — Atari Episode Length")
+    ax.set_xlabel("Simulation")
+    ax.set_ylabel("Steps")
+    fig.tight_layout()
+    _save(fig, os.path.join(results_dir, "atari_episode_lengths.png"))
+    return True
+
+
+def _normalized_action_counts(action_counts: dict | None) -> dict[int, int]:
+    normalized: dict[int, int] = {}
+    for action_id, count in (action_counts or {}).items():
+        try:
+            normalized[int(action_id)] = normalized.get(int(action_id), 0) + int(count)
+        except (TypeError, ValueError):
+            continue
+    return normalized
+
+
+def plot_action_histogram(data: ExperimentData, results_dir: str) -> bool:
+    """Plot aggregate action choices over the greedy phase."""
+    if not _HAS_MPL:
+        return False
+    sim_counts = [_normalized_action_counts(s.action_counts) for s in data.greedy_sims]
+    sim_counts = [counts for counts in sim_counts if counts]
+    if not sim_counts:
+        return False
+
+    action_ids = sorted({action_id for counts in sim_counts for action_id in counts})
+    totals = [sum(counts.get(action_id, 0) for counts in sim_counts) for action_id in action_ids]
+    if not any(totals):
+        return False
+
+    fig, ax = plt.subplots(figsize=(max(8, len(action_ids) * 0.55), 4))
+    colors = cm.tab20(np.linspace(0, 1, max(len(action_ids), 1)))
+    ax.bar([str(action_id) for action_id in action_ids], totals, color=colors, edgecolor="white", linewidth=0.6)
+    ax.set_title(f"{data.experiment_name} — Atari Action Histogram")
+    ax.set_xlabel("Action index")
+    ax.set_ylabel("Steps")
+    fig.tight_layout()
+    _save(fig, os.path.join(results_dir, "atari_action_histogram.png"))
+    return True
+
+
+def _atari_summary_md(data: ExperimentData) -> str:
+    sims = data.greedy_sims
+    if not sims:
+        return ""
+
+    returns = [s.reward for s in sims]
+    lengths = [s.total_steps for s in sims]
+    lines = [
+        "## Atari Metrics\n\n",
+        "| Metric | Value |\n",
+        "|--------|-------|\n",
+        f"| Best episode return | {max(returns):+.1f} |\n",
+        f"| Mean episode return | {float(np.mean(returns)):+.1f} |\n",
+        f"| Mean episode length | {float(np.mean(lengths)):.1f} steps |\n",
+    ]
+
+    aggregate_counts: dict[int, int] = {}
+    for sim in sims:
+        for action_id, count in _normalized_action_counts(sim.action_counts).items():
+            aggregate_counts[action_id] = aggregate_counts.get(action_id, 0) + count
+    total = sum(aggregate_counts.values())
+    if total > 0:
+        top_action, top_count = max(aggregate_counts.items(), key=lambda item: item[1])
+        lines.append(f"| Most-used action | {top_action} ({top_count / total:.1%} of steps) |\n")
+    return "".join(lines) + "\n"
 
 
 def save_experiment_results(data: ExperimentData, results_dir: str) -> None:
@@ -55,7 +188,17 @@ def save_experiment_results(data: ExperimentData, results_dir: str) -> None:
         sections.append("\n![Greedy rewards](greedy_rewards.png)\n\n")
 
     plot_reward_trajectory(data, results_dir)
+    wrote_episode_returns = plot_episode_returns(data, results_dir)
+    wrote_episode_lengths = plot_episode_lengths(data, results_dir)
+    wrote_action_histogram = plot_action_histogram(data, results_dir)
+    sections.append(_atari_summary_md(data))
     sections.append("## Additional Plots\n\n")
+    if wrote_episode_returns:
+        sections.append("![Atari episode return](atari_episode_returns.png)\n\n")
+    if wrote_episode_lengths:
+        sections.append("![Atari episode length](atari_episode_lengths.png)\n\n")
+    if wrote_action_histogram:
+        sections.append("![Atari action histogram](atari_action_histogram.png)\n\n")
     sections.append("![Reward trajectory](reward_trajectory.png)\n\n")
 
     report_path = os.path.join(results_dir, "results.md")

--- a/games/atari/env.py
+++ b/games/atari/env.py
@@ -134,6 +134,7 @@ class AtariEnv(BaseGameEnv):
         )
 
         self._step_count: int = 0
+        self._episode_action_counts: dict[int, int] = {}
 
     # ------------------------------------------------------------------
     # Properties
@@ -161,6 +162,7 @@ class AtariEnv(BaseGameEnv):
         super().reset(seed=seed)
         raw_obs, info = self._env.reset(seed=seed, options=options)
         self._step_count = 0
+        self._episode_action_counts = {}
         self._reward_calc.reset()
         return self._build_obs(raw_obs), info
 
@@ -171,6 +173,10 @@ class AtariEnv(BaseGameEnv):
 
         info["native_reward"] = float(native_reward)
         info["action_index"] = idx
+        self._episode_action_counts[idx] = self._episode_action_counts.get(idx, 0) + 1
+        if terminated or truncated:
+            info["episode_action_counts"] = dict(self._episode_action_counts)
+            info["episode_action_name_map"] = {i: f"action_{i}" for i in range(self._n_legal_actions)}
         info.setdefault("termination_reason", None)
         if terminated:
             info["termination_reason"] = "finish"

--- a/tests/test_atari_analytics.py
+++ b/tests/test_atari_analytics.py
@@ -1,0 +1,61 @@
+"""Tests for Atari-specific analytics output."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from framework.analytics import ExperimentData, GreedySimResult
+from games.atari.analytics import save_experiment_results
+
+
+class TestAtariAnalytics(unittest.TestCase):
+    def test_results_report_includes_return_length_and_action_artifacts(self):
+        data = ExperimentData(
+            experiment_name="atari-smoke",
+            probe_results=[],
+            cold_start_restarts=[],
+            greedy_sims=[
+                GreedySimResult(
+                    sim=1,
+                    reward=1.0,
+                    improved=True,
+                    throttle_counts=[0, 0, 0],
+                    total_steps=12,
+                    action_counts={0: 2, 1: 10},
+                ),
+                GreedySimResult(
+                    sim=2,
+                    reward=3.0,
+                    improved=True,
+                    throttle_counts=[0, 0, 0],
+                    total_steps=20,
+                    action_counts={1: 5, 2: 15},
+                ),
+            ],
+            probe_floor=None,
+            weights_file="policy_weights.yaml",
+            reward_config_file="reward_config.yaml",
+            training_params={},
+            timings={"start": "s", "end": "e", "total_s": 1.0, "probe_s": None, "cold_start_s": None, "greedy_s": 1.0},
+            track="Pong-v5",
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            save_experiment_results(data, tmp)
+            report = Path(tmp, "results.md").read_text(encoding="utf-8")
+
+            self.assertIn("## Atari Metrics", report)
+            self.assertIn("Best episode return", report)
+            self.assertIn("Mean episode length", report)
+            self.assertIn("atari_episode_returns.png", report)
+            self.assertIn("atari_episode_lengths.png", report)
+            self.assertIn("atari_action_histogram.png", report)
+            self.assertTrue(Path(tmp, "atari_episode_returns.png").exists())
+            self.assertTrue(Path(tmp, "atari_episode_lengths.png").exists())
+            self.assertTrue(Path(tmp, "atari_action_histogram.png").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_atari_env.py
+++ b/tests/test_atari_env.py
@@ -98,6 +98,20 @@ class TestAtariEnvBasics(unittest.TestCase):
             self.assertIn("native_reward", info)
             self.assertIn("action_index", info)
 
+    def test_terminal_step_reports_episode_action_counts(self):
+        fake = _FakeGymEnv(n_actions=6)
+        with _patched_env_module(fake):
+            from games.atari.env import AtariEnv  # noqa: PLC0415
+
+            env = AtariEnv(map_name="Pong-v5", max_episode_steps=10)
+            env.reset(seed=0)
+            env.step(np.array([1.0], dtype=np.float32))
+            env.step(np.array([3.0], dtype=np.float32))
+            _, _, terminated, truncated, info = env.step(np.array([3.0], dtype=np.float32))
+            self.assertTrue(terminated or truncated)
+            self.assertEqual(info["episode_action_counts"], {1: 1, 3: 2})
+            self.assertEqual(info["episode_action_name_map"][3], "action_3")
+
     def test_episode_terminates_at_step_limit_of_fake_env(self):
         fake = _FakeGymEnv(n_actions=6)
         with _patched_env_module(fake):


### PR DESCRIPTION
## Summary
- Adds Atari-specific episode return, best-so-far, episode-length, and action-histogram analytics artifacts.
- Carries per-episode Atari action counts through env terminal info so training summaries can aggregate action choices.
- Adds focused regression coverage for terminal action counts and generated Atari analytics reports.

## Verification
- `/tmp/bounty_atari_venv/bin/python -m pytest tests/test_atari_env.py tests/test_atari_analytics.py -q` (15 passed)
- `git diff --check`
- added-line security scan: 0 findings
- independent reviewer: passed

Closes #465