### PR TITLE
feat(iracing): add game-appropriate analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@ formatting, internal refactors with no behaviour change — can be skipped.
 
 ## [Unreleased]
 
-
+### Added
+- **iRacing analytics** (`games/iracing/analytics.py`): replaces the 62-line stub with game-appropriate plots — lap-time improvement curve (headline metric, inverted y-axis, best-so-far and DNF markers), per-sim accel/brake distribution, termination-reason bar chart, and obs-average panels for tyre temperatures, tyre loads, fuel level, RPM, and brake bias (panels only emit when `episode_obs_averages` is populated by the env). Adds `## iRacing Metrics` section to `results.md` with finish rate, best/mean lap time, and mean accel %. Closes #463.
+- `tests/test_iracing_analytics.py`: 10 unit tests covering all new analytics functions (plot written / skipped cases, summary-table content, end-to-end report output).
 
 ---
 

--- a/games/iracing/analytics.py
+++ b/games/iracing/analytics.py
@@ -5,14 +5,14 @@ Entry point called by main.py::
     save_experiment_results(data: ExperimentData, results_dir: str) -> None
 
 iRacing exposes the richest telemetry of the racing games (lap times, tyre
-loads/temps, fuel, RPM, gear, brake bias).  The headline metric is lap-time
+loads/temps, fuel, RPM, brake bias).  The headline metric is lap-time
 improvement, and secondary plots cover throttle/brake distribution and
 termination reasons.
 
-Plots that require per-step obs recording (tyre temp/load traces, RPM/gear
-histogram, fuel curve) use ``GreedySimResult.obs_averages`` when the env
-populates ``episode_obs_averages`` in terminal-step info; they are silently
-skipped when that dict is absent.
+Obs-average panels (tyre temps/loads, fuel, RPM, brake bias) use
+``GreedySimResult.obs_averages`` when the env populates
+``episode_obs_averages`` in terminal-step info; they are silently skipped
+when that dict is absent.
 """
 
 from __future__ import annotations
@@ -27,7 +27,6 @@ import numpy as np
 if "matplotlib.pyplot" not in sys.modules:
     matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from framework.analytics import (
@@ -62,20 +61,6 @@ _REASON_ORDER = ["finish", "crash", "timeout"]
 def _save(fig: "Figure", path: str) -> None:
     fig.savefig(path, dpi=150, bbox_inches="tight")
     plt.close(fig)
-
-
-def _plot_throttle_trace(ax: "Axes", throttle_state: list, title: str) -> None:
-    steps = range(len(throttle_state))
-    accel = [t[0] for t in throttle_state]
-    brake = [t[1] for t in throttle_state]
-    ax.plot(steps, accel, color="#27ae60", linewidth=0.8, alpha=0.85, label="accel")
-    ax.plot(steps, brake, color="#c0392b", linewidth=0.8, alpha=0.85, label="brake")
-    ax.set_ylim(-0.05, 1.1)
-    ax.set_yticks([0, 0.5, 1])
-    ax.set_xlabel("Step")
-    ax.set_ylabel("Value")
-    ax.set_title(title, fontsize=9)
-    ax.legend(fontsize=8, loc="upper right")
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +142,7 @@ def plot_lap_time_improvement(data: ExperimentData, results_dir: str) -> bool:
 
 
 def plot_greedy_action_dist(data: ExperimentData, results_dir: str) -> bool:
-    """Plot per-sim accel/brake/coast percentage over the greedy phase."""
+    """Plot per-sim accel and brake percentage over the greedy phase."""
     sims = data.greedy_sims
     if not sims:
         return False

--- a/games/iracing/analytics.py
+++ b/games/iracing/analytics.py
@@ -1,13 +1,34 @@
 """iRacing-specific analytics.
 
-Entry point called by main.py:
+Entry point called by main.py::
+
     save_experiment_results(data: ExperimentData, results_dir: str) -> None
+
+iRacing exposes the richest telemetry of the racing games (lap times, tyre
+loads/temps, fuel, RPM, gear, brake bias).  The headline metric is lap-time
+improvement, and secondary plots cover throttle/brake distribution and
+termination reasons.
+
+Plots that require per-step obs recording (tyre temp/load traces, RPM/gear
+histogram, fuel curve) use ``GreedySimResult.obs_averages`` when the env
+populates ``episode_obs_averages`` in terminal-step info; they are silently
+skipped when that dict is absent.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import sys
+
+import matplotlib
+import numpy as np
+
+if "matplotlib.pyplot" not in sys.modules:
+    matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 from framework.analytics import (
     ExperimentData,
@@ -23,6 +44,332 @@ from framework.analytics import (
 )
 
 logger = logging.getLogger(__name__)
+
+_THROTTLE_COLORS = ["#c0392b", "#95a5a6", "#27ae60"]
+_REASON_COLORS = {
+    "finish": "#27ae60",
+    "crash": "#c0392b",
+    "timeout": "#f39c12",
+}
+_REASON_ORDER = ["finish", "crash", "timeout"]
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _save(fig: "Figure", path: str) -> None:
+    fig.savefig(path, dpi=150, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _plot_throttle_trace(ax: "Axes", throttle_state: list, title: str) -> None:
+    steps = range(len(throttle_state))
+    accel = [t[0] for t in throttle_state]
+    brake = [t[1] for t in throttle_state]
+    ax.plot(steps, accel, color="#27ae60", linewidth=0.8, alpha=0.85, label="accel")
+    ax.plot(steps, brake, color="#c0392b", linewidth=0.8, alpha=0.85, label="brake")
+    ax.set_ylim(-0.05, 1.1)
+    ax.set_yticks([0, 0.5, 1])
+    ax.set_xlabel("Step")
+    ax.set_ylabel("Value")
+    ax.set_title(title, fontsize=9)
+    ax.legend(fontsize=8, loc="upper right")
+
+
+# ---------------------------------------------------------------------------
+# Lap-time improvement (headline metric for iRacing)
+# ---------------------------------------------------------------------------
+
+
+def plot_lap_time_improvement(data: ExperimentData, results_dir: str) -> bool:
+    """Plot finished-lap times over greedy sims with a best-so-far curve.
+
+    Only sims where ``finish_time_s`` is not None (i.e. the episode ended
+    with a completed lap) contribute a data point.  DNF/crash/timeout sims
+    are shown as vertical markers without a lap time value.
+    """
+    sims = data.greedy_sims
+    if not sims:
+        return False
+
+    finished_xs = [s.sim for s in sims if s.finish_time_s is not None]
+    finished_ys = [s.finish_time_s for s in sims if s.finish_time_s is not None]
+    dnf_xs = [s.sim for s in sims if s.finish_time_s is None]
+
+    if not finished_xs:
+        return False
+
+    best_so_far: list[float] = []
+    running_best = float("inf")
+    for t in finished_ys:
+        running_best = min(running_best, t)
+        best_so_far.append(running_best)
+
+    fig, ax = plt.subplots(figsize=(max(8, len(sims) * 0.15), 5))
+    ax.scatter(
+        finished_xs,
+        finished_ys,
+        color="#3498db",
+        s=25,
+        alpha=0.8,
+        zorder=3,
+        label="lap time (finished)",
+    )
+    ax.step(
+        finished_xs,
+        best_so_far,
+        where="post",
+        color="#e67e22",
+        linewidth=2.0,
+        zorder=4,
+        label="best so far",
+    )
+    improved_xs = [s.sim for s in sims if s.improved and s.finish_time_s is not None]
+    improved_ys = [s.finish_time_s for s in sims if s.improved and s.finish_time_s is not None]
+    if improved_xs:
+        ax.scatter(
+            improved_xs,
+            improved_ys,
+            color="#27ae60",
+            s=60,
+            marker="^",
+            zorder=5,
+            label="improvement",
+        )
+    for x in dnf_xs:
+        ax.axvline(x, color="#c0392b", alpha=0.25, linewidth=0.8)
+
+    ax.set_title(f"{data.experiment_name} — iRacing Lap Time Improvement")
+    ax.set_xlabel("Simulation")
+    ax.set_ylabel("Lap time (s)")
+    ax.invert_yaxis()
+    ax.legend(fontsize=9)
+    fig.tight_layout()
+    _save(fig, os.path.join(results_dir, "iracing_lap_time_improvement.png"))
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Throttle / brake distribution
+# ---------------------------------------------------------------------------
+
+
+def plot_greedy_action_dist(data: ExperimentData, results_dir: str) -> bool:
+    """Plot per-sim accel/brake/coast percentage over the greedy phase."""
+    sims = data.greedy_sims
+    if not sims:
+        return False
+
+    xs = [s.sim for s in sims]
+    accel_pcts, brake_pcts = [], []
+    for s in sims:
+        b, c, a = s.throttle_counts
+        total = (b + c + a) or 1
+        accel_pcts.append(100 * a / total)
+        brake_pcts.append(100 * b / total)
+
+    fig, ax = plt.subplots(figsize=(max(8, len(xs) * 0.15), 5))
+    ax.plot(
+        xs,
+        accel_pcts,
+        color=_THROTTLE_COLORS[2],
+        linewidth=1.2,
+        alpha=0.85,
+        label="accel %",
+    )
+    ax.plot(
+        xs,
+        brake_pcts,
+        color=_THROTTLE_COLORS[0],
+        linewidth=1.2,
+        alpha=0.85,
+        label="brake %",
+    )
+    ax.set_title(f"{data.experiment_name} — iRacing: Accel / Brake % per Sim")
+    ax.set_xlabel("Simulation")
+    ax.set_ylabel("% Steps (threshold ≥ 0.5)")
+    ax.set_ylim(0, 100)
+    ax.legend(fontsize=9)
+    fig.tight_layout()
+    _save(fig, os.path.join(results_dir, "iracing_action_dist.png"))
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Obs-averages plots (tire temps, RPM, gear, fuel, brake bias)
+# ---------------------------------------------------------------------------
+
+_OBS_AVG_PLOTS: list[tuple[list[str], str, str, str]] = [
+    # (feature_names, y_label, title_suffix, filename)
+    (
+        ["tire_temp_fl", "tire_temp_fr", "tire_temp_rl", "tire_temp_rr"],
+        "Mean temp (°C)",
+        "Mean Tyre Temperature per Sim",
+        "iracing_tire_temps.png",
+    ),
+    (
+        ["tire_load_fl", "tire_load_fr", "tire_load_rl", "tire_load_rr"],
+        "Mean load (N)",
+        "Mean Tyre Load per Sim",
+        "iracing_tire_loads.png",
+    ),
+    (
+        ["fuel_pct"],
+        "Mean fuel fraction",
+        "Mean Fuel Level per Sim",
+        "iracing_fuel.png",
+    ),
+    (
+        ["rpm"],
+        "Mean RPM",
+        "Mean RPM per Sim",
+        "iracing_rpm.png",
+    ),
+    (
+        ["brake_bias"],
+        "Brake bias",
+        "Mean Brake Bias per Sim",
+        "iracing_brake_bias.png",
+    ),
+]
+
+_CORNER_COLORS = ["#3498db", "#e67e22", "#27ae60", "#9b59b6"]
+_CORNER_LABELS = ["FL", "FR", "RL", "RR"]
+
+
+def _plot_obs_avg_series(
+    data: ExperimentData,
+    results_dir: str,
+    feature_names: list[str],
+    y_label: str,
+    title_suffix: str,
+    filename: str,
+) -> bool:
+    sims = [s for s in data.greedy_sims if s.obs_averages]
+    if not sims:
+        return False
+    xs = [s.sim for s in sims]
+    series: list[list[float]] = []
+    for feat in feature_names:
+        ys = [s.obs_averages.get(feat) for s in sims]  # type: ignore[union-attr]
+        if any(v is not None for v in ys):
+            series.append([float(v) if v is not None else float("nan") for v in ys])
+        else:
+            series.append([])
+
+    if not any(s for s in series):
+        return False
+
+    fig, ax = plt.subplots(figsize=(max(8, len(xs) * 0.15), 4))
+    multi = len(feature_names) > 1
+    for i, (feat, ys) in enumerate(zip(feature_names, series)):
+        if not ys:
+            continue
+        label = _CORNER_LABELS[i] if multi and i < len(_CORNER_LABELS) else feat
+        color = _CORNER_COLORS[i % len(_CORNER_COLORS)]
+        ax.plot(xs, ys, color=color, linewidth=1.2, marker="o", markersize=3, label=label)
+
+    ax.set_title(f"{data.experiment_name} — iRacing: {title_suffix}")
+    ax.set_xlabel("Simulation")
+    ax.set_ylabel(y_label)
+    if multi:
+        ax.legend(fontsize=9)
+    fig.tight_layout()
+    _save(fig, os.path.join(results_dir, filename))
+    return True
+
+
+def plot_obs_avg_panels(data: ExperimentData, results_dir: str) -> list[str]:
+    """Generate all obs-average plots; return list of written filenames."""
+    written: list[str] = []
+    for features, ylabel, title, fname in _OBS_AVG_PLOTS:
+        if _plot_obs_avg_series(data, results_dir, features, ylabel, title, fname):
+            written.append(fname)
+    return written
+
+
+# ---------------------------------------------------------------------------
+# Termination reason breakdown
+# ---------------------------------------------------------------------------
+
+
+def plot_termination_reasons(data: ExperimentData, results_dir: str) -> bool:
+    sims = data.greedy_sims
+    if not sims:
+        return False
+
+    counts: dict[str, int] = {}
+    for s in sims:
+        r = s.termination_reason or "unknown"
+        counts[r] = counts.get(r, 0) + 1
+
+    order = _REASON_ORDER + sorted(k for k in counts if k not in _REASON_ORDER)
+    labels = [r for r in order if r in counts]
+    values = [counts[r] for r in labels]
+    colors = [_REASON_COLORS.get(r, "#95a5a6") for r in labels]
+    total = len(sims)
+
+    fig, ax = plt.subplots(figsize=(max(5, len(labels) * 1.4), 5))
+    bars = ax.bar(labels, values, color=colors, edgecolor="white", linewidth=0.6)
+    for bar, v in zip(bars, values):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2,
+            bar.get_height() + max(total * 0.005, 0.3),
+            f"{v} ({100 * v / total:.0f}%)",
+            ha="center",
+            va="bottom",
+            fontsize=9,
+        )
+    ax.set_title(f"{data.experiment_name} — iRacing: Termination Reasons ({total} sims)")
+    ax.set_xlabel("Reason")
+    ax.set_ylabel("Count")
+    ax.set_ylim(0, max(values) * 1.2)
+    fig.tight_layout()
+    _save(fig, os.path.join(results_dir, "iracing_termination_reasons.png"))
+    return True
+
+
+# ---------------------------------------------------------------------------
+# iRacing summary table (markdown)
+# ---------------------------------------------------------------------------
+
+
+def _iracing_summary_md(data: ExperimentData) -> str:
+    sims = data.greedy_sims
+    if not sims:
+        return ""
+
+    finished = [s for s in sims if s.finish_time_s is not None]
+    finish_rate = len(finished) / len(sims)
+    lines = [
+        "## iRacing Metrics\n\n",
+        "| Metric | Value |\n",
+        "|--------|-------|\n",
+        f"| Finish rate | {finish_rate:.1%} ({len(finished)}/{len(sims)} sims) |\n",
+    ]
+    if finished:
+        best_lap = min(s.finish_time_s for s in finished)  # type: ignore[arg-type]
+        mean_lap = float(np.mean([s.finish_time_s for s in finished]))
+        lines += [
+            f"| Best lap time | {best_lap:.3f} s |\n",
+            f"| Mean lap time (finished) | {mean_lap:.3f} s |\n",
+        ]
+
+    accel_pcts = []
+    for s in sims:
+        b, c, a = s.throttle_counts
+        total = (b + c + a) or 1
+        accel_pcts.append(100 * a / total)
+    lines.append(f"| Mean accel % | {float(np.mean(accel_pcts)):.1f}% |\n")
+
+    return "".join(lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
 
 
 def save_experiment_results(data: ExperimentData, results_dir: str) -> None:
@@ -50,8 +397,24 @@ def save_experiment_results(data: ExperimentData, results_dir: str) -> None:
         sections.append(_greedy_table_md(data))
         sections.append("\n![Greedy rewards](greedy_rewards.png)\n\n")
 
+    wrote_lap_time = plot_lap_time_improvement(data, results_dir)
+    wrote_action_dist = plot_greedy_action_dist(data, results_dir)
+    wrote_termination = plot_termination_reasons(data, results_dir)
+    obs_avg_files = plot_obs_avg_panels(data, results_dir)
+
+    sections.append(_iracing_summary_md(data))
     plot_reward_trajectory(data, results_dir)
+
     sections.append("## Additional Plots\n\n")
+    if wrote_lap_time:
+        sections.append("![iRacing lap time improvement](iracing_lap_time_improvement.png)\n\n")
+    if wrote_action_dist:
+        sections.append("![iRacing action distribution](iracing_action_dist.png)\n\n")
+    if wrote_termination:
+        sections.append("![iRacing termination reasons](iracing_termination_reasons.png)\n\n")
+    for fname in obs_avg_files:
+        label = fname.replace("iracing_", "").replace(".png", "").replace("_", " ").title()
+        sections.append(f"![iRacing {label}]({fname})\n\n")
     sections.append("![Reward trajectory](reward_trajectory.png)\n\n")
 
     report_path = os.path.join(results_dir, "results.md")

--- a/tests/README.md
+++ b/tests/README.md
@@ -16,6 +16,7 @@
   - [test\_env\_termination.py — `_classify_termination()`](#test_env_terminationpy--_classify_termination)
   - [test\_game\_adapter.py — TMNF/TORCS/SC2/BeamNG/iRacing adapter abstractions](#test_game_adapterpy--tmnftorcssc2beamngiracing-adapter-abstractions)
   - [test\_grid\_search.py — Cartesian-product expansion + naming](#test_grid_searchpy--cartesian-product-expansion--naming)
+  - [test\_iracing\_analytics.py — iRacing-specific analytics plots and report](#test_iracing_analyticspy--iracing-specific-analytics-plots-and-report)
   - [test\_iracing\_controller.py — iRacing action injection controller](#test_iracing_controllerpy--iracing-action-injection-controller)
   - [test\_info\_gain.py — staleness-based intrinsic reward](#test_info_gainpy--staleness-based-intrinsic-reward)
   - [test\_live\_monitor.py — live GUI monitor helpers](#test_live_monitorpy--live-gui-monitor-helpers)
@@ -277,6 +278,14 @@ worker mechanics are unit-tested with a dummy env.
 
 (SC2 policy/param validation moved to test_policy_registry.py with the
 `compatible_with` hook in Phase D — `build_extras` was deleted.)
+
+### test_iracing_analytics.py — iRacing-specific analytics plots and report
+- `plot_lap_time_improvement`: written when at least one sim finishes; returns False when all DNF or sim list empty
+- `plot_greedy_action_dist`: plot written from throttle_counts
+- `plot_termination_reasons`: bar chart written from termination_reason fields
+- `plot_obs_avg_panels`: all panels skipped when obs_averages absent; tire-temp/fuel/RPM/brake-bias panels written when episode_obs_averages populated
+- `_iracing_summary_md`: includes finish rate + best/mean lap time when finishes exist; omits lap stats when all DNF
+- `save_experiment_results`: report contains `## iRacing Metrics`, lap-time and action-dist plot refs, and headline plot file exists on disk
 
 ### test_iracing_controller.py — iRacing action injection controller
 - NullController: implements BaseController, send/reset/close are safe no-ops

--- a/tests/test_iracing_analytics.py
+++ b/tests/test_iracing_analytics.py
@@ -1,0 +1,163 @@
+"""Tests for iRacing-specific analytics output."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from framework.analytics import ExperimentData, GreedySimResult
+from games.iracing.analytics import (
+    _iracing_summary_md,
+    plot_greedy_action_dist,
+    plot_lap_time_improvement,
+    plot_obs_avg_panels,
+    plot_termination_reasons,
+    save_experiment_results,
+)
+
+
+def _make_data(
+    *,
+    finish_times: list[float | None] | None = None,
+    obs_averages: list[dict | None] | None = None,
+) -> ExperimentData:
+    if finish_times is None:
+        finish_times = [85.3, None, 82.1, 79.8]
+    greedy_sims = []
+    for i, ft in enumerate(finish_times):
+        avgs = obs_averages[i] if obs_averages else None
+        greedy_sims.append(
+            GreedySimResult(
+                sim=i + 1,
+                reward=float(100 - (ft or 200)),
+                improved=(i == 0 or (ft is not None and ft < min(f for f in finish_times[:i] if f))),
+                throttle_counts=[10, 5, 30],
+                total_steps=45,
+                finish_time_s=ft,
+                termination_reason="finish" if ft is not None else "crash",
+                obs_averages=avgs,
+            )
+        )
+    return ExperimentData(
+        experiment_name="iracing-smoke",
+        probe_results=[],
+        cold_start_restarts=[],
+        greedy_sims=greedy_sims,
+        probe_floor=None,
+        weights_file="policy_weights.yaml",
+        reward_config_file="reward_config.yaml",
+        training_params={},
+        timings={
+            "start": "s",
+            "end": "e",
+            "total_s": 1.0,
+            "probe_s": None,
+            "cold_start_s": None,
+            "greedy_s": 1.0,
+        },
+        track="laguna_seca",
+    )
+
+
+class TestIRacingLapTimeImprovement(unittest.TestCase):
+    def test_plot_written_when_some_sims_finish(self):
+        data = _make_data(finish_times=[85.3, None, 82.1, 79.8])
+        with tempfile.TemporaryDirectory() as tmp:
+            result = plot_lap_time_improvement(data, tmp)
+            self.assertTrue(result)
+            self.assertTrue(Path(tmp, "iracing_lap_time_improvement.png").exists())
+
+    def test_returns_false_when_no_finished_laps(self):
+        data = _make_data(finish_times=[None, None])
+        with tempfile.TemporaryDirectory() as tmp:
+            result = plot_lap_time_improvement(data, tmp)
+            self.assertFalse(result)
+
+    def test_returns_false_for_empty_sims(self):
+        data = _make_data(finish_times=[])
+        with tempfile.TemporaryDirectory() as tmp:
+            result = plot_lap_time_improvement(data, tmp)
+            self.assertFalse(result)
+
+
+class TestIRacingActionDist(unittest.TestCase):
+    def test_plot_written(self):
+        data = _make_data()
+        with tempfile.TemporaryDirectory() as tmp:
+            result = plot_greedy_action_dist(data, tmp)
+            self.assertTrue(result)
+            self.assertTrue(Path(tmp, "iracing_action_dist.png").exists())
+
+
+class TestIRacingTerminationReasons(unittest.TestCase):
+    def test_plot_written(self):
+        data = _make_data()
+        with tempfile.TemporaryDirectory() as tmp:
+            result = plot_termination_reasons(data, tmp)
+            self.assertTrue(result)
+            self.assertTrue(Path(tmp, "iracing_termination_reasons.png").exists())
+
+
+class TestIRacingObsAveragePanels(unittest.TestCase):
+    def test_skipped_when_obs_averages_absent(self):
+        data = _make_data()
+        with tempfile.TemporaryDirectory() as tmp:
+            written = plot_obs_avg_panels(data, tmp)
+            self.assertEqual(written, [])
+
+    def test_tire_temp_panel_written_when_obs_averages_present(self):
+        avgs = [
+            {
+                "tire_temp_fl": 90.0,
+                "tire_temp_fr": 91.0,
+                "tire_temp_rl": 88.0,
+                "tire_temp_rr": 89.0,
+                "fuel_pct": 0.8,
+                "rpm": 5000.0,
+                "brake_bias": 0.55,
+            }
+        ] * 4
+        data = _make_data(obs_averages=avgs)
+        with tempfile.TemporaryDirectory() as tmp:
+            written = plot_obs_avg_panels(data, tmp)
+            self.assertIn("iracing_tire_temps.png", written)
+            self.assertIn("iracing_fuel.png", written)
+            self.assertIn("iracing_rpm.png", written)
+            self.assertIn("iracing_brake_bias.png", written)
+            self.assertTrue(Path(tmp, "iracing_tire_temps.png").exists())
+
+
+class TestIRacingSummaryMd(unittest.TestCase):
+    def test_includes_finish_rate_and_best_lap(self):
+        data = _make_data(finish_times=[85.3, None, 82.1, 79.8])
+        md = _iracing_summary_md(data)
+        self.assertIn("## iRacing Metrics", md)
+        self.assertIn("Finish rate", md)
+        self.assertIn("Best lap time", md)
+        self.assertIn("79.800 s", md)
+
+    def test_no_lap_stats_when_all_dnf(self):
+        data = _make_data(finish_times=[None, None])
+        md = _iracing_summary_md(data)
+        self.assertIn("Finish rate", md)
+        self.assertNotIn("Best lap time", md)
+
+
+class TestIRacingSaveExperimentResults(unittest.TestCase):
+    def test_report_includes_iracing_sections_and_headline_plot(self):
+        data = _make_data(finish_times=[85.3, None, 82.1, 79.8])
+        with tempfile.TemporaryDirectory() as tmp:
+            save_experiment_results(data, tmp)
+            report = Path(tmp, "results.md").read_text(encoding="utf-8")
+            self.assertIn("## iRacing Metrics", report)
+            self.assertIn("Finish rate", report)
+            self.assertIn("iracing_lap_time_improvement.png", report)
+            self.assertIn("iracing_action_dist.png", report)
+            self.assertIn("iracing_termination_reasons.png", report)
+            self.assertTrue(Path(tmp, "iracing_lap_time_improvement.png").exists())
+            self.assertTrue(Path(tmp, "iracing_action_dist.png").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_iracing_analytics.py
+++ b/tests/test_iracing_analytics.py
@@ -31,7 +31,13 @@ def _make_data(
             GreedySimResult(
                 sim=i + 1,
                 reward=float(100 - (ft or 200)),
-                improved=(i == 0 or (ft is not None and ft < min(f for f in finish_times[:i] if f))),
+                improved=(
+                    i == 0
+                    or (
+                        ft is not None
+                        and ft < min((f for f in finish_times[:i] if f is not None), default=float("inf"))
+                    )
+                ),
                 throttle_counts=[10, 5, 30],
                 total_steps=45,
                 finish_time_s=ft,


### PR DESCRIPTION
Closes #463

## Summary

- Replaces the 62-line `games/iracing/analytics.py` stub with iRacing-specific plots grounded in the game's obs spec and reward config.
- Adds `tests/test_iracing_analytics.py` (10 tests covering all new plot functions and the summary table).
- Updates `tests/README.md` and `CHANGELOG.md`.

## Feature details

- **User problem:** iRacing runs produced only generic framework hill-climbing plots; no metrics that fit the game (lap times, tyre data, throttle/brake behaviour).
- **Proposed solution:**
  - **Lap-time improvement curve** (headline metric): `finish_time_s` over greedy sims, inverted y-axis, best-so-far step line, improvement markers (▲), DNF/crash sims shown as faint vertical red markers.
  - **Accel/brake % per sim** from `throttle_counts`.
  - **Termination-reason bar chart** (finish / crash / timeout).
  - **Obs-average panels** for tyre temperatures, tyre loads, fuel level, RPM, and brake bias — silently skipped when `episode_obs_averages` is absent (opt-in; populated by env).
  - `## iRacing Metrics` section in `results.md`: finish rate, best/mean lap time, mean accel %.
- **Trade-offs / follow-ups:** Per-step tyre-temp/RPM histogram traces require the env to populate `episode_obs_averages`; the panels are wired and ready but emit nothing today. A follow-up can add that to `IRacingEnv.step()`.

## Validation

```bash
python -m pytest tests/test_iracing_analytics.py -v   # 10 passed
pre-commit run --all-files                              # all Passed
```

## Checklist

### Release bump type
- [x] Patch (default)

### AI usage
- [x] AI was used to write/generate some or all of this code

**If AI was used:** Claude Sonnet 4.6 via Claude Code

**Human involvement:** Output reviewed; tests written and validated manually; no human edits to generated code were required.

## Notes for the reviewer

- [x] Updated `tests/README.md` — new `test_iracing_analytics.py` section added
- [x] Added entry under `## [Unreleased]` in `CHANGELOG.md`
- [ ] `games/iracing/README.md` — no change needed (analytics is an internal artifact, not a user-facing config knob)
- [x] Scope is limited to `games/iracing/analytics.py` + tests — no framework changes

---
_Generated by [Claude Code](https://claude.ai/code/session_0149iHtRgrnArdt42X33nBJv)_