### PR TITLE
Exclude graphify-out/ from pre-commit hooks and git merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+graphify-out/**       merge=ours
+graphify-out/**       linguist-generated=true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,9 @@ repos:
       - id: check-yaml
       - id: check-merge-conflict
       - id: end-of-file-fixer
+        exclude: ^graphify-out/
       - id: trailing-whitespace
+        exclude: ^graphify-out/
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.11


### PR DESCRIPTION
## Summary

- Added `.gitattributes` to mark `graphify-out/` as generated code and use `ours` merge strategy
- Updated `.pre-commit-config.yaml` to exclude `graphify-out/` from `end-of-file-fixer` and `trailing-whitespace` hooks

## Refactor / docs / chore details

- What changed:
  - Created `.gitattributes` with two rules for `graphify-out/**`: `merge=ours` (always keep our version in conflicts) and `linguist-generated=true` (mark as generated in GitHub)
  - Added `exclude: ^graphify-out/` to `end-of-file-fixer` and `trailing-whitespace` pre-commit hooks to prevent linting the auto-generated knowledge graph
  
- Why this is safe:
  - The knowledge graph in `graphify-out/` is regenerated by CI on every merge to `main` (as documented in `CLAUDE.md`), so excluding it from pre-commit linting and using `ours` merge strategy prevents unnecessary conflicts and lint failures on generated files
  - This aligns with the project's convention that `graphify-out/` is maintained automatically and should not be manually edited

## Validation

No testing needed — this is a configuration change for pre-commit hooks and git merge behavior.

## Notes for the reviewer

- [x] Scope is limited to this issue/PR
- [x] No secrets, large binaries, or experiment outputs committed

https://claude.ai/code/session_016priS1TsNjscCdiLzw6YRy